### PR TITLE
feat(cli): haiku outro with docs + local URL, and a setup intro line

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -69,10 +69,10 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
   p.outro(
     [
       pc.italic('Server renders calm'),
-      pc.italic("Islands wake to user's touch"),
-      pc.italic('Mochi blooms in code'),
+      `   ${pc.italic("Islands wake to user's touch")}`,
+      `   ${pc.italic('Mochi blooms in code')}`,
       '',
-      `${pc.dim('Docs:')} ${pc.cyan('https://mochi.fast/')}`,
+      `   ${pc.dim('Docs:')} ${pc.cyan('https://mochi.fast/')}`,
     ].join('\n'),
   );
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -4,7 +4,7 @@ import { Command, Option } from 'commander';
 import * as p from '@clack/prompts';
 import pc from 'picocolors';
 import pkg from '../package.json' with { type: 'json' };
-import { create } from './create.ts';
+import { create, SCAFFOLDED_PORT } from './create.ts';
 import { TEMPLATES, TEMPLATE_IDS, type TemplateId } from './templates.ts';
 import { isDirEmpty, validatePackageName } from './utils.ts';
 
@@ -81,7 +81,7 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
       `   ${pc.italic('Mochi blooms in code')}`,
       '',
       `   ${pc.dim('Docs:')}  ${pc.cyan('https://mochi.fast/')}`,
-      `   ${pc.dim('Local:')} ${pc.cyan(localUrlFor(template))}`,
+      `   ${pc.dim('Local:')} ${pc.cyan(`http://localhost:${SCAFFOLDED_PORT}/`)}`,
     ].join('\n'),
   );
 }
@@ -89,11 +89,6 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
 function defaultNameFor(dir: string): string {
   const base = path.basename(path.resolve(dir));
   return validatePackageName(base) === null ? base : 'mochi-app';
-}
-
-function localUrlFor(template: TemplateId): string {
-  const port = template === 'demos' ? 3334 : 3335;
-  return `http://localhost:${port}/`;
 }
 
 async function promptDirectory(provided: string | undefined): Promise<string> {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -66,7 +66,15 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
     [`${pc.dim('1.')} cd ${rel}`, `${pc.dim('2.')} bun install`, `${pc.dim('3.')} bun run dev`, '', pc.dim(`mochi-framework pinned to ${result.mochiVersion}`)].join('\n'),
     "You're all set!",
   );
-  p.outro(`Happy hacking! ${pc.dim('https://github.com/khromov/mochi')}`);
+  p.outro(
+    [
+      pc.italic('Server renders calm'),
+      pc.italic("Islands wake to user's touch"),
+      pc.italic('Mochi blooms in code'),
+      '',
+      `${pc.dim('Docs:')} ${pc.cyan('https://mochi.fast/')}`,
+    ].join('\n'),
+  );
 }
 
 function defaultNameFor(dir: string): string {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -63,7 +63,15 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
 
   const rel = path.relative(process.cwd(), result.dir) || '.';
   p.note(
-    [`${pc.dim('1.')} cd ${rel}`, `${pc.dim('2.')} bun install`, `${pc.dim('3.')} bun run dev`, '', pc.dim(`mochi-framework pinned to ${result.mochiVersion}`)].join('\n'),
+    [
+      pc.dim('Run this to get started:'),
+      '',
+      `${pc.dim('1.')} cd ${rel}`,
+      `${pc.dim('2.')} bun install`,
+      `${pc.dim('3.')} bun run dev`,
+      '',
+      pc.dim(`mochi-framework pinned to ${result.mochiVersion}`),
+    ].join('\n'),
     "You're all set!",
   );
   p.outro(
@@ -72,7 +80,8 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
       `   ${pc.italic("Islands wake to user's touch")}`,
       `   ${pc.italic('Mochi blooms in code')}`,
       '',
-      `   ${pc.dim('Docs:')} ${pc.cyan('https://mochi.fast/')}`,
+      `   ${pc.dim('Docs:')}  ${pc.cyan('https://mochi.fast/')}`,
+      `   ${pc.dim('Local:')} ${pc.cyan(localUrlFor(template))}`,
     ].join('\n'),
   );
 }
@@ -80,6 +89,11 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
 function defaultNameFor(dir: string): string {
   const base = path.basename(path.resolve(dir));
   return validatePackageName(base) === null ? base : 'mochi-app';
+}
+
+function localUrlFor(template: TemplateId): string {
+  const port = template === 'demos' ? 3334 : 3335;
+  return `http://localhost:${port}/`;
 }
 
 async function promptDirectory(provided: string | undefined): Promise<string> {

--- a/packages/cli/src/create.ts
+++ b/packages/cli/src/create.ts
@@ -4,7 +4,7 @@ import { downloadTemplate } from '@bluwy/giget-core';
 import { getTemplate, type TemplateId } from './templates.ts';
 import { ensureGitignore, fetchLatestMochiVersion, resolveMochiVersionRange, setDefaultPort, transformPackageJson, transformTsconfig, validatePackageName } from './utils.ts';
 
-const SCAFFOLDED_PORT = 3333;
+export const SCAFFOLDED_PORT = 3333;
 
 export interface CreateOptions {
   /** Destination directory (absolute or cwd-relative). */


### PR DESCRIPTION
## Summary

- Replace the `Happy hacking! github.com/khromov/mochi` outro with a short haiku and a link to `https://mochi.fast/`.
- Add a `Local: http://localhost:3333/` line under the docs link, sourced from the exported `SCAFFOLDED_PORT` constant in `create.ts` so the URL stays in sync with whatever port the scaffolder writes.
- Prepend `Run this to get started:` before the numbered steps in the "You're all set!" note.
- Indent multi-line outro continuation lines by 3 spaces so they line up under `└`.

The new outro renders as:

```
└  Server renders calm
   Islands wake to user's touch
   Mochi blooms in code

   Docs:  https://mochi.fast/
   Local: http://localhost:3333/
```

## Test plan

- [x] `bun --cwd=packages/cli run typecheck` passes.
- [x] `bun run format` is clean.
- [x] Scaffolded into `/tmp/mochi-haiku-test` with `--template minimal --force` and visually confirmed the new note + outro render correctly.
- [ ] Repeat with `--template demos` if desired (port is identical — 3333 — because `create.ts` rewrites it).