### PR TITLE
fix: drop stale root `patches/` COPY from Dockerfile.production

### DIFF
--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -6,10 +6,11 @@ WORKDIR /usr/src/app
 # package.json so bun install can resolve the workspace topology
 FROM base AS install
 COPY package.json bun.lock /temp/prod/
-COPY patches /temp/prod/patches
 # Copy every workspace wholesale so bun install can reconcile the lockfile
 # topology AND the workspace:* bin shims (e.g. mochi-framework -> src/cli.js)
 # resolve correctly. Trades a bit of layer-cache granularity for robustness.
+# packages/ also carries packages/mochi/patches/, which the root package.json's
+# patchedDependencies field references.
 COPY packages /temp/prod/packages
 # --production drops devDeps. Don't omit peers — mochi-framework's peer
 # (svelte) must resolve from packages/mochi/src/ at build time, and dropping


### PR DESCRIPTION
## Summary

The svelte-check patch moved from the repo root to `packages/mochi/patches/` in #10, but `Dockerfile.production` still tried to `COPY patches /temp/prod/patches` from the (now-missing) top-level directory, breaking image builds:

```
COPY patches /temp/prod/patches
ERROR: failed to compute cache key: failed to calculate checksum of ref ...:
"/patches": not found
```

The patch is now reached via the existing `COPY packages /temp/prod/packages` line below — `packages/mochi/patches/svelte-check@4.4.7.patch` rides along with the wholesale workspace copy. The root `package.json`'s `patchedDependencies` field already points there, so `bun install` will resolve the patch path inside `/temp/prod` correctly.

## Test plan

- [ ] Docker daemon wasn't available locally — verify the build succeeds in CI / on a host with Docker
- [ ] Confirm the resulting image still applies the svelte-check patch (or note: with `--omit=dev` the patch's target package isn't even installed, so a missing apply is fine for the production runtime image)