### PR TITLE
fix: align engines.bun with mochi-framework's >=1.3.13

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "packages/*"
   ],
   "engines": {
-    "bun": "^1.0"
+    "bun": ">=1.3.13"
   },
   "scripts": {
     "build": "bun --filter='*' run build",

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "bun": "^1.0"
+    "bun": ">=1.3.13"
   },
   "scripts": {
     "build": "bun scripts/prebuild.ts && mochi-framework build",

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "bun": "^1.0"
+    "bun": ">=1.3.13"
   },
   "scripts": {
     "build": "mochi-framework build",

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "type": "module",
   "engines": {
-    "bun": "^1.0"
+    "bun": ">=1.3.13"
   },
   "scripts": {
     "build": "bun src/lib/generateDocsBarrel.ts && mochi-framework build",


### PR DESCRIPTION
## Summary
- Bumps `engines.bun` from `^1.0` to `>=1.3.13` in the root, `site`, `minimal`, and `demos` `package.json` files so they match what `mochi-framework` already declares.
- Resolves the `npm engine-mismatch` warning: `Engines mismatch for "mochi-framework@0.1.0": bun: requires ">=1.3.13", but package supports "^1.0" (partial overlap).`

## Test plan
- [x] `bun install` no longer prints the engine-mismatch warning
- [x] `bun run format` clean