### PR TITLE
perf(ssr): cache and skip Svelte preprocessing for non-island sources

### DIFF
--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -11,7 +11,8 @@ import type { DebugBarData } from './requestContext';
 import { logger } from './log';
 import { mochiEvents } from './events';
 import type { MarkdownConfig, MochiManifest } from './types';
-import { preprocessHydratable, type HydratableComponent, type ServerIslandComponent } from './svelteAstPreprocess';
+import { type HydratableComponent, type ServerIslandComponent } from './svelteAstPreprocess';
+import { cachedPreprocessHydratable } from './preprocessCache';
 import { mergeCompilerOptions, type MochiSvelteConfig } from './svelteConfig';
 import { applyFilter } from './extensions';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
@@ -300,6 +301,7 @@ export class ComponentRegistry {
     const development = this.development;
     const userCompilerOptions = this.svelteConfig.compilerOptions ?? {};
     const markdown = this.markdown;
+    const preprocessCacheDir = path.resolve(this.outDir, 'preprocess-cache');
 
     const sveltePlugin: BunPlugin = {
       name: 'svelte-ssr',
@@ -401,7 +403,11 @@ export class ComponentRegistry {
         build.onLoad({ filter: /\.svelte$/ }, async (args) => {
           const raw = await Bun.file(args.path).text();
           const preprocessed = await applyUserPreprocessors(raw, args.path, 'server', development);
-          const { transformed, hydratables, serverIslands } = preprocessHydratable(preprocessed, args.path);
+          // Vendored .svelte from node_modules can never carry `mochi:*` directives
+          const isVendored = args.path.includes(`${path.sep}node_modules${path.sep}`);
+          const { transformed, hydratables, serverIslands } = isVendored
+            ? { transformed: preprocessed, hydratables: [] as HydratableComponent[], serverIslands: [] as ServerIslandComponent[] }
+            : cachedPreprocessHydratable(preprocessed, args.path, preprocessCacheDir);
           fileHydratables.set(args.path, hydratables);
           allHydratables.push(...hydratables);
           allServerIslands.push(...serverIslands);

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -9,7 +9,7 @@ import { buildIslandPropsScripts } from './islandPropsRegistry';
 import { requestContext } from './requestContext';
 import type { DebugBarData } from './requestContext';
 import { logger } from './log';
-import { hasSubscribers, mochiEvents } from './events';
+import { mochiEvents } from './events';
 import type { MarkdownConfig, MochiManifest } from './types';
 import { type HydratableComponent, type ServerIslandComponent } from './svelteAstPreprocess';
 import { cachedPreprocessHydratable, consumePreprocessCacheStats } from './preprocessCache';
@@ -596,12 +596,10 @@ export class ComponentRegistry {
       durationMs: performance.now() - compileStart,
     });
 
-    if (hasSubscribers('preprocess-cache:summary')) {
-      const stats = consumePreprocessCacheStats();
-      const files = stats.hits + stats.misses;
-      if (files > 0) {
-        mochiEvents.emit('preprocess-cache:summary', { hits: stats.hits, misses: stats.misses, files });
-      }
+    const stats = consumePreprocessCacheStats();
+    const files = stats.hits + stats.misses;
+    if (files > 0) {
+      mochiEvents.emit('preprocess-cache:summary', { hits: stats.hits, misses: stats.misses, files });
     }
 
     // Write per-component CSS files to disk (minified) and track their URLs

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -9,10 +9,10 @@ import { buildIslandPropsScripts } from './islandPropsRegistry';
 import { requestContext } from './requestContext';
 import type { DebugBarData } from './requestContext';
 import { logger } from './log';
-import { mochiEvents } from './events';
+import { hasSubscribers, mochiEvents } from './events';
 import type { MarkdownConfig, MochiManifest } from './types';
 import { type HydratableComponent, type ServerIslandComponent } from './svelteAstPreprocess';
-import { cachedPreprocessHydratable } from './preprocessCache';
+import { cachedPreprocessHydratable, consumePreprocessCacheStats } from './preprocessCache';
 import { mergeCompilerOptions, type MochiSvelteConfig } from './svelteConfig';
 import { applyFilter } from './extensions';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
@@ -595,6 +595,14 @@ export class ComponentRegistry {
       count: todo.length,
       durationMs: performance.now() - compileStart,
     });
+
+    if (hasSubscribers('preprocess-cache:summary')) {
+      const stats = consumePreprocessCacheStats();
+      const files = stats.hits + stats.misses;
+      if (files > 0) {
+        mochiEvents.emit('preprocess-cache:summary', { hits: stats.hits, misses: stats.misses, files });
+      }
+    }
 
     // Write per-component CSS files to disk (minified) and track their URLs
     const cssOutDir = `${this.outDir}/svelte-css`;

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -301,7 +301,6 @@ export class ComponentRegistry {
     const development = this.development;
     const userCompilerOptions = this.svelteConfig.compilerOptions ?? {};
     const markdown = this.markdown;
-    const preprocessCacheDir = path.resolve(this.outDir, 'preprocess-cache');
 
     const sveltePlugin: BunPlugin = {
       name: 'svelte-ssr',
@@ -407,7 +406,7 @@ export class ComponentRegistry {
           const isVendored = args.path.includes(`${path.sep}node_modules${path.sep}`);
           const { transformed, hydratables, serverIslands } = isVendored
             ? { transformed: preprocessed, hydratables: [] as HydratableComponent[], serverIslands: [] as ServerIslandComponent[] }
-            : cachedPreprocessHydratable(preprocessed, args.path, preprocessCacheDir);
+            : cachedPreprocessHydratable(preprocessed, args.path);
           fileHydratables.set(args.path, hydratables);
           allHydratables.push(...hydratables);
           allServerIslands.push(...serverIslands);

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -12,7 +12,7 @@ import { logger } from './log';
 import { mochiEvents } from './events';
 import type { MarkdownConfig, MochiManifest } from './types';
 import { type HydratableComponent, type ServerIslandComponent } from './svelteAstPreprocess';
-import { cachedPreprocessHydratable, consumePreprocessCacheStats } from './preprocessCache';
+import { cachedPreprocessHydratable, createPreprocessCacheStats } from './preprocessCache';
 import { mergeCompilerOptions, type MochiSvelteConfig } from './svelteConfig';
 import { applyFilter } from './extensions';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
@@ -297,6 +297,7 @@ export class ComponentRegistry {
     const importedCssPaths = new Set<string>();
     const allHydratables: HydratableComponent[] = [];
     const allServerIslands: ServerIslandComponent[] = [];
+    const preprocessCacheStats = createPreprocessCacheStats();
     const fileHydratables = new Map<string, HydratableComponent[]>();
     const development = this.development;
     const userCompilerOptions = this.svelteConfig.compilerOptions ?? {};
@@ -406,7 +407,7 @@ export class ComponentRegistry {
           const isVendored = args.path.includes(`${path.sep}node_modules${path.sep}`);
           const { transformed, hydratables, serverIslands } = isVendored
             ? { transformed: preprocessed, hydratables: [] as HydratableComponent[], serverIslands: [] as ServerIslandComponent[] }
-            : cachedPreprocessHydratable(preprocessed, args.path);
+            : cachedPreprocessHydratable(preprocessed, args.path, preprocessCacheStats);
           fileHydratables.set(args.path, hydratables);
           allHydratables.push(...hydratables);
           allServerIslands.push(...serverIslands);
@@ -596,10 +597,13 @@ export class ComponentRegistry {
       durationMs: performance.now() - compileStart,
     });
 
-    const stats = consumePreprocessCacheStats();
-    const files = stats.hits + stats.misses;
+    const files = preprocessCacheStats.hits + preprocessCacheStats.misses;
     if (files > 0) {
-      mochiEvents.emit('preprocess-cache:summary', { hits: stats.hits, misses: stats.misses, files });
+      mochiEvents.emit('preprocess-cache:summary', {
+        hits: preprocessCacheStats.hits,
+        misses: preprocessCacheStats.misses,
+        files,
+      });
     }
 
     // Write per-component CSS files to disk (minified) and track their URLs

--- a/packages/mochi/src/consoleLogger.ts
+++ b/packages/mochi/src/consoleLogger.ts
@@ -16,6 +16,12 @@ export interface ConsoleLoggerOptions {
    * - `false` — silence compile/HMR events entirely.
    */
   compile?: boolean;
+  /**
+   * Preprocess-cache verbosity:
+   * - `'silent'` (default) — no preprocess-cache lines. No events are emitted by the wrapper either.
+   * - `'verbose'` — per-file `PCACHE hit` / `PCACHE miss` lines plus a one-line summary at the end of each `compileAll`.
+   */
+  preprocessCache?: 'silent' | 'verbose';
 }
 
 const DEFAULT_SLOW = 500;
@@ -156,6 +162,29 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     path: payload.key,
     note: pc.cyan('revalidate'),
   }));
+
+  if (options.preprocessCache === 'verbose') {
+    subscribe('preprocess-cache:hit', ({ filePath }) => ({
+      label: 'PCACHE',
+      path: relPath(filePath),
+      note: pc.green('hit'),
+      level: 'debug',
+    }));
+    subscribe('preprocess-cache:miss', ({ filePath }) => ({
+      label: 'PCACHE',
+      path: relPath(filePath),
+      note: pc.yellow('miss'),
+      level: 'debug',
+    }));
+    subscribe('preprocess-cache:summary', ({ hits, misses, files }) => {
+      const rate = files === 0 ? '0.0' : ((hits / files) * 100).toFixed(1);
+      return {
+        label: 'PCACHE',
+        path: '-',
+        note: pc.dim(`${hits} hit / ${misses} miss across ${files} files (${rate}%)`),
+      };
+    });
+  }
 
   if (options.compile ?? true) {
     subscribe('compile:complete', ({ path, ssrSizeBytes, hydratableCount, serverIslandCount }) => ({

--- a/packages/mochi/src/consoleLogger.ts
+++ b/packages/mochi/src/consoleLogger.ts
@@ -16,12 +16,6 @@ export interface ConsoleLoggerOptions {
    * - `false` — silence compile/HMR events entirely.
    */
   compile?: boolean;
-  /**
-   * Preprocess-cache verbosity:
-   * - `'silent'` (default) — no preprocess-cache lines. No events are emitted by the wrapper either.
-   * - `'verbose'` — per-file `PCACHE hit` / `PCACHE miss` lines plus a one-line summary at the end of each `compileAll`.
-   */
-  preprocessCache?: 'silent' | 'verbose';
 }
 
 const DEFAULT_SLOW = 500;
@@ -163,28 +157,27 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     note: pc.cyan('revalidate'),
   }));
 
-  if (options.preprocessCache === 'verbose') {
-    subscribe('preprocess-cache:hit', ({ filePath }) => ({
+  subscribe('preprocess-cache:hit', ({ filePath }) => ({
+    label: 'PCACHE',
+    path: relPath(filePath),
+    note: pc.green('hit'),
+    level: 'debug',
+  }));
+  subscribe('preprocess-cache:miss', ({ filePath }) => ({
+    label: 'PCACHE',
+    path: relPath(filePath),
+    note: pc.yellow('miss'),
+    level: 'debug',
+  }));
+  subscribe('preprocess-cache:summary', ({ hits, misses, files }) => {
+    const rate = files === 0 ? '0.0' : ((hits / files) * 100).toFixed(1);
+    return {
       label: 'PCACHE',
-      path: relPath(filePath),
-      note: pc.green('hit'),
-      level: 'debug',
-    }));
-    subscribe('preprocess-cache:miss', ({ filePath }) => ({
-      label: 'PCACHE',
-      path: relPath(filePath),
-      note: pc.yellow('miss'),
-      level: 'debug',
-    }));
-    subscribe('preprocess-cache:summary', ({ hits, misses, files }) => {
-      const rate = files === 0 ? '0.0' : ((hits / files) * 100).toFixed(1);
-      return {
-        label: 'PCACHE',
-        path: '-',
-        note: pc.dim(`${hits} hit / ${misses} miss across ${files} files (${rate}%)`),
-      };
-    });
-  }
+      path: '-',
+      note: pc.dim(`${hits} hit / ${misses} miss across ${files} files (${rate}%)`),
+      level: 'log',
+    };
+  });
 
   if (options.compile ?? true) {
     subscribe('compile:complete', ({ path, ssrSizeBytes, hydratableCount, serverIslandCount }) => ({

--- a/packages/mochi/src/devWatcher.ts
+++ b/packages/mochi/src/devWatcher.ts
@@ -8,6 +8,7 @@ import { applyFilter } from './extensions';
 import { mochiEvents } from './events';
 import type { MochiFileChangeType } from './events';
 import { logger } from './log';
+import { evictPreprocessCacheEntry } from './preprocessCache';
 import { buildPublicUrl } from './proxy';
 import { scanPublicDir } from './publicDir';
 import { loadSvelteConfig } from './svelteConfig';
@@ -192,6 +193,9 @@ export function startDevWatcher(deps: DevWatcherDeps): void {
           path: path.resolve(filePath),
           type: event as MochiFileChangeType,
         });
+      }
+      if (event === 'unlink' && filePath.endsWith('.svelte')) {
+        evictPreprocessCacheEntry(path.resolve(filePath));
       }
       if (reloadPublic && filePath.startsWith(publicDirRel + path.sep)) {
         reloadPublic(filePath);

--- a/packages/mochi/src/events.ts
+++ b/packages/mochi/src/events.ts
@@ -182,6 +182,18 @@ export interface MochiCompileBatchCompleteEvent {
   durationMs: number;
 }
 
+export interface MochiPreprocessCacheEvent {
+  /** Absolute path of the `.svelte` file the cache wrapper was invoked for. */
+  filePath: string;
+}
+
+export interface MochiPreprocessCacheSummaryEvent {
+  hits: number;
+  misses: number;
+  /** Total file lookups during the batch (`hits + misses`). */
+  files: number;
+}
+
 export interface MochiCompileErrorLog {
   file?: string;
   line?: number;
@@ -217,6 +229,9 @@ export type MochiEventMap = {
   'compile:complete': MochiCompileCompleteEvent;
   'compile:batch-complete': MochiCompileBatchCompleteEvent;
   'compile:error': MochiCompileErrorEvent;
+  'preprocess-cache:hit': MochiPreprocessCacheEvent;
+  'preprocess-cache:miss': MochiPreprocessCacheEvent;
+  'preprocess-cache:summary': MochiPreprocessCacheSummaryEvent;
   'recompile:start': MochiRecompileStartEvent;
   'recompile:complete': MochiRecompileCompleteEvent;
   'client-bundle:complete': MochiClientBundleEvent;

--- a/packages/mochi/src/preprocessCache.test.ts
+++ b/packages/mochi/src/preprocessCache.test.ts
@@ -1,96 +1,56 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
-import { tmpdir } from 'node:os';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { createHash } from 'node:crypto';
 import { __resetPreprocessMemCache, cachedPreprocessHydratable } from './preprocessCache';
-import { PREPROCESS_LOGIC_VERSION } from './svelteAstPreprocess';
 
 const SCRIPT = (imports: string) => `<script>\n${imports}\n</script>\n`;
 const ISLAND_SOURCE = `${SCRIPT('import Foo from "./Foo.svelte";')}<Foo mochi:hydrate />`;
 
-let cacheDir: string;
-
 beforeEach(() => {
-  cacheDir = mkdtempSync(path.join(tmpdir(), 'mochi-preprocess-cache-test-'));
   __resetPreprocessMemCache();
 });
 
-afterEach(() => {
-  rmSync(cacheDir, { recursive: true, force: true });
-});
-
-function diskKey(source: string, filePath: string): string {
-  return createHash('sha256').update(source).update('\0').update(filePath).update('\0').update(PREPROCESS_LOGIC_VERSION).digest('hex');
-}
-
 describe('cachedPreprocessHydratable', () => {
-  test('first call writes cache, second call reads from cache', () => {
-    const first = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
+  test('repeated call with same source+path returns the same object reference', () => {
+    const first = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    const second = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    // Identity check proves it came from the cache, not a re-run.
+    expect(second).toBe(first);
     expect(first.hydratables).toHaveLength(1);
-
-    const filesBefore = readdirSync(cacheDir).length;
-    expect(filesBefore).toBe(1);
-
-    // Drop in-memory cache so the second call must come from disk.
-    __resetPreprocessMemCache();
-
-    const second = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
-    expect(second).toEqual(first);
-    // Disk shouldn't grow on a hit.
-    expect(readdirSync(cacheDir).length).toBe(filesBefore);
   });
 
-  test('cache miss when source changes', () => {
-    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
+  test('source change invalidates the cache entry', () => {
+    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
     const mutated = ISLAND_SOURCE + '<!-- a comment -->';
-    const b = cachedPreprocessHydratable(mutated, '/test/A.svelte', cacheDir);
-
+    const b = cachedPreprocessHydratable(mutated, '/test/A.svelte');
+    expect(b).not.toBe(a);
     expect(a.transformed).not.toBe(b.transformed);
-    expect(readdirSync(cacheDir).length).toBe(2);
   });
 
-  test('cache miss when file path changes', () => {
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/elsewhere/A.svelte', cacheDir);
-
-    // Different file path resolves child imports differently, so results
-    // differ and the cache must hold two distinct entries.
-    expect(readdirSync(cacheDir).length).toBe(2);
-  });
-
-  test('different file paths yield different hydratable resolvedPath values', () => {
-    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-a/A.svelte', cacheDir);
-    const b = cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-b/A.svelte', cacheDir);
-
-    expect(a.hydratables[0]!.resolvedPath).not.toBe(b.hydratables[0]!.resolvedPath);
+  test('different file paths produce independent entries', () => {
+    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-a/A.svelte');
+    const b = cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-b/A.svelte');
     expect(a.hydratables[0]!.resolvedPath).toBe(path.resolve('/dir-a', './Foo.svelte'));
     expect(b.hydratables[0]!.resolvedPath).toBe(path.resolve('/dir-b', './Foo.svelte'));
-  });
-
-  test('corrupt cache file falls through to fresh preprocess and is overwritten', () => {
-    const filePath = '/test/A.svelte';
-    const key = diskKey(ISLAND_SOURCE, filePath);
-    const diskFile = path.join(cacheDir, `${key}.json`);
-
-    writeFileSync(diskFile, '{not valid json');
-
-    const result = cachedPreprocessHydratable(ISLAND_SOURCE, filePath, cacheDir);
-    expect(result.hydratables).toHaveLength(1);
-
-    // The corrupt file should have been overwritten with valid JSON.
-    const refreshed = cachedPreprocessHydratable(ISLAND_SOURCE, filePath, cacheDir);
-    expect(refreshed).toEqual(result);
+    // Hitting either path again still returns its respective cached entry.
+    expect(cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-a/A.svelte')).toBe(a);
+    expect(cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-b/A.svelte')).toBe(b);
   });
 
   test('non-island source still round-trips through the cache', () => {
     const plain = `${SCRIPT('import Foo from "./Foo.svelte";')}<Foo />`;
-    const r = cachedPreprocessHydratable(plain, '/test/Plain.svelte', cacheDir);
+    const r = cachedPreprocessHydratable(plain, '/test/Plain.svelte');
     expect(r.transformed).toBe(plain);
     expect(r.hydratables).toHaveLength(0);
-    expect(r.serverIslands).toHaveLength(0);
-    // Cache writes happen even on the fast-path output — that's fine,
-    // hits are still cheaper than re-running the string scan + function call.
-    expect(readdirSync(cacheDir).length).toBe(1);
+    expect(cachedPreprocessHydratable(plain, '/test/Plain.svelte')).toBe(r);
+  });
+
+  test('__resetPreprocessMemCache forces a fresh preprocess on next call', () => {
+    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    __resetPreprocessMemCache();
+    const b = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    // Different object identity, identical content.
+    expect(b).not.toBe(a);
+    expect(b.transformed).toBe(a.transformed);
+    expect(b.hydratables).toEqual(a.hydratables);
   });
 });

--- a/packages/mochi/src/preprocessCache.test.ts
+++ b/packages/mochi/src/preprocessCache.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { __resetPreprocessMemCache, cachedPreprocessHydratable } from './preprocessCache';
+import { PREPROCESS_LOGIC_VERSION } from './svelteAstPreprocess';
+
+const SCRIPT = (imports: string) => `<script>\n${imports}\n</script>\n`;
+const ISLAND_SOURCE = `${SCRIPT('import Foo from "./Foo.svelte";')}<Foo mochi:hydrate />`;
+
+let cacheDir: string;
+
+beforeEach(() => {
+  cacheDir = mkdtempSync(path.join(tmpdir(), 'mochi-preprocess-cache-test-'));
+  __resetPreprocessMemCache();
+});
+
+afterEach(() => {
+  rmSync(cacheDir, { recursive: true, force: true });
+});
+
+function diskKey(source: string, filePath: string): string {
+  return createHash('sha256').update(source).update('\0').update(filePath).update('\0').update(PREPROCESS_LOGIC_VERSION).digest('hex');
+}
+
+describe('cachedPreprocessHydratable', () => {
+  test('first call writes cache, second call reads from cache', () => {
+    const first = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
+    expect(first.hydratables).toHaveLength(1);
+
+    const filesBefore = readdirSync(cacheDir).length;
+    expect(filesBefore).toBe(1);
+
+    // Drop in-memory cache so the second call must come from disk.
+    __resetPreprocessMemCache();
+
+    const second = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
+    expect(second).toEqual(first);
+    // Disk shouldn't grow on a hit.
+    expect(readdirSync(cacheDir).length).toBe(filesBefore);
+  });
+
+  test('cache miss when source changes', () => {
+    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
+    const mutated = ISLAND_SOURCE + '<!-- a comment -->';
+    const b = cachedPreprocessHydratable(mutated, '/test/A.svelte', cacheDir);
+
+    expect(a.transformed).not.toBe(b.transformed);
+    expect(readdirSync(cacheDir).length).toBe(2);
+  });
+
+  test('cache miss when file path changes', () => {
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', cacheDir);
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/elsewhere/A.svelte', cacheDir);
+
+    // Different file path resolves child imports differently, so results
+    // differ and the cache must hold two distinct entries.
+    expect(readdirSync(cacheDir).length).toBe(2);
+  });
+
+  test('different file paths yield different hydratable resolvedPath values', () => {
+    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-a/A.svelte', cacheDir);
+    const b = cachedPreprocessHydratable(ISLAND_SOURCE, '/dir-b/A.svelte', cacheDir);
+
+    expect(a.hydratables[0]!.resolvedPath).not.toBe(b.hydratables[0]!.resolvedPath);
+    expect(a.hydratables[0]!.resolvedPath).toBe(path.resolve('/dir-a', './Foo.svelte'));
+    expect(b.hydratables[0]!.resolvedPath).toBe(path.resolve('/dir-b', './Foo.svelte'));
+  });
+
+  test('corrupt cache file falls through to fresh preprocess and is overwritten', () => {
+    const filePath = '/test/A.svelte';
+    const key = diskKey(ISLAND_SOURCE, filePath);
+    const diskFile = path.join(cacheDir, `${key}.json`);
+
+    writeFileSync(diskFile, '{not valid json');
+
+    const result = cachedPreprocessHydratable(ISLAND_SOURCE, filePath, cacheDir);
+    expect(result.hydratables).toHaveLength(1);
+
+    // The corrupt file should have been overwritten with valid JSON.
+    const refreshed = cachedPreprocessHydratable(ISLAND_SOURCE, filePath, cacheDir);
+    expect(refreshed).toEqual(result);
+  });
+
+  test('non-island source still round-trips through the cache', () => {
+    const plain = `${SCRIPT('import Foo from "./Foo.svelte";')}<Foo />`;
+    const r = cachedPreprocessHydratable(plain, '/test/Plain.svelte', cacheDir);
+    expect(r.transformed).toBe(plain);
+    expect(r.hydratables).toHaveLength(0);
+    expect(r.serverIslands).toHaveLength(0);
+    // Cache writes happen even on the fast-path output — that's fine,
+    // hits are still cheaper than re-running the string scan + function call.
+    expect(readdirSync(cacheDir).length).toBe(1);
+  });
+});

--- a/packages/mochi/src/preprocessCache.test.ts
+++ b/packages/mochi/src/preprocessCache.test.ts
@@ -76,6 +76,8 @@ describe('preprocess-cache event emission', () => {
   beforeEach(() => {
     received.length = 0;
     __resetPreprocessMemCache();
+    mochiEvents.on('preprocess-cache:hit', onHit);
+    mochiEvents.on('preprocess-cache:miss', onMiss);
   });
 
   afterEach(() => {
@@ -83,22 +85,14 @@ describe('preprocess-cache event emission', () => {
     mochiEvents.off('preprocess-cache:miss', onMiss);
   });
 
-  test('does NOT emit events when no subscribers are attached', () => {
+  test('emits one miss for a cold lookup', () => {
     cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
-    expect(received).toHaveLength(0);
-    // Stats still tick even without subscribers — they're free integer increments
-    // and the summary path needs them.
-    expect(consumePreprocessCacheStats()).toEqual({ hits: 1, misses: 1 });
+    expect(received).toEqual([{ type: 'miss', payload: { filePath: '/test/A.svelte' } }]);
   });
 
-  test('emits hit + miss events when subscribers are attached', () => {
-    mochiEvents.on('preprocess-cache:hit', onHit);
-    mochiEvents.on('preprocess-cache:miss', onMiss);
-
+  test('emits a hit on the second lookup with the same source+path', () => {
     cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
     cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
-
     expect(received).toEqual([
       { type: 'miss', payload: { filePath: '/test/A.svelte' } },
       { type: 'hit', payload: { filePath: '/test/A.svelte' } },

--- a/packages/mochi/src/preprocessCache.test.ts
+++ b/packages/mochi/src/preprocessCache.test.ts
@@ -48,9 +48,10 @@ describe('cachedPreprocessHydratable', () => {
     const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
     __resetPreprocessMemCache();
     const b = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
-    // Different object identity, identical content.
+    // Different object identity proves a re-run happened. The `nanoid(8)` baseId
+    // baked into the transformed source regenerates per call, so the transformed
+    // strings differ — but the deterministic hydratables array stays equal.
     expect(b).not.toBe(a);
-    expect(b.transformed).toBe(a.transformed);
     expect(b.hydratables).toEqual(a.hydratables);
   });
 });

--- a/packages/mochi/src/preprocessCache.test.ts
+++ b/packages/mochi/src/preprocessCache.test.ts
@@ -1,6 +1,8 @@
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { __resetPreprocessMemCache, cachedPreprocessHydratable } from './preprocessCache';
+import { __resetPreprocessMemCache, cachedPreprocessHydratable, consumePreprocessCacheStats } from './preprocessCache';
+import { mochiEvents } from './events';
+import type { MochiEventMap } from './events';
 
 const SCRIPT = (imports: string) => `<script>\n${imports}\n</script>\n`;
 const ISLAND_SOURCE = `${SCRIPT('import Foo from "./Foo.svelte";')}<Foo mochi:hydrate />`;
@@ -53,5 +55,53 @@ describe('cachedPreprocessHydratable', () => {
     // strings differ — but the deterministic hydratables array stays equal.
     expect(b).not.toBe(a);
     expect(b.hydratables).toEqual(a.hydratables);
+  });
+
+  test('consumePreprocessCacheStats reports counts and resets them', () => {
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte'); // miss
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte'); // hit
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte'); // hit
+    const first = consumePreprocessCacheStats();
+    expect(first).toEqual({ hits: 2, misses: 1 });
+    // Second consume is post-reset.
+    expect(consumePreprocessCacheStats()).toEqual({ hits: 0, misses: 0 });
+  });
+});
+
+describe('preprocess-cache event emission', () => {
+  const received: Array<{ type: string; payload: unknown }> = [];
+  const onHit = (p: MochiEventMap['preprocess-cache:hit']) => received.push({ type: 'hit', payload: p });
+  const onMiss = (p: MochiEventMap['preprocess-cache:miss']) => received.push({ type: 'miss', payload: p });
+
+  beforeEach(() => {
+    received.length = 0;
+    __resetPreprocessMemCache();
+  });
+
+  afterEach(() => {
+    mochiEvents.off('preprocess-cache:hit', onHit);
+    mochiEvents.off('preprocess-cache:miss', onMiss);
+  });
+
+  test('does NOT emit events when no subscribers are attached', () => {
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    expect(received).toHaveLength(0);
+    // Stats still tick even without subscribers — they're free integer increments
+    // and the summary path needs them.
+    expect(consumePreprocessCacheStats()).toEqual({ hits: 1, misses: 1 });
+  });
+
+  test('emits hit + miss events when subscribers are attached', () => {
+    mochiEvents.on('preprocess-cache:hit', onHit);
+    mochiEvents.on('preprocess-cache:miss', onMiss);
+
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+
+    expect(received).toEqual([
+      { type: 'miss', payload: { filePath: '/test/A.svelte' } },
+      { type: 'hit', payload: { filePath: '/test/A.svelte' } },
+    ]);
   });
 });

--- a/packages/mochi/src/preprocessCache.test.ts
+++ b/packages/mochi/src/preprocessCache.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { __resetPreprocessMemCache, cachedPreprocessHydratable, consumePreprocessCacheStats } from './preprocessCache';
+import { __resetPreprocessMemCache, cachedPreprocessHydratable, createPreprocessCacheStats, evictPreprocessCacheEntry } from './preprocessCache';
 import { mochiEvents } from './events';
 import type { MochiEventMap } from './events';
 
@@ -57,14 +57,40 @@ describe('cachedPreprocessHydratable', () => {
     expect(b.hydratables).toEqual(a.hydratables);
   });
 
-  test('consumePreprocessCacheStats reports counts and resets them', () => {
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte'); // miss
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte'); // hit
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte'); // hit
-    const first = consumePreprocessCacheStats();
-    expect(first).toEqual({ hits: 2, misses: 1 });
-    // Second consume is post-reset.
-    expect(consumePreprocessCacheStats()).toEqual({ hits: 0, misses: 0 });
+  test('evictPreprocessCacheEntry drops a single entry without touching others', () => {
+    const a = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    const b = cachedPreprocessHydratable(ISLAND_SOURCE, '/test/B.svelte');
+    expect(evictPreprocessCacheEntry('/test/A.svelte')).toBe(true);
+    // A re-runs (new object), B is still cached (same reference).
+    expect(cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte')).not.toBe(a);
+    expect(cachedPreprocessHydratable(ISLAND_SOURCE, '/test/B.svelte')).toBe(b);
+  });
+
+  test('evictPreprocessCacheEntry returns false for an unknown path', () => {
+    expect(evictPreprocessCacheEntry('/never/seen.svelte')).toBe(false);
+  });
+
+  test('threaded stats accumulator counts hits and misses per batch', () => {
+    const stats = createPreprocessCacheStats();
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', stats); // miss
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', stats); // hit
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', stats); // hit
+    expect(stats).toEqual({ hits: 2, misses: 1 });
+  });
+
+  test('separate stats objects from concurrent batches do not interfere', () => {
+    const batchA = createPreprocessCacheStats();
+    const batchB = createPreprocessCacheStats();
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', batchA); // miss → A
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte', batchB); // hit → B
+    expect(batchA).toEqual({ hits: 0, misses: 1 });
+    expect(batchB).toEqual({ hits: 1, misses: 0 });
+  });
+
+  test('omitting the stats accumulator is allowed', () => {
+    // The bundler's `onLoad` is the only required caller; the parameter is
+    // optional so callers (and test setups) can skip it without crashing.
+    expect(() => cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte')).not.toThrow();
   });
 });
 
@@ -97,5 +123,15 @@ describe('preprocess-cache event emission', () => {
       { type: 'miss', payload: { filePath: '/test/A.svelte' } },
       { type: 'hit', payload: { filePath: '/test/A.svelte' } },
     ]);
+  });
+
+  test('no event fires when there are no subscribers', () => {
+    // Detach the listeners attached by the outer beforeEach — emission must
+    // be gated on subscriber presence.
+    mochiEvents.off('preprocess-cache:hit', onHit);
+    mochiEvents.off('preprocess-cache:miss', onMiss);
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+    expect(received).toEqual([]);
   });
 });

--- a/packages/mochi/src/preprocessCache.ts
+++ b/packages/mochi/src/preprocessCache.ts
@@ -1,20 +1,44 @@
+import { hasSubscribers, mochiEvents } from './events';
 import { preprocessHydratable, type PreprocessResult } from './svelteAstPreprocess';
 
-// Keyed by absolute file path. Each entry stores the source text it was
-// computed from so we can detect edits on subsequent calls without hashing.
 const memCache: Map<string, { source: string; result: PreprocessResult }> = new Map();
 
+let hits = 0;
+let misses = 0;
+
 export function cachedPreprocessHydratable(source: string, filePath: string): PreprocessResult {
-  const hit = memCache.get(filePath);
-  if (hit && hit.source === source) {
-    return hit.result;
+  const entry = memCache.get(filePath);
+  if (entry && entry.source === source) {
+    hits++;
+    if (hasSubscribers('preprocess-cache:hit')) {
+      mochiEvents.emit('preprocess-cache:hit', { filePath });
+    }
+    return entry.result;
   }
   const result = preprocessHydratable(source, filePath);
   memCache.set(filePath, { source, result });
+  misses++;
+  if (hasSubscribers('preprocess-cache:miss')) {
+    mochiEvents.emit('preprocess-cache:miss', { filePath });
+  }
   return result;
 }
 
-/** Test-only: drop the in-memory cache. */
+/**
+ * Read the current cache stats and reset the counters. Caller (the
+ * `compileAll` orchestrator) emits a `preprocess-cache:summary` event with
+ * the returned values when there are subscribers for it.
+ */
+export function consumePreprocessCacheStats(): { hits: number; misses: number } {
+  const stats = { hits, misses };
+  hits = 0;
+  misses = 0;
+  return stats;
+}
+
+/** Test-only: drop the in-memory cache and reset stats. */
 export function __resetPreprocessMemCache(): void {
   memCache.clear();
+  hits = 0;
+  misses = 0;
 }

--- a/packages/mochi/src/preprocessCache.ts
+++ b/packages/mochi/src/preprocessCache.ts
@@ -1,0 +1,56 @@
+import { createHash } from 'node:crypto';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { preprocessHydratable, PREPROCESS_LOGIC_VERSION, type PreprocessResult } from './svelteAstPreprocess';
+
+const memCache: Map<string, PreprocessResult> = new Map();
+
+/**
+ * Cache key spans three invalidation axes:
+ *   1. source content       — edits to the .svelte file
+ *   2. file path            — `preprocessHydratable` resolves child imports
+ *                             relative to filePath, so the same source at a
+ *                             different path produces a different result
+ *   3. preprocessor logic   — PREPROCESS_LOGIC_VERSION hashes
+ *                             svelteAstPreprocess.ts itself
+ *
+ * Any change in any axis flips the key, so the cache cannot serve stale
+ * output in dev.
+ */
+function cacheKey(source: string, filePath: string): string {
+  return createHash('sha256').update(source).update('\0').update(filePath).update('\0').update(PREPROCESS_LOGIC_VERSION).digest('hex');
+}
+
+export function cachedPreprocessHydratable(source: string, filePath: string, cacheDir: string): PreprocessResult {
+  const key = cacheKey(source, filePath);
+
+  const fromMem = memCache.get(key);
+  if (fromMem) {
+    return fromMem;
+  }
+
+  const diskPath = path.join(cacheDir, `${key}.json`);
+  try {
+    const raw = readFileSync(diskPath, 'utf8');
+    const parsed = JSON.parse(raw) as PreprocessResult;
+    memCache.set(key, parsed);
+    return parsed;
+  } catch {
+    // miss or corrupt — fall through to fresh preprocess
+  }
+
+  const result = preprocessHydratable(source, filePath);
+  memCache.set(key, result);
+  try {
+    mkdirSync(cacheDir, { recursive: true });
+    writeFileSync(diskPath, JSON.stringify(result));
+  } catch {
+    // disk cache is a perf optimization, not correctness — swallow write errors
+  }
+  return result;
+}
+
+/** Test-only: drop the in-memory cache. Disk cache is unaffected. */
+export function __resetPreprocessMemCache(): void {
+  memCache.clear();
+}

--- a/packages/mochi/src/preprocessCache.ts
+++ b/packages/mochi/src/preprocessCache.ts
@@ -1,41 +1,45 @@
-import { mochiEvents } from './events';
+import { hasSubscribers, mochiEvents } from './events';
 import { preprocessHydratable, type PreprocessResult } from './svelteAstPreprocess';
 
 const memCache: Map<string, { source: string; result: PreprocessResult }> = new Map();
 
-let hits = 0;
-let misses = 0;
+export interface PreprocessCacheStats {
+  hits: number;
+  misses: number;
+}
 
-export function cachedPreprocessHydratable(source: string, filePath: string): PreprocessResult {
+export function createPreprocessCacheStats(): PreprocessCacheStats {
+  return { hits: 0, misses: 0 };
+}
+
+export function cachedPreprocessHydratable(source: string, filePath: string, stats?: PreprocessCacheStats): PreprocessResult {
   const entry = memCache.get(filePath);
   // String `===` is a value compare, so any byte change in the source invalidates the entry.
   if (entry && entry.source === source) {
-    hits++;
-    mochiEvents.emit('preprocess-cache:hit', { filePath });
+    if (stats) {stats.hits++;}
+    if (hasSubscribers('preprocess-cache:hit')) {
+      mochiEvents.emit('preprocess-cache:hit', { filePath });
+    }
     return entry.result;
   }
   const result = preprocessHydratable(source, filePath);
   memCache.set(filePath, { source, result });
-  misses++;
-  mochiEvents.emit('preprocess-cache:miss', { filePath });
+  if (stats) {stats.misses++;}
+  if (hasSubscribers('preprocess-cache:miss')) {
+    mochiEvents.emit('preprocess-cache:miss', { filePath });
+  }
   return result;
 }
 
 /**
- * Read the current cache stats and reset the counters. The `compileAll`
- * orchestrator calls this once per batch and forwards the values as a
- * `preprocess-cache:summary` event payload.
+ * Drop the cached entry for `filePath`. Called by the dev watcher on `unlink`
+ * so deleted files don't accumulate stale entries over a long dev session.
  */
-export function consumePreprocessCacheStats(): { hits: number; misses: number } {
-  const stats = { hits, misses };
-  hits = 0;
-  misses = 0;
-  return stats;
+export function evictPreprocessCacheEntry(filePath: string): boolean {
+  return memCache.delete(filePath);
 }
 
-/** Test-only: drop the in-memory cache and reset stats. */
+/** Test-only: drop the in-memory cache. */
 export function __resetPreprocessMemCache(): void {
   memCache.clear();
-  hits = 0;
-  misses = 0;
 }

--- a/packages/mochi/src/preprocessCache.ts
+++ b/packages/mochi/src/preprocessCache.ts
@@ -1,4 +1,4 @@
-import { hasSubscribers, mochiEvents } from './events';
+import { mochiEvents } from './events';
 import { preprocessHydratable, type PreprocessResult } from './svelteAstPreprocess';
 
 const memCache: Map<string, { source: string; result: PreprocessResult }> = new Map();
@@ -8,26 +8,23 @@ let misses = 0;
 
 export function cachedPreprocessHydratable(source: string, filePath: string): PreprocessResult {
   const entry = memCache.get(filePath);
+  // String `===` is a value compare, so any byte change in the source invalidates the entry.
   if (entry && entry.source === source) {
     hits++;
-    if (hasSubscribers('preprocess-cache:hit')) {
-      mochiEvents.emit('preprocess-cache:hit', { filePath });
-    }
+    mochiEvents.emit('preprocess-cache:hit', { filePath });
     return entry.result;
   }
   const result = preprocessHydratable(source, filePath);
   memCache.set(filePath, { source, result });
   misses++;
-  if (hasSubscribers('preprocess-cache:miss')) {
-    mochiEvents.emit('preprocess-cache:miss', { filePath });
-  }
+  mochiEvents.emit('preprocess-cache:miss', { filePath });
   return result;
 }
 
 /**
- * Read the current cache stats and reset the counters. Caller (the
- * `compileAll` orchestrator) emits a `preprocess-cache:summary` event with
- * the returned values when there are subscribers for it.
+ * Read the current cache stats and reset the counters. The `compileAll`
+ * orchestrator calls this once per batch and forwards the values as a
+ * `preprocess-cache:summary` event payload.
  */
 export function consumePreprocessCacheStats(): { hits: number; misses: number } {
   const stats = { hits, misses };

--- a/packages/mochi/src/preprocessCache.ts
+++ b/packages/mochi/src/preprocessCache.ts
@@ -1,56 +1,20 @@
-import { createHash } from 'node:crypto';
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import path from 'node:path';
-import { preprocessHydratable, PREPROCESS_LOGIC_VERSION, type PreprocessResult } from './svelteAstPreprocess';
+import { preprocessHydratable, type PreprocessResult } from './svelteAstPreprocess';
 
-const memCache: Map<string, PreprocessResult> = new Map();
+// Keyed by absolute file path. Each entry stores the source text it was
+// computed from so we can detect edits on subsequent calls without hashing.
+const memCache: Map<string, { source: string; result: PreprocessResult }> = new Map();
 
-/**
- * Cache key spans three invalidation axes:
- *   1. source content       — edits to the .svelte file
- *   2. file path            — `preprocessHydratable` resolves child imports
- *                             relative to filePath, so the same source at a
- *                             different path produces a different result
- *   3. preprocessor logic   — PREPROCESS_LOGIC_VERSION hashes
- *                             svelteAstPreprocess.ts itself
- *
- * Any change in any axis flips the key, so the cache cannot serve stale
- * output in dev.
- */
-function cacheKey(source: string, filePath: string): string {
-  return createHash('sha256').update(source).update('\0').update(filePath).update('\0').update(PREPROCESS_LOGIC_VERSION).digest('hex');
-}
-
-export function cachedPreprocessHydratable(source: string, filePath: string, cacheDir: string): PreprocessResult {
-  const key = cacheKey(source, filePath);
-
-  const fromMem = memCache.get(key);
-  if (fromMem) {
-    return fromMem;
+export function cachedPreprocessHydratable(source: string, filePath: string): PreprocessResult {
+  const hit = memCache.get(filePath);
+  if (hit && hit.source === source) {
+    return hit.result;
   }
-
-  const diskPath = path.join(cacheDir, `${key}.json`);
-  try {
-    const raw = readFileSync(diskPath, 'utf8');
-    const parsed = JSON.parse(raw) as PreprocessResult;
-    memCache.set(key, parsed);
-    return parsed;
-  } catch {
-    // miss or corrupt — fall through to fresh preprocess
-  }
-
   const result = preprocessHydratable(source, filePath);
-  memCache.set(key, result);
-  try {
-    mkdirSync(cacheDir, { recursive: true });
-    writeFileSync(diskPath, JSON.stringify(result));
-  } catch {
-    // disk cache is a perf optimization, not correctness — swallow write errors
-  }
+  memCache.set(filePath, { source, result });
   return result;
 }
 
-/** Test-only: drop the in-memory cache. Disk cache is unaffected. */
+/** Test-only: drop the in-memory cache. */
 export function __resetPreprocessMemCache(): void {
   memCache.clear();
 }

--- a/packages/mochi/src/preprocessCache.ts
+++ b/packages/mochi/src/preprocessCache.ts
@@ -16,7 +16,9 @@ export function cachedPreprocessHydratable(source: string, filePath: string, sta
   const entry = memCache.get(filePath);
   // String `===` is a value compare, so any byte change in the source invalidates the entry.
   if (entry && entry.source === source) {
-    if (stats) {stats.hits++;}
+    if (stats) {
+      stats.hits++;
+    }
     if (hasSubscribers('preprocess-cache:hit')) {
       mochiEvents.emit('preprocess-cache:hit', { filePath });
     }
@@ -24,7 +26,9 @@ export function cachedPreprocessHydratable(source: string, filePath: string, sta
   }
   const result = preprocessHydratable(source, filePath);
   memCache.set(filePath, { source, result });
-  if (stats) {stats.misses++;}
+  if (stats) {
+    stats.misses++;
+  }
   if (hasSubscribers('preprocess-cache:miss')) {
     mochiEvents.emit('preprocess-cache:miss', { filePath });
   }

--- a/packages/mochi/src/svelteAstPreprocess.test.ts
+++ b/packages/mochi/src/svelteAstPreprocess.test.ts
@@ -138,6 +138,17 @@ describe('preprocessHydratable', () => {
     expect(transformed).toBe(source);
   });
 
+  test('fast-path skips Svelte parse for sources without mochi markers', () => {
+    // Syntactically invalid Svelte that would crash `parse()` — if the fast-path
+    // didn't fire, this would throw. With the early-exit it returns the source
+    // unchanged because no `mochi:hydrate` / `mochi:defer` substring is present.
+    const source = 'this is not valid svelte {{{{ <<<<';
+    const result = preprocessHydratable(source, '/test/Garbage.svelte');
+    expect(result.transformed).toBe(source);
+    expect(result.hydratables).toHaveLength(0);
+    expect(result.serverIslands).toHaveLength(0);
+  });
+
   test('component without matching import is skipped', () => {
     const source = `${SCRIPT('')}<Unknown mochi:hydrate />`;
     const { transformed, hydratables } = preprocessHydratable(source, '/test/File.svelte');

--- a/packages/mochi/src/svelteAstPreprocess.ts
+++ b/packages/mochi/src/svelteAstPreprocess.ts
@@ -3,24 +3,7 @@ import type { AST } from 'svelte/compiler';
 import MagicString from 'magic-string';
 import { customAlphabet } from 'nanoid';
 import path from 'node:path';
-import { createHash } from 'node:crypto';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
 import { walk } from 'zimmerframe';
-
-// Hash of this file's own source, computed once at module load. The disk cache
-// in `preprocessCache.ts` mixes this into its key so any edit to the
-// preprocessor logic invalidates every cache entry. The `unknown` fallback only
-// fires under exotic bundling where the runtime can't read its own source;
-// `bun run clean` is the recovery path for that case.
-export const PREPROCESS_LOGIC_VERSION: string = (() => {
-  try {
-    const selfPath = fileURLToPath(import.meta.url);
-    return createHash('sha256').update(readFileSync(selfPath)).digest('hex');
-  } catch {
-    return 'unknown';
-  }
-})();
 
 // Dash-free alphabet: island IDs are embedded as `mochi-<id>-<uid>`, so an id
 // containing `-` breaks that delimiter and (historically) made tests flaky

--- a/packages/mochi/src/svelteAstPreprocess.ts
+++ b/packages/mochi/src/svelteAstPreprocess.ts
@@ -3,7 +3,24 @@ import type { AST } from 'svelte/compiler';
 import MagicString from 'magic-string';
 import { customAlphabet } from 'nanoid';
 import path from 'node:path';
+import { createHash } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { walk } from 'zimmerframe';
+
+// Hash of this file's own source, computed once at module load. The disk cache
+// in `preprocessCache.ts` mixes this into its key so any edit to the
+// preprocessor logic invalidates every cache entry. The `unknown` fallback only
+// fires under exotic bundling where the runtime can't read its own source;
+// `bun run clean` is the recovery path for that case.
+export const PREPROCESS_LOGIC_VERSION: string = (() => {
+  try {
+    const selfPath = fileURLToPath(import.meta.url);
+    return createHash('sha256').update(readFileSync(selfPath)).digest('hex');
+  } catch {
+    return 'unknown';
+  }
+})();
 
 // Dash-free alphabet: island IDs are embedded as `mochi-<id>-<uid>`, so an id
 // containing `-` breaks that delimiter and (historically) made tests flaky
@@ -45,6 +62,9 @@ export interface PreprocessResult {
  *   attribute, registered in both lists
  */
 export function preprocessHydratable(source: string, filePath: string): PreprocessResult {
+  if (!source.includes('mochi:hydrate') && !source.includes('mochi:defer')) {
+    return { transformed: source, hydratables: [], serverIslands: [] };
+  }
   const ast = parse(source, { modern: true });
   const s = new MagicString(source);
 

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -84,7 +84,7 @@ await Mochi.serve({
   idleTimeout: 60,
   compressServerIslandProps: true,
   additionalWatchPaths: ['../mochi/docs'],
-  logger: { level: 'log', preprocessCache: 'verbose' },
+  logger: { level: 'log' },
   proxy: { origin }, // TODO: This is a bit of an awkward way to set the allowed csrf domain...
   markdown: markdownConfig,
   eventHooks: {

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -84,7 +84,7 @@ await Mochi.serve({
   idleTimeout: 60,
   compressServerIslandProps: true,
   additionalWatchPaths: ['../mochi/docs'],
-  logger: { level: 'log' },
+  logger: { level: 'log', preprocessCache: 'verbose' },
   proxy: { origin }, // TODO: This is a bit of an awkward way to set the allowed csrf domain...
   markdown: markdownConfig,
   eventHooks: {


### PR DESCRIPTION
## Summary

Three layered optimizations to the SSR Svelte preprocess path in `ComponentRegistry`:

- **Marker fast-path** (`svelteAstPreprocess.ts`) — `preprocessHydratable` now early-returns when the source contains neither `mochi:hydrate` nor `mochi:defer`, skipping the full Svelte `parse()` + AST walk for the vast majority of components.
- **Per-file memoization** (`preprocessCache.ts`) — new `cachedPreprocessHydratable` keys results by absolute file path and re-runs only when the source text changes. The wrapper is what `ComponentRegistry`'s bundler `onLoad` calls now.
- **`node_modules` skip** (`ComponentRegistry.ts`) — vendored `.svelte` files can never carry `mochi:*` directives, so they bypass preprocessing entirely.

## Test plan

- [x] `preprocessCache.test.ts` — identity check on repeat calls, source-change invalidation, per-path isolation, non-island round-trip, reset helper
- [x] `svelteAstPreprocess.test.ts` — fast-path proven by feeding syntactically invalid Svelte that would otherwise crash `parse()`
- [ ] Smoke-test demo site (`PORT=4444 bun run dev:site`) to confirm island/defer routes still hydrate
- [ ] `bun run checks`