### PR TITLE
fix: debug bar Bundles link points to undefined in production

### DIFF
--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -176,10 +176,10 @@ export class Mochi {
         () =>
           (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
           serverIslandScript +
-          (opts.debugBarUrl ? `<script type="module" src="${opts.debugBarUrl}"></script>` : '') +
-          (opts.liveReloadClientJs
-            ? `<script>window.__mochi_asset_prefix=${JSON.stringify(registry.assetPrefix)};${opts.liveReloadClientJs}</script><mochi-live-reload></mochi-live-reload>`
-            : ''),
+          (opts.debugBarUrl
+            ? `<script type="module" src="${opts.debugBarUrl}"></script><script>window.__mochi_asset_prefix=${JSON.stringify(registry.assetPrefix)}</script>`
+            : '') +
+          (opts.liveReloadClientJs ? `<script>${opts.liveReloadClientJs}</script><mochi-live-reload></mochi-live-reload>` : ''),
       );
   }
 

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -43,8 +43,7 @@
 
   let warnLevel = $derived(getPropsWarnLevel(debugBarState.totalPropsSize));
 
-  // The debug bar mounts client-only via mount() and only runs in dev mode,
-  // where Mochi.ts unconditionally seeds window.__mochi_asset_prefix.
+  // Mochi.ts seeds window.__mochi_asset_prefix whenever the debug bar is enabled.
   const statsHref = `${window.__mochi_asset_prefix}/client/stats`;
 
   onMount(() => {


### PR DESCRIPTION
## Summary

- `window.__mochi_asset_prefix` was only set inside the `liveReloadClientJs` conditional in `Mochi.ts`, so in production (where live-reload is off) the debug bar's Bundles link resolved to `undefined/client/stats/`
- Moved the assignment to be paired with the debug bar script injection instead, so it's set whenever the debug bar is enabled

## Test plan

- [ ] `bun run dev:site` — debug bar Bundles link points to `/_mochi/client/stats`
- [ ] Production mode with debug bar enabled — same link works correctly