### PR TITLE
fix(ci): bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/cli-regression-test.yml
+++ b/.github/workflows/cli-regression-test.yml
@@ -2,7 +2,7 @@ name: cli regression test
 
 on:
   schedule:
-    - cron: '15 6 * * *'
+    - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -33,7 +33,7 @@ jobs:
 
       - name: Upload report artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cli-regression-report
           path: cli-tests/*-report.md

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Check out release PR branch
         if: ${{ steps.release.outputs.prs_created == 'true' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: release-please--branches--main
 
@@ -64,7 +64,7 @@ jobs:
     if: ${{ needs.release-please.outputs.mochi_release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.mochi_tag_name }}
 
@@ -72,7 +72,7 @@ jobs:
         with:
           bun-version-file: .bun-version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -91,7 +91,7 @@ jobs:
     if: ${{ needs.release-please.outputs.cli_release_created == 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ needs.release-please.outputs.cli_tag_name }}
 
@@ -99,7 +99,7 @@ jobs:
         with:
           bun-version-file: .bun-version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'
@@ -117,7 +117,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
 
@@ -125,7 +125,7 @@ jobs:
         with:
           bun-version-file: .bun-version
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -12,7 +12,7 @@ jobs:
   loc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -34,7 +34,7 @@ jobs:
         run: bun .github/scripts/loc-comment.ts main.json pr.json > comment.md
 
       - name: Post or update sticky comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const fs = require('fs');

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## Summary
- Bump `actions/checkout` v4 → v6, `actions/upload-artifact` v4 → v7, `actions/setup-node` v4 → v6, `actions/github-script` v7 → v9 across all workflows
- Update `cli-regression-test.yml` schedule to 08:00 UTC (10:00 GMT+2)

Addresses the Node.js 20 deprecation warning — all actions now use versions with native Node 24 support.

## Test plan
- [ ] Verify all workflows pass on this PR (test, format, review)
- [ ] After merge, manually trigger the cli regression test workflow