### PR TITLE
feat: add /sitemap.xml route

### DIFF
--- a/packages/site/src/lib/docs.ts
+++ b/packages/site/src/lib/docs.ts
@@ -214,8 +214,8 @@ export async function buildSitemapXml(): Promise<string> {
 
   const urls: string[] = [
     `  <url><loc>${SITE_BASE}/</loc></url>`,
-    ...docs.map((d) => `  <url><loc>${SITE_BASE}/docs/${d.slug}</loc></url>`),
-    ...internalDemos.map((d) => `  <url><loc>${SITE_BASE}${d.href}</loc></url>`),
+    ...docs.map((d) => `  <url><loc>${SITE_BASE}/docs/${d.slug}/</loc></url>`),
+    ...internalDemos.map((d) => `  <url><loc>${SITE_BASE}${d.href}/</loc></url>`),
   ];
 
   cachedSitemapXml = ['<?xml version="1.0" encoding="UTF-8"?>', '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', ...urls, '</urlset>', ''].join('\n');

--- a/packages/site/src/lib/docs.ts
+++ b/packages/site/src/lib/docs.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { compile as mdsvexCompile } from 'mdsvex';
 import rehypeSlug from 'rehype-slug';
+import { demos } from './demos';
 import type { TocEntry } from './toc';
 
 type MdsvexRehypePlugin = NonNullable<NonNullable<Parameters<typeof mdsvexCompile>[1]>['rehypePlugins']>[number];
@@ -37,6 +38,7 @@ let cachedBySlug: Map<string, DocEntry> | null = null;
 let cachedNav: TocEntry[] | null = null;
 let cachedLlmsTxt: string | null = null;
 let cachedLlmsFullTxt: string | null = null;
+let cachedSitemapXml: string | null = null;
 
 export function clearDocsCaches(): void {
   cachedDocs = null;
@@ -44,6 +46,7 @@ export function clearDocsCaches(): void {
   cachedNav = null;
   cachedLlmsTxt = null;
   cachedLlmsFullTxt = null;
+  cachedSitemapXml = null;
 }
 
 export async function loadDocs(): Promise<DocEntry[]> {
@@ -198,6 +201,25 @@ export async function buildLlmsFullTxt(): Promise<string> {
   const [docs, demos] = await Promise.all([loadDocs(), buildDemosTxt()]);
   cachedLlmsFullTxt = docs.map((d) => d.raw.trimEnd()).join('\n\n') + '\n\n' + demos;
   return cachedLlmsFullTxt;
+}
+
+const SITE_BASE = 'https://mochi.fast';
+
+export async function buildSitemapXml(): Promise<string> {
+  if (cachedSitemapXml) {
+    return cachedSitemapXml;
+  }
+  const docs = await loadDocs();
+  const internalDemos = demos.filter((d) => d.href.startsWith('/'));
+
+  const urls: string[] = [
+    `  <url><loc>${SITE_BASE}/</loc></url>`,
+    ...docs.map((d) => `  <url><loc>${SITE_BASE}/docs/${d.slug}</loc></url>`),
+    ...internalDemos.map((d) => `  <url><loc>${SITE_BASE}${d.href}</loc></url>`),
+  ];
+
+  cachedSitemapXml = ['<?xml version="1.0" encoding="UTF-8"?>', '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">', ...urls, '</urlset>', ''].join('\n');
+  return cachedSitemapXml;
 }
 
 export async function getDocLlmsTxt(slug: string): Promise<string | null> {

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -3,7 +3,7 @@ import rehypeSlug from 'rehype-slug';
 import { Mochi, error, getRequestContext } from 'mochi-framework';
 import type { MochiBuildOptions, MarkdownConfig, MochiRouteValue } from 'mochi-framework';
 import { highlightCode } from './lib/highlightCode';
-import { buildDocsNav, buildLlmsTxt, buildLlmsFullTxt, getDoc, getDocLlmsTxt, getDocNeighbors, loadDocs } from './lib/docs';
+import { buildDocsNav, buildLlmsTxt, buildLlmsFullTxt, buildSitemapXml, getDoc, getDocLlmsTxt, getDocNeighbors, loadDocs } from './lib/docs';
 import { profilerEnabled, startProfiler, stopProfiler } from './lib/profiler';
 import { routes as apiRoutes } from './demos/api/routes';
 import { routes as cacheEventsRoutes } from './demos/cache-events/routes';
@@ -88,6 +88,11 @@ export const routes: Record<string, MochiRouteValue> = {
     },
   }),
   '/og': Mochi.page('./src/og/OgPage.svelte'),
+  '/sitemap.xml': Mochi.api(async () => {
+    return new Response(await buildSitemapXml(), {
+      headers: { 'Content-Type': 'application/xml; charset=utf-8' },
+    });
+  }),
   '/llms.txt': Mochi.api(async () => {
     return new Response(await buildLlmsTxt(), {
       headers: { 'Content-Type': 'text/plain; charset=utf-8' },


### PR DESCRIPTION
## Summary
- Adds a `/sitemap.xml` API route that dynamically enumerates all public pages (homepage, docs, internal demos)
- Follows the same cached-builder pattern as `/llms-full.txt`
- Filters out external demo sites (those with absolute URLs)

## Test plan
- [ ] `curl http://localhost:3333/sitemap.xml` returns valid XML with all docs and demos
- [ ] External demo sites (HN clone, etc.) are excluded
- [ ] Cache invalidation works via `clearDocsCaches()`