### PR TITLE
fix: immutable asset caching + feat: SSR duration in debug bar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,7 @@ RUN bun packages/site/src/lib/generateDocsBarrel.ts
 
 ENV WORKSPACE=${WORKSPACE}
 ENV MOCHI_LIVE_RELOAD=false
+ENV MOCHI_DOCKER=true
 USER bun
 EXPOSE ${PORT}/tcp
 ENTRYPOINT [ "sh", "-c", "exec bun run dev:${WORKSPACE}" ]

--- a/packages/demos/src/index.ts
+++ b/packages/demos/src/index.ts
@@ -1,5 +1,15 @@
 import { Mochi, silenceInternalRoutes } from 'mochi-framework';
+import type { Handle } from 'mochi-framework';
 import { routes } from './routes';
+
+const IS_DOCKER = process.env.MOCHI_DOCKER === 'true';
+const immutableAssets: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+  if (IS_DOCKER && event.kind === 'asset') {
+    response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+  }
+  return response;
+};
 
 const PORT = Number(process.env.PORT) || 3334;
 
@@ -11,6 +21,7 @@ await Mochi.serve({
   trailingSlash: 'always',
   idleTimeout: 60,
   compressServerIslandProps: true,
+  handle: immutableAssets,
   filters: {
     'consoleLogger:line': silenceInternalRoutes,
   },

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -390,7 +390,11 @@ export class Mochi {
             }
             const formProp = ctx.form ?? null;
             const resolvedProps = formProp === null ? baseProps : { ...baseProps, form: formProp };
+            const ssrStart = performance.now();
             const result = await registry.renderComponent(componentPath, resolvedProps);
+            if (result.debugBarData) {
+              result.debugBarData.ssrDurationMs = Math.round((performance.now() - ssrStart) * 100) / 100;
+            }
             const html = Mochi.resolveHtmlShell(shellTemplate, result, registry, {
               serverIslandClientJs,
               liveReloadClientJs,

--- a/packages/mochi/src/debug-bar/RequestPanel.svelte
+++ b/packages/mochi/src/debug-bar/RequestPanel.svelte
@@ -18,6 +18,7 @@
   let headers: Array<[string, string]> = $state([]);
   let expanded: Record<number, boolean> = $state({});
 
+  let ssrDurationMs: number | null = $state(null);
   let requestCookies: Array<[string, string]> = $state([]);
   let varyOnCookies: Set<string> = $state(new Set());
 
@@ -25,6 +26,9 @@
     const info = window.__mochi_debug;
     if (info) {
       debugInfo = { route: info.route, pathname: info.pathname, params: info.params };
+      if (typeof info.ssrDurationMs === 'number') {
+        ssrDurationMs = info.ssrDurationMs;
+      }
       if (info.headers) {
         headers = info.headers;
       }
@@ -103,6 +107,7 @@
 
 <DebugPanel title="Request" color="#8ab79a" {open} {onclose}>
   {#snippet titleExtra()}
+    {#if ssrDurationMs !== null}<span class="panel-title-meta"><span class="panel-title-sep">·</span>{ssrDurationMs < 1 ? '<1' : Math.round(ssrDurationMs)}ms</span>{/if}
     {#if htmlSizeLabel}<span class="panel-title-meta"
         ><span class="panel-title-sep">·</span>{htmlSizeLabel}{#if gzipDisabledHint}<span class="gzip-info" title={gzipDisabledHint} aria-label={gzipDisabledHint}
             ><Info size={11} /></span

--- a/packages/mochi/src/requestContext.ts
+++ b/packages/mochi/src/requestContext.ts
@@ -86,6 +86,8 @@ export interface DebugBarData {
   varyOnCookies?: string[];
   /** Whether live-reload is enabled for this server instance. */
   liveReloadEnabled?: boolean;
+  /** Time in milliseconds the SSR render took (compile check + Svelte render + HTML processing). */
+  ssrDurationMs?: number;
 }
 
 /**

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -6,6 +6,15 @@ import { clearDocsCaches, DOCS_DIR } from './lib/docs';
 import { markdownConfig, routes } from './routes';
 import { handle as cookieVaryTestHandle } from './demos/cookie-vary-test/routes';
 
+const IS_DOCKER = process.env.MOCHI_DOCKER === 'true';
+const immutableAssets: Handle = async ({ event, resolve }) => {
+  const response = await resolve(event);
+  if (IS_DOCKER && event.kind === 'asset') {
+    response.headers.set('Cache-Control', 'public, max-age=31536000, immutable');
+  }
+  return response;
+};
+
 if (process.env.MODE === 'development') {
   await generateDocsBarrel();
 
@@ -80,7 +89,7 @@ await Mochi.serve({
   liveReload: process.env.MOCHI_LIVE_RELOAD === 'false' ? false : undefined,
   htmlShell: './src/shell.html',
   trailingSlash: 'always',
-  handle: sequence(compress(), helloWorld, asciiDog, noCache, cookieVaryTestHandle),
+  handle: sequence(compress(), immutableAssets, helloWorld, asciiDog, noCache, cookieVaryTestHandle),
   handleError,
   idleTimeout: 60,
   compressServerIslandProps: true,


### PR DESCRIPTION
## Summary
- **Immutable asset headers in Docker**: Sets `Cache-Control: public, max-age=31536000, immutable` on asset responses when running in Docker dev-mode deployments (`MOCHI_DOCKER=true`), restoring proper browser caching for hashed assets
- **SSR render duration in debug bar**: Measures the full `renderComponent()` time (compile check + Svelte render + HTML processing) and displays it in the Request panel title bar alongside the HTML size (e.g. `· 3ms · 14.2 KB`)

## Test plan
- [ ] Run `bun run dev:site`, open the debug bar → Request panel, confirm SSR duration appears
- [ ] Deploy via Docker, verify asset responses have immutable cache headers
- [ ] `bun run checks` passes (lint, format, typecheck, tests)