### PR TITLE
docs: clarify layout composition in Coming from SvelteKit guide

### DIFF
--- a/packages/docs/15-coming-from-sveltekit.md
+++ b/packages/docs/15-coming-from-sveltekit.md
@@ -69,14 +69,9 @@ Register the most specific patterns first — Bun matches in declaration order, 
 
 ### Layouts
 
-SvelteKit's `+layout.svelte` / `+layout.server.ts` have no Mochi equivalent. Compose Svelte components yourself — each page imports the shell it needs, and shared `serverProps` resolvers can call a common helper.
+SvelteKit's `+layout.svelte` / `+layout.server.ts` have no Mochi equivalent. In SvelteKit, layouts persist across navigations — the client-side router keeps the layout component mounted and only swaps the page slot, which also lets `+layout.server.ts` skip refetching data that hasn't been invalidated. Mochi has no client-side router, so every navigation is a full page load; there is no component tree to persist and no data to selectively revalidate.
 
-```ts
-// file (SvelteKit): src/routes/+layout.server.ts
-export async function load() {
-  return { user: await loadCurrentUser() };
-}
-```
+Instead, create a wrapper component that accepts `children`, and import it from each page.
 
 ```svelte
 <!-- file (SvelteKit): src/routes/+layout.svelte -->
@@ -86,6 +81,42 @@ export async function load() {
 
 <nav>Hi {data.user.name}</nav>
 {@render children()}
+```
+
+```svelte
+<!-- file (Mochi): src/lib/Layout.svelte -->
+<script>
+  let { user, children } = $props();
+</script>
+
+<nav>Hi {user.name}</nav>
+{@render children()}
+```
+
+In SvelteKit, `+layout.svelte` wraps `+page.svelte` automatically. In Mochi, the page must import and wrap itself:
+
+```svelte
+<!-- file (Mochi): src/Home.svelte -->
+<script>
+  import Layout from './lib/Layout.svelte';
+  let { user, posts } = $props();
+</script>
+
+<Layout {user}>
+  <h1>Posts</h1>
+  {#each posts as post}
+    <a href="/posts/{post.slug}">{post.title}</a>
+  {/each}
+</Layout>
+```
+
+Share data that SvelteKit's `+layout.server.ts` would have loaded via a common helper, and spread the result into each route's `serverProps`:
+
+```ts
+// file (SvelteKit): src/routes/+layout.server.ts
+export async function load() {
+  return { user: await loadCurrentUser() };
+}
 ```
 
 ```ts
@@ -106,6 +137,12 @@ export const routes = {
   }),
 };
 ```
+
+<Callout type="tip">
+
+Every page that shares a shell imports the layout component explicitly — there is no automatic nesting. This is more verbose than SvelteKit, but makes the component tree visible at each call site.
+
+</Callout>
 
 ### Load functions
 


### PR DESCRIPTION
Explain why layouts differ (no client-side router means no persistent layout tree or selective data revalidation) and add the missing example showing how pages must explicitly import and wrap with a layout component.