### PR TITLE
fix: register trailing-slash alternates for internal framework routes

### DIFF
--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -7,6 +7,7 @@ await Mochi.serve({
   port: PORT,
   development: process.env.MODE === 'development',
   htmlShell: './src/shell.html',
+  trailingSlash: 'always',
   filters: {
     'consoleLogger:line': silenceInternalRoutes,
   },

--- a/packages/mochi/src/clientStatsRoutes.ts
+++ b/packages/mochi/src/clientStatsRoutes.ts
@@ -8,13 +8,15 @@ export const CLIENT_STATS_COMPONENT = new URL('./templates/ClientStats/ClientSta
 // create a circular import. Same dodge as `pageCacheAdminRoutes.ts`.
 export function buildClientStatsRoutes(registry: ComponentRegistry): Record<string, MochiPageConfig> {
   const path = `${registry.assetPrefix}/client/stats`;
+  const config: MochiPageConfig = {
+    __mochiPage: true,
+    componentPath: CLIENT_STATS_COMPONENT,
+    serverProps: () => ({
+      stats: registry.getClientStats() ?? { outputs: [] },
+    }),
+  };
   return {
-    [path]: {
-      __mochiPage: true,
-      componentPath: CLIENT_STATS_COMPONENT,
-      serverProps: () => ({
-        stats: registry.getClientStats() ?? { outputs: [] },
-      }),
-    },
+    [path]: config,
+    [`${path}/`]: config,
   };
 }

--- a/packages/mochi/src/pageCacheAdminRoutes.ts
+++ b/packages/mochi/src/pageCacheAdminRoutes.ts
@@ -34,28 +34,32 @@ const STUB_ENTRIES: StubEntry[] = [
 // `Mochi.page()` / `Mochi.api()` because Mochi.ts already imports from this
 // module, and going through the helpers would create a circular import.
 export function buildPageCacheAdminRoutes(): Record<string, MochiPageConfig | MochiApiConfig> {
-  return {
-    [PAGE_CACHE_ADMIN_PATH]: {
-      __mochiPage: true,
-      componentPath: PAGE_CACHE_ADMIN_COMPONENT,
-      serverProps: () => ({ stats: STUB_STATS, entries: STUB_ENTRIES }),
-      actions: {
-        purgeAll: () => undefined,
-        purge: ({ formData }) => {
-          // Keep the formData lookup so the front-end form contract is unchanged
-          // for when the real cache returns; right now it's a no-op.
-          formData.get('path');
-          return undefined;
-        },
+  const pageConfig: MochiPageConfig = {
+    __mochiPage: true,
+    componentPath: PAGE_CACHE_ADMIN_COMPONENT,
+    serverProps: () => ({ stats: STUB_STATS, entries: STUB_ENTRIES }),
+    actions: {
+      purgeAll: () => undefined,
+      purge: ({ formData }) => {
+        formData.get('path');
+        return undefined;
       },
     },
-    [`${PAGE_CACHE_ADMIN_PATH}/stats`]: {
-      __mochiApi: true,
-      handler: () => Response.json(STUB_STATS, { headers: { 'Cache-Control': 'no-store' } }),
-    },
-    [`${PAGE_CACHE_ADMIN_PATH}/entries`]: {
-      __mochiApi: true,
-      handler: () => Response.json(STUB_ENTRIES, { headers: { 'Cache-Control': 'no-store' } }),
-    },
+  };
+  const statsApi: MochiApiConfig = {
+    __mochiApi: true,
+    handler: () => Response.json(STUB_STATS, { headers: { 'Cache-Control': 'no-store' } }),
+  };
+  const entriesApi: MochiApiConfig = {
+    __mochiApi: true,
+    handler: () => Response.json(STUB_ENTRIES, { headers: { 'Cache-Control': 'no-store' } }),
+  };
+  return {
+    [PAGE_CACHE_ADMIN_PATH]: pageConfig,
+    [`${PAGE_CACHE_ADMIN_PATH}/`]: pageConfig,
+    [`${PAGE_CACHE_ADMIN_PATH}/stats`]: statsApi,
+    [`${PAGE_CACHE_ADMIN_PATH}/stats/`]: statsApi,
+    [`${PAGE_CACHE_ADMIN_PATH}/entries`]: entriesApi,
+    [`${PAGE_CACHE_ADMIN_PATH}/entries/`]: entriesApi,
   };
 }

--- a/packages/mochi/src/trailingSlash.none.isolated.test.ts
+++ b/packages/mochi/src/trailingSlash.none.isolated.test.ts
@@ -39,4 +39,9 @@ describe('trailingSlash: unset (no policy)', () => {
     const res = await fetch(`${base}/about/`, { redirect: 'manual' });
     expect(res.status).toBe(404);
   });
+
+  test('internal /_mochi/client/stats/ (trailing slash) serves 200', async () => {
+    const res = await fetch(`${base}/_mochi/client/stats/`, { redirect: 'manual' });
+    expect(res.status).toBe(200);
+  });
 });


### PR DESCRIPTION
## Summary
- Internal routes (`/_mochi/client/stats`, `/__mochi/admin/page-cache`, etc.) returned 404 when accessed with a trailing slash because Bun's router treats `/path` and `/path/` as distinct patterns
- Each internal route builder now registers both slash variants, independent of the user's `trailingSlash` policy

## Test plan
- [x] New test in `trailingSlash.none.isolated.test.ts` verifies `/_mochi/client/stats/` returns 200 without a trailing slash policy
- [x] All existing tests pass (`bun run checks`)