### PR TITLE
fix(ci): sync release bun.lock + add packages/docs to Dockerfiles

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,19 +36,19 @@ jobs:
           manifest-file: .release-please-manifest.json
 
       - name: Check out release PR branch
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.prs_updated == 'true' }}
         uses: actions/checkout@v6
         with:
           ref: release-please--branches--main
 
       - name: Set up Bun
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.prs_updated == 'true' }}
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
 
       - name: Sync bun.lock
-        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.prs_updated == 'true' }}
         run: |
           bun install
           if ! git diff --quiet bun.lock; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,7 @@ COPY --from=install /temp/dev/node_modules node_modules
 COPY --from=install /temp/dev/packages/mochi/node_modules packages/mochi/node_modules
 COPY --from=install /temp/dev/packages/site/node_modules packages/site/node_modules
 COPY --from=install /temp/dev/packages/demos/node_modules packages/demos/node_modules
+COPY --from=install /temp/dev/packages/docs/node_modules packages/docs/node_modules
 
 # ncdu for disk usage analysis. libgcc is already present in oven/bun:alpine.
 RUN apk add --no-cache ncdu
@@ -51,6 +52,8 @@ RUN apk add --no-cache ncdu
 # .mochi for runtime build cache; src/ must be writable too because demos'
 # tailwind step writes app.generated.css into src/ at startup (no-op for site).
 RUN mkdir -p packages/${WORKSPACE}/.mochi && chown -R bun:bun packages/${WORKSPACE}/.mochi packages/${WORKSPACE}/src
+
+RUN bun packages/site/src/lib/generateDocsBarrel.ts
 
 ENV WORKSPACE=${WORKSPACE}
 ENV MOCHI_LIVE_RELOAD=false

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -26,8 +26,9 @@ WORKDIR /usr/src/app
 FROM base AS install
 ARG WORKSPACE
 COPY packages/mochi /temp/prod/packages/mochi
+COPY packages/docs /temp/prod/packages/docs
 COPY packages/${WORKSPACE} /temp/prod/packages/${WORKSPACE}
-RUN printf '{\n  "name": "mochi-monorepo",\n  "private": true,\n  "type": "module",\n  "workspaces": ["packages/mochi", "packages/%s"]\n}\n' "${WORKSPACE}" > /temp/prod/package.json
+RUN printf '{\n  "name": "mochi-monorepo",\n  "private": true,\n  "type": "module",\n  "workspaces": ["packages/mochi", "packages/docs", "packages/%s"]\n}\n' "${WORKSPACE}" > /temp/prod/package.json
 RUN cd /temp/prod && bun install --production --omit=dev
 # Tailwind/lightningcss are demos-only. Mochi-framework declares them as
 # optional peers + transitive paths still pull them in; prune for everyone
@@ -47,8 +48,10 @@ ARG WORKSPACE
 COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/packages/${WORKSPACE}/node_modules packages/${WORKSPACE}/node_modules
 COPY --from=install /temp/prod/packages/mochi/node_modules packages/mochi/node_modules
+COPY --from=install /temp/prod/packages/docs/node_modules packages/docs/node_modules
 COPY --from=install /temp/prod/package.json ./
 COPY packages/mochi packages/mochi
+COPY packages/docs packages/docs
 COPY packages/${WORKSPACE} packages/${WORKSPACE}
 RUN bun --cwd=packages/${WORKSPACE} run build
 
@@ -60,11 +63,13 @@ ENV WORKSPACE=${WORKSPACE}
 
 COPY --from=install /temp/prod/package.json ./
 COPY packages/mochi packages/mochi
+COPY packages/docs packages/docs
 COPY packages/${WORKSPACE} packages/${WORKSPACE}
 
 COPY --from=install /temp/prod/node_modules node_modules
 COPY --from=install /temp/prod/packages/${WORKSPACE}/node_modules packages/${WORKSPACE}/node_modules
 COPY --from=install /temp/prod/packages/mochi/node_modules packages/mochi/node_modules
+COPY --from=install /temp/prod/packages/docs/node_modules packages/docs/node_modules
 
 COPY --from=build /usr/src/app/packages/${WORKSPACE}/.mochi packages/${WORKSPACE}/.mochi
 


### PR DESCRIPTION
## Summary
- **release.yml**: Broaden the bun.lock sync steps to run on `prs_updated` (not just `prs_created`), so the lockfile stays current across release PR rebases
- **Dockerfile / Dockerfile.production**: Add `packages/docs` source and `node_modules` to all build stages — the docs workspace extraction (#21) broke Docker builds because Callout.svelte couldn't resolve `@lucide/svelte` and the generated docs barrel was missing
- **Dockerfile (dev)**: Generate `docComponents.generated.ts` at build time since the dev entrypoint skips the build script

## Test plan
- [x] `docker build --build-arg WORKSPACE=site -f Dockerfile.production .` succeeds and all 36 pages compile
- [x] Production container serves `/` (200) and `/docs/intro/` (200)
- [x] `docker build --build-arg WORKSPACE=site -f Dockerfile .` succeeds with barrel generation
- [x] Dev container boots and serves both routes