### PR TITLE
fix(cli): pin mochi-framework version fallback to `^0.1.1`

### DIFF
--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -28,8 +28,8 @@ describe('resolveMochiVersionRange', () => {
     expect(resolveMochiVersionRange('1.0.0')).toBe('^1.0.0');
   });
 
-  test('falls back to "latest" when version is null', () => {
-    expect(resolveMochiVersionRange(null)).toBe('latest');
+  test('falls back to the pinned floor when version is null', () => {
+    expect(resolveMochiVersionRange(null)).toBe('^0.1.1');
   });
 });
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import fs from 'node:fs';
 
-const MOCHI_FRAMEWORK_FALLBACK = 'latest';
+const MOCHI_FRAMEWORK_FALLBACK = '^0.1.1';
 
 export function validatePackageName(name: string): string | null {
   if (!name) {


### PR DESCRIPTION
## Summary

- The CLI's `MOCHI_FRAMEWORK_FALLBACK` (used when `fetchLatestMochiVersion` returns null — e.g., offline, registry down, fetch timeout) was the literal dist-tag string `"latest"`. That installs fine but drifts silently on clean re-installs and isn't a semver range tooling can reason about.
- Pin the fallback to `^0.1.1`, the first version that ships `@types/negotiator` in `dependencies` and is compatible with the `patchedDependencies` wiring added in #10. In the happy path the CLI still resolves and writes `^<latest>` from npm.

## Test plan

- [x] `bun test packages/cli/src/utils.test.ts` — updated assertion passes
- [ ] After release, sanity-check `bun create mochi` (offline) writes `"mochi-framework": "^0.1.1"`