### PR TITLE
feat: expose params and cookies on MochiApiEvent

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "svelte": {
+      "type": "http",
+      "url": "https://mcp.svelte.dev/mcp"
+    }
+  }
+}

--- a/packages/mochi/docs/15-coming-from-sveltekit.md
+++ b/packages/mochi/docs/15-coming-from-sveltekit.md
@@ -212,7 +212,7 @@ Do **NOT** call `enhance()` outside a hydrated island; instead, mark the surroun
 
 ### API routes (`+server.ts`)
 
-SvelteKit's `+server.ts` with `GET` / `POST` exports becomes `Mochi.api(handler)` — one handler per route, branch on `method` inside. The handler receives `{ request, url, server, locals, kind, method }`; pull `params`, `cookies`, and other request-scoped values from `getRequestContext()`.
+SvelteKit's `+server.ts` with `GET` / `POST` exports becomes `Mochi.api(handler)` — one handler per route, branch on `method` inside. The handler receives `{ request, url, server, locals, kind, method, params, cookies }`.
 
 ```ts
 // file (SvelteKit): src/routes/api/users/[id]/+server.ts
@@ -227,11 +227,10 @@ export async function POST({ params, request }) {
 
 ```ts
 // file (Mochi): src/routes.ts
-import { Mochi, error, getRequestContext } from 'mochi-framework';
+import { Mochi, error } from 'mochi-framework';
 
 export const routes = {
-  '/api/users/:id': Mochi.api(async ({ method, request }) => {
-    const { params } = getRequestContext();
+  '/api/users/:id': Mochi.api(async ({ method, request, params }) => {
     if (method === 'GET') return Response.json(await loadUser(params.id));
     if (method === 'POST') return Response.json(await createUser(params.id, await request.json()));
     error(405, 'Method not allowed');

--- a/packages/mochi/docs/40-defining-routes.md
+++ b/packages/mochi/docs/40-defining-routes.md
@@ -96,7 +96,7 @@ Do **NOT** return a prop named `form` from `serverProps` when `actions` is decla
 
 ### `Mochi.api`
 
-Register a JSON endpoint via `Mochi.api(handler)`. The handler receives a `MochiApiEvent` (`method`, `request`, `url`, `server`, `locals`) and returns a `Response`.
+Register a JSON endpoint via `Mochi.api(handler)`. The handler receives a `MochiApiEvent` (`method`, `request`, `url`, `server`, `locals`, `params`, `cookies`) and returns a `Response`.
 
 ```ts
 // file: src/routes.ts

--- a/packages/mochi/docs/90-api-routes.md
+++ b/packages/mochi/docs/90-api-routes.md
@@ -5,7 +5,7 @@ slug: api-routes
 
 ## API routes
 
-`Mochi.api(handler)` registers a JSON endpoint. The handler receives a `MochiApiEvent` (`method`, `request`, `url`, `server`, `locals`) and **must** return a `Response` (or a `Promise<Response>`).
+`Mochi.api(handler)` registers a JSON endpoint. The handler receives a `MochiApiEvent` (`method`, `request`, `url`, `server`, `locals`, `params`, `cookies`) and **must** return a `Response` (or a `Promise<Response>`).
 
 ```ts
 // file: src/routes.ts
@@ -20,21 +20,18 @@ Do **NOT** return a plain object or string from a `Mochi.api` handler; instead, 
 
 ### `MochiApiEvent`
 
-The handler's argument carries only what the request needs — no params, no cookies. Pull request-scoped values from `getRequestContext()`:
+Destructure `params` and `cookies` directly off the event — they mirror what `Mochi.page` form-action handlers receive:
 
 ```ts
 // file: src/routes.ts
-import { getRequestContext } from 'mochi-framework';
-
-'/items/:id': Mochi.api(async () => {
-  const { params, url, cookies } = getRequestContext();
+'/items/:id': Mochi.api(({ url, params, cookies }) => {
   const tab = url.searchParams.get('tab') ?? 'overview';
   const session = cookies.get('session');
   return Response.json({ id: params.id, tab, session });
 }),
 ```
 
-Do **NOT** thread `params` through a custom argument; instead, read them from `getRequestContext().params` — the context is request-scoped via `AsyncLocalStorage`.
+`getRequestContext()` still works and exposes the same values plus `requestId`, `islandProps`, `getClientAddress()`, etc. — reach for it from helper functions that aren't passed the event.
 
 ### Reading the request body
 

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -627,6 +627,8 @@ export class Mochi {
                 const apiEvent = {
                   ...event,
                   method: event.request.method as HttpMethod,
+                  params: ctx.params,
+                  cookies: ctx.cookies,
                 };
                 try {
                   const response = await apiHandler(apiEvent);

--- a/packages/mochi/src/apiEvent.isolated.test.ts
+++ b/packages/mochi/src/apiEvent.isolated.test.ts
@@ -1,0 +1,63 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+
+// `*.isolated.test.ts` runs in its own `bun test` invocation:
+// `initMochiConfig()` pins state on `globalThis.__mochi_config__` and throws if
+// `Mochi.serve()` is called twice in one process.
+
+describe('Mochi.api event surface', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-api-event-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      routes: {
+        '/api/items/:id': Mochi.api(({ method, params, cookies, url }) => {
+          const id = params.id ?? '';
+          cookies.set('seen', id, { path: '/' });
+          return Response.json({
+            method,
+            id,
+            tab: url.searchParams.get('tab'),
+            session: cookies.get('session'),
+          });
+        }),
+      },
+    });
+    base = `http://localhost:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('params resolves from the route pattern', async () => {
+    const res = await fetch(`${base}/api/items/abc?tab=details`);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { method: string; id: string; tab: string | null; session: string | null };
+    expect(body.method).toBe('GET');
+    expect(body.id).toBe('abc');
+    expect(body.tab).toBe('details');
+  });
+
+  test('cookies reads request cookies and writes response cookies', async () => {
+    const res = await fetch(`${base}/api/items/42`, {
+      headers: { cookie: 'session=tok' },
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { session: string | null };
+    expect(body.session).toBe('tok');
+    const setCookie = res.headers.get('set-cookie') ?? '';
+    expect(setCookie).toContain('seen=42');
+  });
+});

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -30,11 +30,16 @@ export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH' | 'OPTIONS'
 
 /**
  * The event object passed to API route handlers.
- * Extends MochiEvent with the HTTP method for convenience.
+ * Extends MochiEvent with the HTTP method, the resolved route params, and the
+ * request's cookie jar.
  */
 export interface MochiApiEvent extends MochiEvent {
   /** The HTTP method of the request (GET, POST, PUT, DELETE, etc.). */
   method: HttpMethod;
+  /** Resolved route params (e.g. `:id` from `/api/users/:id`). */
+  params: Record<string, string>;
+  /** The request's cookie jar — read or write cookies on the response. */
+  cookies: MochiCookieJar;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `params` and `cookies` fields to `MochiApiEvent` so API handlers can destructure them directly without calling `getRequestContext()`
- Update `types.ts` to extend `MochiApiEvent` with the new fields
- Pass `ctx.params` and `ctx.cookies` into the api event in `Mochi.ts`
- Update docs (`40-defining-routes.md`, `90-api-routes.md`, `15-coming-from-sveltekit.md`) to reflect the improved API
- Add isolated test for the new event fields

## Test plan

- [ ] `bun test packages/mochi/src/apiEvent.isolated.test.ts` passes
- [ ] API routes can destructure `params` and `cookies` without `getRequestContext()`
- [ ] `getRequestContext()` still works for helpers not passed the event