### PR TITLE
fix(ci): patch workspace versions in bun.lock during release sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,12 @@ jobs:
         if: ${{ steps.release.outputs.prs_created == 'true' || steps.release.outputs.prs_updated == 'true' }}
         run: |
           bun install
+          for dir in packages/*/; do
+            [ -f "${dir}package.json" ] || continue
+            ver=$(jq -r .version "${dir}package.json")
+            key=$(echo "${dir%/}" | sed 's/\//\\\//g')
+            sed -i "/\"${key}\"/,/\"version\"/ s/\"version\": \"[^\"]*\"/\"version\": \"$ver\"/" bun.lock
+          done
           if ! git diff --quiet bun.lock; then
             git config user.name "github-actions[bot]"
             git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/bun.lock
+++ b/bun.lock
@@ -78,7 +78,7 @@
     },
     "packages/mochi": {
       "name": "mochi-framework",
-      "version": "0.2.0",
+      "version": "0.3.2",
       "bin": {
         "mochi-framework": "src/cli.js",
       },


### PR DESCRIPTION
## Summary

- `bun install` doesn't update the `version` field for workspace packages in `bun.lock` — `workspace:*` resolves identically regardless of version, so Bun considers the lockfile up-to-date
- After `bun install`, loop through each `packages/*/package.json`, read its version, and sed-patch the matching entry in `bun.lock`
- Also fixes the currently-stale `mochi-framework` version in `bun.lock` (`0.2.0` → `0.3.2`)

## Test plan

- [ ] Merge a `fix:`/`feat:` commit to `main` and verify the release-please PR gets an updated `bun.lock` with correct workspace versions