### PR TITLE
fix(debug-bar): show green status dot when liveReload is disabled

### DIFF
--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -395,7 +395,7 @@ export class Mochi {
               serverIslandClientJs,
               liveReloadClientJs,
               debugBarUrl: registry.getDebugBarUrl(),
-              debugInfo: result.debugBarData,
+              debugInfo: result.debugBarData ? { ...result.debugBarData, liveReloadEnabled } : undefined,
               logLevel: resolvedLogLevel,
               pageEntry: liveReloadEnabled ? path.resolve(componentPath) : undefined,
             });

--- a/packages/mochi/src/debug-bar/StatusDot.svelte
+++ b/packages/mochi/src/debug-bar/StatusDot.svelte
@@ -8,7 +8,7 @@
   onMount(() => {
     const ws = window.__mochi_reload_ws;
     if (!ws) {
-      status = 'disconnected';
+      status = window.__mochi_debug?.liveReloadEnabled === false ? 'connected' : 'disconnected';
       return;
     }
     if (ws.readyState === WebSocket.OPEN) {

--- a/packages/mochi/src/requestContext.ts
+++ b/packages/mochi/src/requestContext.ts
@@ -84,6 +84,8 @@ export interface DebugBarData {
    * this to flag cookie rows.
    */
   varyOnCookies?: string[];
+  /** Whether live-reload is enabled for this server instance. */
+  liveReloadEnabled?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- When `liveReload` is disabled, the debug bar status dot showed red (disconnected) because no WebSocket was created. Now it checks `window.__mochi_debug.liveReloadEnabled` and shows green when live reload is intentionally off.
- Pipes the `liveReloadEnabled` flag through `DebugBarData` into the client-side debug payload.

## Test plan
- [ ] Start the dev server with `liveReload: false` and verify the debug bar dot is green
- [ ] Start the dev server normally (liveReload enabled) and verify the dot is green when connected, red when disconnected