### PR TITLE
feat: per-page JS bundle panel in debug bar

### DIFF
--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -90,16 +90,18 @@ function main() {
 
   const allPackages = new Set([...mainDoc.packages.map((p) => p.name), ...prDoc.packages.map((p) => p.name)]);
 
-  const lines: string[] = [MARKER, '### Mochi review report', '', '**Lines of code** (non-blank lines)', ''];
+  const lines: string[] = [MARKER, '### Mochi review report', ''];
+
+  if (repo && runId) {
+    lines.push(...renderInstallSection(repo, runId));
+    lines.push('');
+  }
+
+  lines.push('**Lines of code** (non-blank lines)', '');
   for (const pkgName of allPackages) {
     const m = mainDoc.packages.find((p) => p.name === pkgName);
     const p = prDoc.packages.find((pp) => pp.name === pkgName);
     lines.push(...renderPackageSection(pkgName, m, p));
-    lines.push('');
-  }
-
-  if (repo && runId) {
-    lines.push(...renderInstallSection(repo, runId));
     lines.push('');
   }
 

--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -25,7 +25,7 @@ function renderRow(name: string, mainLines: number, prLines: number, bold = fals
   return `| ${wrap(name)} | ${wrap(mainLines)} | ${wrap(prLines)} | ${wrap(delta(prLines - mainLines))} |`;
 }
 
-function renderPackageSection(name: string, mainReport: Report | undefined, prReport: Report | undefined, collapsible: boolean): string[] {
+function renderPackageSection(name: string, mainReport: Report | undefined, prReport: Report | undefined, openByDefault: boolean): string[] {
   const main = mainReport?.byCategory ?? {};
   const pr = prReport?.byCategory ?? {};
   const allCategories = new Set([...Object.keys(main), ...Object.keys(pr)]);
@@ -52,10 +52,8 @@ function renderPackageSection(name: string, mainReport: Report | undefined, prRe
     table.push(`_Unchanged: ${unchanged.map((c) => `\`${c.name}\` (${c.lines})`).join(', ')}._`);
   }
 
-  if (collapsible) {
-    return ['<details>', `<summary><strong>${name}</strong></summary>`, '', ...table, '', '</details>'];
-  }
-  return [`#### ${name}`, '', ...table];
+  const detailsTag = openByDefault ? '<details open>' : '<details>';
+  return [detailsTag, `<summary><strong>${name}</strong></summary>`, '', ...table, '', '</details>'];
 }
 
 function renderInstallSection(repo: string, runId: string): string[] {
@@ -106,7 +104,7 @@ function main() {
   for (const pkgName of allPackages) {
     const m = mainDoc.packages.find((p) => p.name === pkgName);
     const p = prDoc.packages.find((pp) => pp.name === pkgName);
-    lines.push(...renderPackageSection(pkgName, m, p, pkgName !== 'packages/mochi'));
+    lines.push(...renderPackageSection(pkgName, m, p, pkgName === 'packages/mochi'));
     lines.push('');
   }
 

--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -2,7 +2,7 @@
 /**
  * Renders the markdown body for the review-bot PR comment by diffing two
  * loc-report.ts JSON outputs.
- * Usage: bun loc-comment.ts <main.json> <pr.json> [--run-url <url>]
+ * Usage: bun loc-comment.ts <main.json> <pr.json> [--repo <owner/repo> --run-id <id>]
  */
 
 import { readFileSync } from 'node:fs';
@@ -54,17 +54,18 @@ function renderPackageSection(name: string, mainReport: Report | undefined, prRe
   return lines;
 }
 
-function renderInstallSection(runUrl: string): string[] {
+function renderInstallSection(repo: string, runId: string): string[] {
+  const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
   return [
     '---',
     '<details>',
     '<summary>Try this PR</summary>',
     '',
-    `Download [\`mochi-framework-pr.tgz\`](${runUrl}#artifacts) from the workflow artifacts, then:`,
-    '',
     '```sh',
-    'bun i ./mochi-framework-pr.tgz',
+    `gh run download -R ${repo} ${runId} -n mochi-framework-pr -D /tmp/mochi-pr && bun i /tmp/mochi-pr/mochi-framework-pr.tgz`,
     '```',
+    '',
+    `<sub><a href="${runUrl}#artifacts">Download manually</a></sub>`,
     '',
     '</details>',
   ];
@@ -74,11 +75,13 @@ function main() {
   const args = process.argv.slice(2);
   const mainPath = args[0];
   const prPath = args[1];
-  const runUrlIdx = args.indexOf('--run-url');
-  const runUrl = runUrlIdx !== -1 ? args[runUrlIdx + 1] : undefined;
+  const repoIdx = args.indexOf('--repo');
+  const repo = repoIdx !== -1 ? args[repoIdx + 1] : undefined;
+  const runIdIdx = args.indexOf('--run-id');
+  const runId = runIdIdx !== -1 ? args[runIdIdx + 1] : undefined;
 
   if (!mainPath || !prPath) {
-    console.error('Usage: bun loc-comment.ts <main.json> <pr.json> [--run-url <url>]');
+    console.error('Usage: bun loc-comment.ts <main.json> <pr.json> [--repo <owner/repo> --run-id <id>]');
     process.exit(1);
   }
 
@@ -95,8 +98,8 @@ function main() {
     lines.push('');
   }
 
-  if (runUrl) {
-    lines.push(...renderInstallSection(runUrl));
+  if (repo && runId) {
+    lines.push(...renderInstallSection(repo, runId));
     lines.push('');
   }
 

--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env bun
 /**
  * Renders the markdown body for the review-bot PR comment by diffing two
- * loc-report.ts JSON outputs. Usage: bun loc-comment.ts <main.json> <pr.json>
+ * loc-report.ts JSON outputs.
+ * Usage: bun loc-comment.ts <main.json> <pr.json> [--run-url <url>]
  */
 
 import { readFileSync } from 'node:fs';
@@ -53,10 +54,31 @@ function renderPackageSection(name: string, mainReport: Report | undefined, prRe
   return lines;
 }
 
+function renderInstallSection(runUrl: string): string[] {
+  return [
+    '---',
+    '<details>',
+    '<summary>Try this PR</summary>',
+    '',
+    `Download [\`mochi-framework-pr.tgz\`](${runUrl}#artifacts) from the workflow artifacts, then:`,
+    '',
+    '```sh',
+    'bun i ./mochi-framework-pr.tgz',
+    '```',
+    '',
+    '</details>',
+  ];
+}
+
 function main() {
-  const [mainPath, prPath] = process.argv.slice(2);
+  const args = process.argv.slice(2);
+  const mainPath = args[0];
+  const prPath = args[1];
+  const runUrlIdx = args.indexOf('--run-url');
+  const runUrl = runUrlIdx !== -1 ? args[runUrlIdx + 1] : undefined;
+
   if (!mainPath || !prPath) {
-    console.error('Usage: bun loc-comment.ts <main.json> <pr.json>');
+    console.error('Usage: bun loc-comment.ts <main.json> <pr.json> [--run-url <url>]');
     process.exit(1);
   }
 
@@ -70,6 +92,11 @@ function main() {
     const m = mainDoc.packages.find((p) => p.name === pkgName);
     const p = prDoc.packages.find((pp) => pp.name === pkgName);
     lines.push(...renderPackageSection(pkgName, m, p));
+    lines.push('');
+  }
+
+  if (runUrl) {
+    lines.push(...renderInstallSection(runUrl));
     lines.push('');
   }
 

--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -25,7 +25,7 @@ function renderRow(name: string, mainLines: number, prLines: number, bold = fals
   return `| ${wrap(name)} | ${wrap(mainLines)} | ${wrap(prLines)} | ${wrap(delta(prLines - mainLines))} |`;
 }
 
-function renderPackageSection(name: string, mainReport: Report | undefined, prReport: Report | undefined): string[] {
+function renderPackageSection(name: string, mainReport: Report | undefined, prReport: Report | undefined, collapsible: boolean): string[] {
   const main = mainReport?.byCategory ?? {};
   const pr = prReport?.byCategory ?? {};
   const allCategories = new Set([...Object.keys(main), ...Object.keys(pr)]);
@@ -46,20 +46,25 @@ function renderPackageSection(name: string, mainReport: Report | undefined, prRe
   }
   changedRows.push(renderRow('Total', mainReport?.totals.lines ?? 0, prReport?.totals.lines ?? 0, true));
 
-  const lines: string[] = [`#### ${name}`, '', '| Category | main | PR | Δ |', '|---|---:|---:|---:|', ...changedRows];
+  const table = ['| Category | main | PR | Δ |', '|---|---:|---:|---:|', ...changedRows];
   if (unchanged.length > 0) {
-    lines.push('');
-    lines.push(`_Unchanged: ${unchanged.map((c) => `\`${c.name}\` (${c.lines})`).join(', ')}._`);
+    table.push('');
+    table.push(`_Unchanged: ${unchanged.map((c) => `\`${c.name}\` (${c.lines})`).join(', ')}._`);
   }
-  return lines;
+
+  if (collapsible) {
+    return ['<details>', `<summary><strong>${name}</strong></summary>`, '', ...table, '', '</details>'];
+  }
+  return [`#### ${name}`, '', ...table];
 }
 
 function renderInstallSection(repo: string, runId: string): string[] {
   const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
   return [
-    '---',
+    '#### Try this PR',
+    '',
     '<details>',
-    '<summary>Try this PR</summary>',
+    '<summary>Expand instructions</summary>',
     '',
     '```sh',
     `gh run download -R ${repo} ${runId} -n mochi-framework-pr -D /tmp/mochi-pr && bun i /tmp/mochi-pr/mochi-framework-pr.tgz`,
@@ -101,7 +106,7 @@ function main() {
   for (const pkgName of allPackages) {
     const m = mainDoc.packages.find((p) => p.name === pkgName);
     const p = prDoc.packages.find((pp) => pp.name === pkgName);
-    lines.push(...renderPackageSection(pkgName, m, p));
+    lines.push(...renderPackageSection(pkgName, m, p, pkgName !== 'packages/mochi'));
     lines.push('');
   }
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -43,7 +43,7 @@ jobs:
           path: mochi-framework-pr.tgz
 
       - name: Render comment
-        run: bun .github/scripts/loc-comment.ts main.json pr.json --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > comment.md
+        run: bun .github/scripts/loc-comment.ts main.json pr.json --repo ${{ github.repository }} --run-id ${{ github.run_id }} > comment.md
 
       - name: Post or update sticky comment
         uses: actions/github-script@v9

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,8 +30,20 @@ jobs:
           (cd ../main-tree && bun .github/scripts/loc-report.ts --json) > main.json
           git worktree remove --force ../main-tree
 
+      - name: Pack mochi-framework
+        run: |
+          cd packages/mochi
+          TARBALL=$(bun pack)
+          mv "$TARBALL" ../../mochi-framework-pr.tgz
+
+      - name: Upload tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: mochi-framework-pr
+          path: mochi-framework-pr.tgz
+
       - name: Render comment
-        run: bun .github/scripts/loc-comment.ts main.json pr.json > comment.md
+        run: bun .github/scripts/loc-comment.ts main.json pr.json --run-url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > comment.md
 
       - name: Post or update sticky comment
         uses: actions/github-script@v9

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -33,8 +33,8 @@ jobs:
       - name: Pack mochi-framework
         run: |
           cd packages/mochi
-          TARBALL=$(bun pack)
-          mv "$TARBALL" ../../mochi-framework-pr.tgz
+          bun pm pack
+          mv mochi-framework-*.tgz ../../mochi-framework-pr.tgz
 
       - name: Upload tarball
         uses: actions/upload-artifact@v4

--- a/packages/demos/src/index.ts
+++ b/packages/demos/src/index.ts
@@ -1,4 +1,4 @@
-import { Mochi, silenceInternalRoutes } from 'mochi-framework';
+import { Mochi, sequence, silenceInternalRoutes } from 'mochi-framework';
 import type { Handle } from 'mochi-framework';
 import { routes } from './routes';
 
@@ -11,6 +11,15 @@ const immutableAssets: Handle = async ({ event, resolve }) => {
   return response;
 };
 
+const ANALYTICS_SCRIPT = `<script defer src="https://u.khromov.se/u.js" data-website-id="8dceb8f5-6533-4c03-9cd6-1ce74accd63a"></script>`;
+const analytics: Handle = async ({ event, resolve }) => {
+  return resolve(event, {
+    transformPage({ html }) {
+      return html.replace('{{mochi.analytics}}', process.env.MODE === 'development' ? '' : ANALYTICS_SCRIPT);
+    },
+  });
+};
+
 const PORT = Number(process.env.PORT) || 3334;
 
 await Mochi.serve({
@@ -21,7 +30,7 @@ await Mochi.serve({
   trailingSlash: 'always',
   idleTimeout: 60,
   compressServerIslandProps: true,
-  handle: immutableAssets,
+  handle: sequence(immutableAssets, analytics),
   filters: {
     'consoleLogger:line': silenceInternalRoutes,
   },

--- a/packages/demos/src/shell.html
+++ b/packages/demos/src/shell.html
@@ -204,7 +204,6 @@
         ></path>
       </svg>
     </a>
-    {{mochi.script}}
-    <script defer src="https://u.khromov.se/u.js" data-website-id="8dceb8f5-6533-4c03-9cd6-1ce74accd63a"></script>
+    {{mochi.script}} {{mochi.analytics}}
   </body>
 </html>

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -1080,19 +1080,19 @@ export class ComponentRegistry {
             if (!pageHasIslands) {
               continue;
             }
-            bundles.push({ url, label: 'Island runtime', sizeBytes: output.size, kind: 'bootstrap' });
+            bundles.push({ url, label: 'Island runtime', sizeBytes: output.size, kind: 'bootstrap', inputs: output.inputs });
           } else {
             const compName = urlToComponent.get(url);
             if (compName) {
               if (!renderedIslandNames.has(compName)) {
                 continue;
               }
-              bundles.push({ url, label: compName, sizeBytes: output.size, kind: 'island' });
+              bundles.push({ url, label: compName, sizeBytes: output.size, kind: 'island', inputs: output.inputs });
             } else {
               if (!pageHasIslands) {
                 continue;
               }
-              bundles.push({ url, label: output.name, sizeBytes: output.size, kind: 'chunk' });
+              bundles.push({ url, label: output.name, sizeBytes: output.size, kind: 'chunk', inputs: output.inputs });
             }
           }
         }

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -1087,19 +1087,27 @@ export class ComponentRegistry {
             }
             const wcInputs = this.collectWebComponentInputs(output, outputByName);
             const wcSize = wcInputs.reduce((sum, i) => sum + i.size, 0);
-            bundles.push({ url, label: 'Island runtime', sizeBytes: output.size, kind: 'bootstrap', inputs: output.inputs, effectiveSize: wcSize, effectiveInputs: wcInputs });
+            bundles.push({
+              url,
+              label: 'Island runtime',
+              sizeBytes: output.size,
+              kind: 'bootstrap',
+              inputs: ComponentRegistry.cleanInputs(output.inputs),
+              effectiveSize: wcSize,
+              effectiveInputs: ComponentRegistry.cleanInputs(wcInputs),
+            });
           } else {
             const compName = urlToComponent.get(url);
             if (compName) {
               if (!renderedIslandNames.has(compName)) {
                 continue;
               }
-              bundles.push({ url, label: compName, sizeBytes: output.size, kind: 'island', inputs: output.inputs });
+              bundles.push({ url, label: compName, sizeBytes: output.size, kind: 'island', inputs: ComponentRegistry.cleanInputs(output.inputs) });
             } else {
               if (!pageHasIslands) {
                 continue;
               }
-              bundles.push({ url, label: output.name, sizeBytes: output.size, kind: 'chunk', inputs: output.inputs });
+              bundles.push({ url, label: output.name, sizeBytes: output.size, kind: 'chunk', inputs: ComponentRegistry.cleanInputs(output.inputs) });
             }
           }
         }
@@ -1156,6 +1164,14 @@ export class ComponentRegistry {
       hasServerIslands,
       debugBarData,
     };
+  }
+
+  private static cleanInputPath(p: string): string {
+    return p.replace(/^(?:\.\.\/)*node_modules\/(?:\.bun\/[^/]+\/node_modules\/)?/, '');
+  }
+
+  private static cleanInputs(inputs: { path: string; size: number }[]): { path: string; size: number }[] {
+    return inputs.map((i) => ({ path: ComponentRegistry.cleanInputPath(i.path), size: i.size }));
   }
 
   private collectWebComponentInputs(

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -223,6 +223,7 @@ export class ComponentRegistry {
       name: string;
       size: number;
       inputs: { path: string; size: number }[];
+      imports: string[];
     }[];
   } | null = null;
   /** Stats for side-effect CSS bundles, merged into clientStats at read time. */
@@ -230,6 +231,7 @@ export class ComponentRegistry {
     name: string;
     size: number;
     inputs: { path: string; size: number }[];
+    imports: string[];
   }[] = [];
   /** Maps server island component name → resolved file path */
   private serverIslandPaths: Map<string, string> = new Map();
@@ -927,10 +929,12 @@ export class ComponentRegistry {
           size: inputMeta.bytesInOutput,
         }));
         inputs.sort((a, b) => b.size - a.size);
+        const imports = (outMeta.imports ?? []).filter((i) => i.kind === 'import-statement').map((i) => path.basename(i.path));
         return {
           name: path.basename(outPath),
           size: outMeta.bytes,
           inputs,
+          imports,
         };
       });
       outputStats.sort((a, b) => b.size - a.size);
@@ -1071,6 +1075,7 @@ export class ComponentRegistry {
         }
         const pageHasIslands = hydratables.length > 0;
         const bundles: NonNullable<typeof debugBarData.bundles> = [];
+        const outputByName = new Map(this.clientStats.outputs.map((o) => [o.name, o]));
         for (const output of this.clientStats.outputs) {
           const url = `${this.assetPrefix}/client/${output.name}`;
           if (url === this.debugBarUrl) {
@@ -1080,7 +1085,9 @@ export class ComponentRegistry {
             if (!pageHasIslands) {
               continue;
             }
-            bundles.push({ url, label: 'Island runtime', sizeBytes: output.size, kind: 'bootstrap', inputs: output.inputs });
+            const wcInputs = this.collectWebComponentInputs(output, outputByName);
+            const wcSize = wcInputs.reduce((sum, i) => sum + i.size, 0);
+            bundles.push({ url, label: 'Island runtime', sizeBytes: output.size, kind: 'bootstrap', inputs: output.inputs, effectiveSize: wcSize, effectiveInputs: wcInputs });
           } else {
             const compName = urlToComponent.get(url);
             if (compName) {
@@ -1149,6 +1156,36 @@ export class ComponentRegistry {
       hasServerIslands,
       debugBarData,
     };
+  }
+
+  private collectWebComponentInputs(
+    entry: { inputs: { path: string; size: number }[]; imports: string[] },
+    outputByName: Map<string, { inputs: { path: string; size: number }[]; imports: string[] }>,
+  ): { path: string; size: number }[] {
+    const merged = new Map<string, number>();
+    const addInputs = (inputs: { path: string; size: number }[]) => {
+      for (const i of inputs) {
+        if (i.path.includes('web-components/')) {
+          merged.set(i.path, (merged.get(i.path) ?? 0) + i.size);
+        }
+      }
+    };
+    addInputs(entry.inputs);
+    const visited = new Set<string>();
+    const queue = [...entry.imports];
+    while (queue.length > 0) {
+      const name = queue.pop()!;
+      if (visited.has(name)) {
+        continue;
+      }
+      visited.add(name);
+      const dep = outputByName.get(name);
+      if (dep) {
+        addInputs(dep.inputs);
+        queue.push(...dep.imports);
+      }
+    }
+    return [...merged.entries()].map(([p, s]) => ({ path: p, size: s })).sort((a, b) => b.size - a.size);
   }
 
   /** Get the client entry URL for a hydratable component by name. */
@@ -1258,6 +1295,7 @@ export class ComponentRegistry {
           name: path.basename(out.path),
           size: cssText.length,
           inputs: [{ path: path.relative(process.cwd(), cssPath), size: cssText.length }],
+          imports: [],
         });
       }),
     );

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -1090,24 +1090,25 @@ export class ComponentRegistry {
             bundles.push({
               url,
               label: 'Island runtime',
-              sizeBytes: output.size,
+              sizeBytes: wcSize,
               kind: 'bootstrap',
-              inputs: ComponentRegistry.cleanInputs(output.inputs),
-              effectiveSize: wcSize,
-              effectiveInputs: ComponentRegistry.cleanInputs(wcInputs),
+              inputs: ComponentRegistry.cleanInputs(wcInputs),
             });
           } else {
             const compName = urlToComponent.get(url);
+            const cleaned = ComponentRegistry.cleanInputs(output.inputs);
+            const nonWc = cleaned.filter((i) => !i.path.includes('web-components/'));
+            const wcDeduct = cleaned.reduce((s, i) => s + (i.path.includes('web-components/') ? i.size : 0), 0);
             if (compName) {
               if (!renderedIslandNames.has(compName)) {
                 continue;
               }
-              bundles.push({ url, label: compName, sizeBytes: output.size, kind: 'island', inputs: ComponentRegistry.cleanInputs(output.inputs) });
+              bundles.push({ url, label: compName, sizeBytes: output.size - wcDeduct, kind: 'island', inputs: nonWc });
             } else {
               if (!pageHasIslands) {
                 continue;
               }
-              bundles.push({ url, label: output.name, sizeBytes: output.size, kind: 'chunk', inputs: ComponentRegistry.cleanInputs(output.inputs) });
+              bundles.push({ url, label: output.name, sizeBytes: output.size - wcDeduct, kind: 'chunk', inputs: nonWc });
             }
           }
         }

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -1063,6 +1063,41 @@ export class ComponentRegistry {
       for (const k of Object.keys(ctx.debugBarData.islandProps)) {
         delete ctx.debugBarData.islandProps[k];
       }
+
+      if (this.debugBarEnabled && this.clientStats) {
+        const urlToComponent = new Map<string, string>();
+        for (const [name, url] of this.componentEntryUrls) {
+          urlToComponent.set(url, name);
+        }
+        const pageHasIslands = hydratables.length > 0;
+        const bundles: NonNullable<typeof debugBarData.bundles> = [];
+        for (const output of this.clientStats.outputs) {
+          const url = `${this.assetPrefix}/client/${output.name}`;
+          if (url === this.debugBarUrl) {
+            continue;
+          }
+          if (url === this.islandBootstrapUrl) {
+            if (!pageHasIslands) {
+              continue;
+            }
+            bundles.push({ url, label: 'Island runtime', sizeBytes: output.size, kind: 'bootstrap' });
+          } else {
+            const compName = urlToComponent.get(url);
+            if (compName) {
+              if (!renderedIslandNames.has(compName)) {
+                continue;
+              }
+              bundles.push({ url, label: compName, sizeBytes: output.size, kind: 'island' });
+            } else {
+              if (!pageHasIslands) {
+                continue;
+              }
+              bundles.push({ url, label: output.name, sizeBytes: output.size, kind: 'chunk' });
+            }
+          }
+        }
+        debugBarData.bundles = bundles;
+      }
     }
 
     for (const componentPath of cssComponents) {

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -394,6 +394,16 @@ export class Mochi {
             const result = await registry.renderComponent(componentPath, resolvedProps);
             if (result.debugBarData) {
               result.debugBarData.ssrDurationMs = Math.round((performance.now() - ssrStart) * 100) / 100;
+              if (result.hasServerIslands) {
+                const serverIslandSize = new TextEncoder().encode(serverIslandClientJs).length;
+                (result.debugBarData.bundles ??= []).push({
+                  url: '(inline)',
+                  label: 'Server island runtime',
+                  sizeBytes: serverIslandSize,
+                  kind: 'bootstrap',
+                  inputs: [],
+                });
+              }
             }
             const html = Mochi.resolveHtmlShell(shellTemplate, result, registry, {
               serverIslandClientJs,

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -1,0 +1,154 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+  import DebugPanel from './DebugPanel.svelte';
+  import { debugBarState } from './state.svelte';
+  import { formatSize } from './utils';
+  import ArrowUpRight from '../icons/arrow-up-right.svelte';
+
+  let { open, onclose }: { open: boolean; onclose: () => void } = $props();
+
+  type BundleInfo = {
+    url: string;
+    label: string;
+    sizeBytes: number;
+    kind: 'bootstrap' | 'island' | 'chunk';
+  };
+
+  let bundles: BundleInfo[] = $state([]);
+
+  let totalSize = $derived(bundles.reduce((sum, b) => sum + b.sizeBytes, 0));
+  let bootstrapBundles = $derived(bundles.filter((b) => b.kind === 'bootstrap'));
+  let islandBundles = $derived(bundles.filter((b) => b.kind === 'island'));
+  let chunkBundles = $derived(bundles.filter((b) => b.kind === 'chunk'));
+
+  $effect(() => {
+    debugBarState.totalBundleSize = totalSize;
+  });
+
+  const statsHref = `${window.__mochi_asset_prefix}/client/stats`;
+
+  onMount(() => {
+    bundles = (window.__mochi_debug?.bundles as BundleInfo[] | undefined) ?? [];
+  });
+</script>
+
+<DebugPanel title="JS Bundles" color="#b8a3c4" {open} {onclose}>
+  <div class="bundle-body">
+    {#if bundles.length === 0}
+      <div class="bundle-empty">No framework bundles on this page.</div>
+    {:else}
+      <div class="bundle-summary">
+        <strong>{formatSize(totalSize)}</strong> total &middot; {bundles.length} bundle{bundles.length !== 1 ? 's' : ''}
+      </div>
+
+      {#if bootstrapBundles.length > 0}
+        <div class="bundle-group-label">Runtime</div>
+        {#each bootstrapBundles as bundle (bundle.url)}
+          <div class="bundle-row">
+            <span class="bundle-name">{bundle.label}</span>
+            <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
+          </div>
+        {/each}
+      {/if}
+
+      {#if islandBundles.length > 0}
+        <div class="bundle-group-label">Islands</div>
+        {#each islandBundles as bundle (bundle.url)}
+          <div class="bundle-row">
+            <span class="bundle-name">{bundle.label}</span>
+            <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
+          </div>
+        {/each}
+      {/if}
+
+      {#if chunkBundles.length > 0}
+        <div class="bundle-group-label">Shared Chunks</div>
+        {#each chunkBundles as bundle (bundle.url)}
+          <div class="bundle-row">
+            <span class="bundle-name">{bundle.label}</span>
+            <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
+          </div>
+        {/each}
+      {/if}
+    {/if}
+    <a href={statsHref} target="_blank" rel="noopener" class="stats-link">
+      Full bundle analysis <ArrowUpRight size={10} />
+    </a>
+  </div>
+</DebugPanel>
+
+<style>
+  .bundle-summary {
+    background: #272a22;
+    color: #bdc2b4;
+    padding: 8px 10px;
+    border-radius: 6px;
+    border: 1px solid #353930;
+    font-size: 11px;
+    line-height: 1.6;
+    margin-bottom: 6px;
+  }
+  .bundle-summary :global(strong) {
+    color: #e8e6dd;
+    font-weight: 700;
+  }
+  .bundle-group-label {
+    color: #8c9286;
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    padding: 8px 6px 4px;
+    font-family: inherit;
+  }
+  .bundle-row {
+    background: #272a22;
+    color: #e8e6dd;
+    padding: 6px 10px;
+    border-radius: 6px;
+    border: 1px solid #353930;
+    font-size: 11px;
+    line-height: 1.5;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 3px;
+  }
+  .bundle-row:last-child {
+    margin-bottom: 0;
+  }
+  .bundle-name {
+    font-weight: 500;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  }
+  .bundle-size {
+    font-size: 10px;
+    color: #b8a3c4;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    flex-shrink: 0;
+  }
+  .bundle-empty {
+    color: #72786c;
+    font-size: 11px;
+    padding: 16px 10px;
+    text-align: center;
+    font-style: italic;
+  }
+  .stats-link {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    color: #8c9286;
+    font-size: 10px;
+    text-decoration: none;
+    padding: 8px 6px 2px;
+    transition: color 120ms ease;
+  }
+  .stats-link:hover {
+    color: #b8a3c4;
+  }
+</style>

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -121,6 +121,9 @@
                 {/if}
               </button>
             {/each}
+            {#if (bootstrap.effectiveInputs ?? bootstrap.inputs).length === 0}
+              <div class="bundle-note">Islands may pull in additional bundles not calculated here.</div>
+            {/if}
           </div>
         </div>
       {/each}
@@ -326,6 +329,12 @@
       opacity: 0;
       transform: translateY(-8px);
     }
+  }
+  .bundle-note {
+    color: #72786c;
+    font-size: 10px;
+    font-style: italic;
+    padding: 6px 4px;
   }
   .bundle-empty {
     padding: 20px 10px 16px;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -90,7 +90,8 @@
   <div class="bundle-body">
     {#if bundles.length === 0}
       <div class="bundle-empty">
-        <div class="empty-blob">
+        <div class="empty-celebration">
+          <div class="empty-blob"></div>
           <span class="empty-emoji">{'\u{1F973}'}</span>
         </div>
         <div class="empty-text">No framework bundles on this page!</div>
@@ -334,32 +335,27 @@
     align-items: center;
     gap: 10px;
   }
-  .empty-blob {
+  .empty-celebration {
     position: relative;
     width: 76px;
     height: 76px;
+  }
+  .empty-blob {
+    position: absolute;
+    inset: 0;
     background: rgba(138, 183, 154, 0.22);
     border-radius: 42% 58% 64% 36% / 47% 34% 66% 53%;
-    display: flex;
-    align-items: center;
-    justify-content: center;
     animation: blob-morph 6s ease-in-out infinite, blob-rotate 12s linear infinite;
   }
   .empty-emoji {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 54px;
     line-height: 1;
-    margin-top: -6px;
-    margin-left: 2px;
     filter: saturate(0.85);
-    animation: counter-rotate 12s linear infinite;
-  }
-  @keyframes counter-rotate {
-    from {
-      transform: rotate(0deg);
-    }
-    to {
-      transform: rotate(-360deg);
-    }
   }
   .empty-text {
     color: #a8ada0;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -107,10 +107,13 @@
           </div>
           <div class="bundle-inputs">
             {#each bootstrap.effectiveInputs ?? bootstrap.inputs as input (input.path)}
-              <div class="input-row">
+              <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
                 <span class="input-path">{displayPath(input.path)}</span>
                 <span class="input-size">{formatSize(input.size)}</span>
-              </div>
+                {#if copiedPath === input.path}
+                  <span class="copied-toast">Copied</span>
+                {/if}
+              </button>
             {/each}
           </div>
         </div>
@@ -248,6 +251,7 @@
     display: block;
   }
   .input-row {
+    position: relative;
     display: flex;
     justify-content: space-between;
     align-items: baseline;
@@ -291,24 +295,35 @@
     flex-shrink: 0;
   }
   .copied-toast {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     font-size: 9px;
-    font-weight: 600;
-    color: #b8a3c4;
-    flex-shrink: 0;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    color: #1c1f17;
+    pointer-events: none;
     animation: copied-fade 1.2s ease forwards;
+  }
+  .copied-toast::before {
+    content: '';
+    position: absolute;
+    inset: 1px 0;
+    background: #b8a3c4;
+    border-radius: 3px;
+    z-index: -1;
   }
   @keyframes copied-fade {
     0% {
       opacity: 1;
-      transform: translateY(0);
     }
     70% {
       opacity: 1;
-      transform: translateY(-4px);
     }
     100% {
       opacity: 0;
-      transform: translateY(-8px);
     }
   }
   .bundle-empty {

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -11,7 +11,7 @@
 
   let bundles: BundleInfo[] = $state([]);
   let expanded: Record<string, boolean> = $state({});
-  const HIDE_SVELTE_KEY = 'mochi-debug-hide-svelte';
+  const HIDE_SVELTE_KEY = 'mochi:debug:hide-svelte';
   let filterSvelte = $state(localStorage.getItem(HIDE_SVELTE_KEY) === '1');
 
   function svelteSizeOf(b: BundleInfo): number {

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -91,7 +91,7 @@
     {#if bundles.length === 0}
       <div class="bundle-empty">
         <div class="empty-celebration">
-          <div class="empty-blob"></div>
+          <div class="empty-blob" class:animate={open}></div>
           <span class="empty-emoji">{'\u{1F973}'}</span>
         </div>
         <div class="empty-text">No framework bundles on this page!</div>
@@ -345,9 +345,10 @@
     inset: 0;
     background: rgba(138, 183, 154, 0.22);
     border-radius: 42% 58% 64% 36% / 47% 34% 66% 53%;
-    animation:
-      blob-morph 6s ease-in-out infinite,
-      blob-rotate 12s linear infinite;
+    animation: none;
+  }
+  .empty-blob.animate {
+    animation: blob-morph 6s ease-in-out infinite, blob-rotate 12s linear infinite;
   }
   .empty-emoji {
     position: absolute;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -11,8 +11,14 @@
 
   let bundles: BundleInfo[] = $state([]);
   let expanded: Record<string, boolean> = $state({});
+  let filterSvelte = $state(false);
+
+  function svelteSizeOf(b: BundleInfo): number {
+    return (b.effectiveInputs ?? b.inputs).filter((i) => i.path.startsWith('svelte/')).reduce((s, i) => s + i.size, 0);
+  }
 
   let totalSize = $derived(bundles.reduce((sum, b) => sum + b.sizeBytes, 0));
+  let displayTotal = $derived(filterSvelte ? bundles.reduce((sum, b) => sum + b.sizeBytes - svelteSizeOf(b), 0) : totalSize);
   let bootstrapBundles = $derived(bundles.filter((b) => b.kind === 'bootstrap'));
   let islandBundles = $derived(bundles.filter((b) => b.kind === 'island'));
   let chunkBundles = $derived(bundles.filter((b) => b.kind === 'chunk'));
@@ -55,8 +61,9 @@
 </script>
 
 {#snippet bundleRow(bundle: BundleInfo)}
-  {@const displaySize = bundle.effectiveSize ?? bundle.sizeBytes}
-  {@const displayInputs = bundle.effectiveInputs ?? bundle.inputs}
+  {@const allInputs = bundle.effectiveInputs ?? bundle.inputs}
+  {@const displayInputs = filterSvelte ? allInputs.filter((i) => !i.path.startsWith('svelte/')) : allInputs}
+  {@const displaySize = (bundle.effectiveSize ?? bundle.sizeBytes) - (filterSvelte ? svelteSizeOf(bundle) : 0)}
   <div class="bundle-entry" class:open={expanded[bundle.url]}>
     <div class="bundle-row">
       <button class="bundle-header" type="button" onclick={() => toggleExpand(bundle.url)}>
@@ -75,7 +82,7 @@
           {/if}
         </button>
       {/each}
-      {#if displayInputs.length === 0 && bundle.kind === 'bootstrap'}
+      {#if allInputs.length === 0 && bundle.kind === 'bootstrap'}
         <div class="bundle-note">Islands may pull in additional bundles not calculated here.</div>
       {/if}
     </div>
@@ -94,7 +101,11 @@
       </div>
     {:else}
       <div class="bundle-summary">
-        <strong>{formatSize(totalSize)}</strong> total &middot; {bundles.length} bundle{bundles.length !== 1 ? 's' : ''}
+        <strong>{formatSize(displayTotal)}</strong> total &middot; {bundles.length} bundle{bundles.length !== 1 ? 's' : ''}
+        <label class="filter-toggle">
+          <input type="checkbox" bind:checked={filterSvelte} />
+          Filter Svelte
+        </label>
       </div>
 
       {#if bootstrapBundles.length > 0}
@@ -138,6 +149,24 @@
   .bundle-summary :global(strong) {
     color: #e8e6dd;
     font-weight: 700;
+  }
+  .filter-toggle {
+    float: right;
+    font-size: 10px;
+    color: #8c9286;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    user-select: none;
+  }
+  .filter-toggle:hover {
+    color: #b8a3c4;
+  }
+  .filter-toggle input {
+    accent-color: #b8a3c4;
+    cursor: pointer;
+    margin: 0;
   }
   .bundle-group-label {
     color: #8c9286;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -264,7 +264,6 @@
   .input-row.selected .input-path {
     white-space: normal;
     word-break: break-all;
-    direction: ltr;
     color: #d4cce0;
   }
   .input-path {
@@ -273,7 +272,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    direction: rtl;
     text-align: left;
     transition: color 120ms ease;
   }

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -35,6 +35,8 @@
   }
 
   let selectedInput: string | null = $state(null);
+  let copiedPath: string | null = $state(null);
+  let copiedTimer: ReturnType<typeof setTimeout> | undefined;
 
   function displayPath(p: string): string {
     return p.replace(/^(?:\.\.\/)*node_modules\/(?:\.bun\/[^/]+\/node_modules\/)?/, '');
@@ -47,6 +49,11 @@
     }
     selectedInput = path;
     navigator.clipboard?.writeText(path);
+    clearTimeout(copiedTimer);
+    copiedPath = path;
+    copiedTimer = setTimeout(() => {
+      copiedPath = null;
+    }, 1200);
   }
 
   const statsHref = `${window.__mochi_asset_prefix}/client/stats`;
@@ -70,6 +77,9 @@
         <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
           <span class="input-path">{displayPath(input.path)}</span>
           <span class="input-size">{formatSize(input.size)}</span>
+          {#if copiedPath === input.path}
+            <span class="copied-toast">Copied</span>
+          {/if}
         </button>
       {/each}
     </div>
@@ -279,6 +289,27 @@
     color: #8c9286;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     flex-shrink: 0;
+  }
+  .copied-toast {
+    font-size: 9px;
+    font-weight: 600;
+    color: #b8a3c4;
+    flex-shrink: 0;
+    animation: copied-fade 1.2s ease forwards;
+  }
+  @keyframes copied-fade {
+    0% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+    70% {
+      opacity: 1;
+      transform: translateY(-4px);
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(-8px);
+    }
   }
   .bundle-empty {
     color: #72786c;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -345,7 +345,9 @@
     inset: 0;
     background: rgba(138, 183, 154, 0.22);
     border-radius: 42% 58% 64% 36% / 47% 34% 66% 53%;
-    animation: blob-morph 6s ease-in-out infinite, blob-rotate 12s linear infinite;
+    animation:
+      blob-morph 6s ease-in-out infinite,
+      blob-rotate 12s linear infinite;
   }
   .empty-emoji {
     position: absolute;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -348,7 +348,9 @@
     animation: none;
   }
   .empty-blob.animate {
-    animation: blob-morph 6s ease-in-out infinite, blob-rotate 12s linear infinite;
+    animation:
+      blob-morph 6s ease-in-out infinite,
+      blob-rotate 12s linear infinite;
   }
   .empty-emoji {
     position: absolute;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -36,6 +36,10 @@
 
   let selectedInput: string | null = $state(null);
 
+  function displayPath(p: string): string {
+    return p.replace(/^(?:\.\.\/)*node_modules\/(?:\.bun\/[^/]+\/node_modules\/)?/, '');
+  }
+
   function selectInput(path: string) {
     if (selectedInput === path) {
       selectedInput = null;
@@ -64,7 +68,7 @@
     <div class="bundle-inputs">
       {#each bundle.inputs as input (input.path)}
         <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
-          <span class="input-path">{input.path}</span>
+          <span class="input-path">{displayPath(input.path)}</span>
           <span class="input-size">{formatSize(input.size)}</span>
         </button>
       {/each}
@@ -94,7 +98,7 @@
           <div class="bundle-inputs">
             {#each bootstrap.effectiveInputs ?? bootstrap.inputs as input (input.path)}
               <div class="input-row">
-                <span class="input-path">{input.path}</span>
+                <span class="input-path">{displayPath(input.path)}</span>
                 <span class="input-size">{formatSize(input.size)}</span>
               </div>
             {/each}

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -89,7 +89,12 @@
 <DebugPanel title="JS Bundles" color="#b8a3c4" {open} {onclose}>
   <div class="bundle-body">
     {#if bundles.length === 0}
-      <div class="bundle-empty">No framework bundles on this page.</div>
+      <div class="bundle-empty">
+        <div class="empty-blob">
+          <span class="empty-emoji">{'\u{1F973}'}</span>
+        </div>
+        <div class="empty-text">No framework bundles on this page!</div>
+      </div>
     {:else}
       <div class="bundle-summary">
         <strong>{formatSize(totalSize)}</strong> total &middot; {bundles.length} bundle{bundles.length !== 1 ? 's' : ''}
@@ -322,11 +327,65 @@
     }
   }
   .bundle-empty {
-    color: #72786c;
-    font-size: 11px;
-    padding: 16px 10px;
+    padding: 20px 10px 16px;
     text-align: center;
-    font-style: italic;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+  }
+  .empty-blob {
+    position: relative;
+    width: 76px;
+    height: 76px;
+    background: rgba(138, 183, 154, 0.22);
+    border-radius: 42% 58% 64% 36% / 47% 34% 66% 53%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    animation: blob-morph 6s ease-in-out infinite, blob-rotate 12s linear infinite;
+  }
+  .empty-emoji {
+    font-size: 54px;
+    line-height: 1;
+    margin-top: -6px;
+    margin-left: 2px;
+    filter: saturate(0.85);
+    animation: counter-rotate 12s linear infinite;
+  }
+  @keyframes counter-rotate {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(-360deg);
+    }
+  }
+  .empty-text {
+    color: #a8ada0;
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+  }
+  @keyframes blob-morph {
+    0%,
+    100% {
+      border-radius: 42% 58% 64% 36% / 47% 34% 66% 53%;
+    }
+    33% {
+      border-radius: 58% 42% 36% 64% / 34% 66% 34% 66%;
+    }
+    66% {
+      border-radius: 36% 64% 52% 48% / 66% 42% 58% 42%;
+    }
+  }
+  @keyframes blob-rotate {
+    from {
+      transform: rotate(0deg);
+    }
+    to {
+      transform: rotate(360deg);
+    }
   }
   .stats-link {
     display: flex;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -14,7 +14,7 @@
   let filterSvelte = $state(false);
 
   function svelteSizeOf(b: BundleInfo): number {
-    return (b.effectiveInputs ?? b.inputs).filter((i) => i.path.startsWith('svelte/')).reduce((s, i) => s + i.size, 0);
+    return b.inputs.filter((i) => i.path.startsWith('svelte/')).reduce((s, i) => s + i.size, 0);
   }
 
   let totalSize = $derived(bundles.reduce((sum, b) => sum + b.sizeBytes, 0));
@@ -61,9 +61,8 @@
 </script>
 
 {#snippet bundleRow(bundle: BundleInfo)}
-  {@const allInputs = bundle.effectiveInputs ?? bundle.inputs}
-  {@const displayInputs = filterSvelte ? allInputs.filter((i) => !i.path.startsWith('svelte/')) : allInputs}
-  {@const displaySize = (bundle.effectiveSize ?? bundle.sizeBytes) - (filterSvelte ? svelteSizeOf(bundle) : 0)}
+  {@const displayInputs = filterSvelte ? bundle.inputs.filter((i) => !i.path.startsWith('svelte/')) : bundle.inputs}
+  {@const displaySize = bundle.sizeBytes - (filterSvelte ? svelteSizeOf(bundle) : 0)}
   <div class="bundle-entry" class:open={expanded[bundle.url]}>
     <div class="bundle-row">
       <button class="bundle-header" type="button" onclick={() => toggleExpand(bundle.url)}>
@@ -82,7 +81,7 @@
           {/if}
         </button>
       {/each}
-      {#if allInputs.length === 0 && bundle.kind === 'bootstrap'}
+      {#if bundle.inputs.length === 0 && bundle.kind === 'bootstrap'}
         <div class="bundle-note">Islands may pull in additional bundles not calculated here.</div>
       {/if}
     </div>

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -296,34 +296,29 @@
   }
   .copied-toast {
     position: absolute;
-    inset: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    top: 1px;
+    right: 4px;
     font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
+    font-weight: 600;
     color: #1c1f17;
+    background: #b8a3c4;
+    padding: 1px 6px;
+    border-radius: 3px;
     pointer-events: none;
     animation: copied-fade 1.2s ease forwards;
-  }
-  .copied-toast::before {
-    content: '';
-    position: absolute;
-    inset: 1px 0;
-    background: #b8a3c4;
-    border-radius: 3px;
-    z-index: -1;
   }
   @keyframes copied-fade {
     0% {
       opacity: 1;
+      transform: translateY(0);
     }
     70% {
       opacity: 1;
+      transform: translateY(-4px);
     }
     100% {
       opacity: 0;
+      transform: translateY(-8px);
     }
   }
   .bundle-empty {

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -11,7 +11,8 @@
 
   let bundles: BundleInfo[] = $state([]);
   let expanded: Record<string, boolean> = $state({});
-  let filterSvelte = $state(false);
+  const HIDE_SVELTE_KEY = 'mochi-debug-hide-svelte';
+  let filterSvelte = $state(localStorage.getItem(HIDE_SVELTE_KEY) === '1');
 
   function svelteSizeOf(b: BundleInfo): number {
     return b.inputs.filter((i) => i.path.startsWith('svelte/')).reduce((s, i) => s + i.size, 0);
@@ -25,6 +26,12 @@
 
   $effect(() => {
     debugBarState.totalBundleSize = totalSize;
+    debugBarState.displayBundleSize = displayTotal;
+    debugBarState.bundleFiltered = filterSvelte;
+  });
+
+  $effect(() => {
+    localStorage.setItem(HIDE_SVELTE_KEY, filterSvelte ? '1' : '0');
   });
 
   function toggleExpand(url: string) {
@@ -63,9 +70,10 @@
 {#snippet bundleRow(bundle: BundleInfo)}
   {@const displayInputs = filterSvelte ? bundle.inputs.filter((i) => !i.path.startsWith('svelte/')) : bundle.inputs}
   {@const displaySize = bundle.sizeBytes - (filterSvelte ? svelteSizeOf(bundle) : 0)}
-  <div class="bundle-entry" class:open={expanded[bundle.url]}>
+  {@const empty = displayInputs.length === 0 && bundle.kind !== 'bootstrap'}
+  <div class="bundle-entry" class:open={!empty && expanded[bundle.url]} class:dimmed={empty}>
     <div class="bundle-row">
-      <button class="bundle-header" type="button" onclick={() => toggleExpand(bundle.url)}>
+      <button class="bundle-header" type="button" disabled={empty} onclick={() => toggleExpand(bundle.url)}>
         <span class="chevron"><ChevronRight size={12} /></span>
         <span class="bundle-name">{bundle.label}</span>
       </button>
@@ -103,7 +111,7 @@
         <strong>{formatSize(displayTotal)}</strong> total &middot; {bundles.length} bundle{bundles.length !== 1 ? 's' : ''}
         <label class="filter-toggle">
           <input type="checkbox" bind:checked={filterSvelte} />
-          Filter Svelte
+          Hide Svelte
         </label>
       </div>
 
@@ -178,6 +186,12 @@
   }
   .bundle-entry {
     margin-bottom: 3px;
+  }
+  .bundle-entry.dimmed {
+    opacity: 0.4;
+  }
+  .bundle-entry.dimmed .bundle-header {
+    cursor: default;
   }
   .bundle-entry:last-child {
     margin-bottom: 0;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
+  import { onMount, onDestroy } from 'svelte';
+  import type { BundleInfo } from '../requestContext';
   import ChevronRight from '../icons/chevron-right.svelte';
   import ArrowUpRight from '../icons/arrow-up-right.svelte';
   import DebugPanel from './DebugPanel.svelte';
@@ -7,16 +8,6 @@
   import { formatSize } from './utils';
 
   let { open, onclose }: { open: boolean; onclose: () => void } = $props();
-
-  type BundleInfo = {
-    url: string;
-    label: string;
-    sizeBytes: number;
-    kind: 'bootstrap' | 'island' | 'chunk';
-    inputs: Array<{ path: string; size: number }>;
-    effectiveSize?: number;
-    effectiveInputs?: Array<{ path: string; size: number }>;
-  };
 
   let bundles: BundleInfo[] = $state([]);
   let expanded: Record<string, boolean> = $state({});
@@ -61,19 +52,25 @@
   onMount(() => {
     bundles = (window.__mochi_debug?.bundles as BundleInfo[] | undefined) ?? [];
   });
+
+  onDestroy(() => {
+    clearTimeout(copiedTimer);
+  });
 </script>
 
 {#snippet bundleRow(bundle: BundleInfo)}
+  {@const displaySize = bundle.effectiveSize ?? bundle.sizeBytes}
+  {@const displayInputs = bundle.effectiveInputs ?? bundle.inputs}
   <div class="bundle-entry" class:open={expanded[bundle.url]}>
     <div class="bundle-row">
       <button class="bundle-header" type="button" onclick={() => toggleExpand(bundle.url)}>
         <span class="chevron"><ChevronRight size={12} /></span>
         <span class="bundle-name">{bundle.label}</span>
       </button>
-      <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
+      <span class="bundle-size">{formatSize(displaySize)}</span>
     </div>
     <div class="bundle-inputs">
-      {#each bundle.inputs as input (input.path)}
+      {#each displayInputs as input (input.path)}
         <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
           <span class="input-path">{displayPath(input.path)}</span>
           <span class="input-size">{formatSize(input.size)}</span>
@@ -82,6 +79,9 @@
           {/if}
         </button>
       {/each}
+      {#if displayInputs.length === 0 && bundle.kind === 'bootstrap'}
+        <div class="bundle-note">Islands may pull in additional bundles not calculated here.</div>
+      {/if}
     </div>
   </div>
 {/snippet}
@@ -101,32 +101,12 @@
         <strong>{formatSize(totalSize)}</strong> total &middot; {bundles.length} bundle{bundles.length !== 1 ? 's' : ''}
       </div>
 
-      {#each bootstrapBundles.slice(0, 1) as bootstrap (bootstrap.url)}
+      {#if bootstrapBundles.length > 0}
         <div class="bundle-group-label">Runtime</div>
-        <div class="bundle-entry" class:open={expanded[bootstrap.url]}>
-          <div class="bundle-row">
-            <button class="bundle-header" type="button" onclick={() => toggleExpand(bootstrap.url)}>
-              <span class="chevron"><ChevronRight size={12} /></span>
-              <span class="bundle-name">{bootstrap.label}</span>
-            </button>
-            <span class="bundle-size">{formatSize(bootstrap.effectiveSize ?? bootstrap.sizeBytes)}</span>
-          </div>
-          <div class="bundle-inputs">
-            {#each bootstrap.effectiveInputs ?? bootstrap.inputs as input (input.path)}
-              <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
-                <span class="input-path">{displayPath(input.path)}</span>
-                <span class="input-size">{formatSize(input.size)}</span>
-                {#if copiedPath === input.path}
-                  <span class="copied-toast">Copied</span>
-                {/if}
-              </button>
-            {/each}
-            {#if (bootstrap.effectiveInputs ?? bootstrap.inputs).length === 0}
-              <div class="bundle-note">Islands may pull in additional bundles not calculated here.</div>
-            {/if}
-          </div>
-        </div>
-      {/each}
+        {#each bootstrapBundles as bundle (bundle.url)}
+          {@render bundleRow(bundle)}
+        {/each}
+      {/if}
 
       {#if islandBundles.length > 0}
         <div class="bundle-group-label">Islands</div>

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -29,10 +29,6 @@
   let copiedPath: string | null = $state(null);
   let copiedTimer: ReturnType<typeof setTimeout> | undefined;
 
-  function displayPath(p: string): string {
-    return p.replace(/^(?:\.\.\/)*node_modules\/(?:\.bun\/[^/]+\/node_modules\/)?/, '');
-  }
-
   function selectInput(path: string) {
     if (selectedInput === path) {
       selectedInput = null;
@@ -72,7 +68,7 @@
     <div class="bundle-inputs">
       {#each displayInputs as input (input.path)}
         <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
-          <span class="input-path">{displayPath(input.path)}</span>
+          <span class="input-path">{input.path}</span>
           <span class="input-size">{formatSize(input.size)}</span>
           {#if copiedPath === input.path}
             <span class="copied-toast">Copied</span>

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { onMount } from 'svelte';
+  import ChevronRight from '../icons/chevron-right.svelte';
+  import ArrowUpRight from '../icons/arrow-up-right.svelte';
   import DebugPanel from './DebugPanel.svelte';
   import { debugBarState } from './state.svelte';
   import { formatSize } from './utils';
-  import ArrowUpRight from '../icons/arrow-up-right.svelte';
 
   let { open, onclose }: { open: boolean; onclose: () => void } = $props();
 
@@ -12,9 +13,11 @@
     label: string;
     sizeBytes: number;
     kind: 'bootstrap' | 'island' | 'chunk';
+    inputs: Array<{ path: string; size: number }>;
   };
 
   let bundles: BundleInfo[] = $state([]);
+  let expanded: Record<string, boolean> = $state({});
 
   let totalSize = $derived(bundles.reduce((sum, b) => sum + b.sizeBytes, 0));
   let bootstrapBundles = $derived(bundles.filter((b) => b.kind === 'bootstrap'));
@@ -25,12 +28,38 @@
     debugBarState.totalBundleSize = totalSize;
   });
 
+  function toggleExpand(url: string) {
+    expanded[url] = !expanded[url];
+  }
+
   const statsHref = `${window.__mochi_asset_prefix}/client/stats`;
 
   onMount(() => {
     bundles = (window.__mochi_debug?.bundles as BundleInfo[] | undefined) ?? [];
   });
 </script>
+
+{#snippet bundleRow(bundle: BundleInfo)}
+  <div class="bundle-entry" class:open={expanded[bundle.url]}>
+    <div class="bundle-row">
+      <button class="bundle-header" type="button" onclick={() => toggleExpand(bundle.url)}>
+        <span class="chevron"><ChevronRight size={12} /></span>
+        <span class="bundle-name">{bundle.label}</span>
+      </button>
+      <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
+    </div>
+    {#if bundle.inputs.length > 0}
+      <div class="bundle-inputs">
+        {#each bundle.inputs as input (input.path)}
+          <div class="input-row">
+            <span class="input-path">{input.path}</span>
+            <span class="input-size">{formatSize(input.size)}</span>
+          </div>
+        {/each}
+      </div>
+    {/if}
+  </div>
+{/snippet}
 
 <DebugPanel title="JS Bundles" color="#b8a3c4" {open} {onclose}>
   <div class="bundle-body">
@@ -44,30 +73,21 @@
       {#if bootstrapBundles.length > 0}
         <div class="bundle-group-label">Runtime</div>
         {#each bootstrapBundles as bundle (bundle.url)}
-          <div class="bundle-row">
-            <span class="bundle-name">{bundle.label}</span>
-            <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
-          </div>
+          {@render bundleRow(bundle)}
         {/each}
       {/if}
 
       {#if islandBundles.length > 0}
         <div class="bundle-group-label">Islands</div>
         {#each islandBundles as bundle (bundle.url)}
-          <div class="bundle-row">
-            <span class="bundle-name">{bundle.label}</span>
-            <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
-          </div>
+          {@render bundleRow(bundle)}
         {/each}
       {/if}
 
       {#if chunkBundles.length > 0}
         <div class="bundle-group-label">Shared Chunks</div>
         {#each chunkBundles as bundle (bundle.url)}
-          <div class="bundle-row">
-            <span class="bundle-name">{bundle.label}</span>
-            <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
-          </div>
+          {@render bundleRow(bundle)}
         {/each}
       {/if}
     {/if}
@@ -101,6 +121,12 @@
     padding: 8px 6px 4px;
     font-family: inherit;
   }
+  .bundle-entry {
+    margin-bottom: 3px;
+  }
+  .bundle-entry:last-child {
+    margin-bottom: 0;
+  }
   .bundle-row {
     background: #272a22;
     color: #e8e6dd;
@@ -113,10 +139,48 @@
     justify-content: space-between;
     align-items: center;
     gap: 8px;
-    margin-bottom: 3px;
+    transition:
+      background 120ms ease,
+      border-color 120ms ease;
   }
-  .bundle-row:last-child {
-    margin-bottom: 0;
+  .bundle-row:hover {
+    background: #2d3128;
+    border-color: #434836;
+  }
+  .bundle-entry.open .bundle-row {
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+    background: #2d3128;
+    border-bottom-color: transparent;
+  }
+  .bundle-header {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    background: none;
+    border: none;
+    color: inherit;
+    font: inherit;
+    padding: 0;
+    cursor: pointer;
+    text-align: left;
+    flex: 1;
+    min-width: 0;
+  }
+  .chevron {
+    color: #8e9488;
+    display: inline-flex;
+    align-items: center;
+    transition:
+      transform 120ms ease,
+      color 120ms ease;
+  }
+  .bundle-header:hover .chevron {
+    color: #b8a3c4;
+  }
+  .bundle-entry.open .chevron {
+    transform: rotate(90deg);
+    color: #b8a3c4;
   }
   .bundle-name {
     font-weight: 500;
@@ -128,6 +192,46 @@
   .bundle-size {
     font-size: 10px;
     color: #b8a3c4;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    flex-shrink: 0;
+  }
+  .bundle-inputs {
+    display: none;
+    background: #181b13;
+    border: 1px solid #353930;
+    border-top: 1px solid #2e3228;
+    border-radius: 0 0 6px 6px;
+    padding: 6px 8px;
+    max-height: 200px;
+    overflow-y: auto;
+  }
+  .bundle-entry.open .bundle-inputs {
+    display: block;
+  }
+  .input-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 8px;
+    padding: 2px 4px;
+    font-size: 10px;
+    line-height: 1.5;
+  }
+  .input-row:hover {
+    background: rgba(184, 163, 196, 0.06);
+    border-radius: 3px;
+  }
+  .input-path {
+    color: #a8ada0;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    direction: rtl;
+    text-align: left;
+  }
+  .input-size {
+    color: #8c9286;
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
     flex-shrink: 0;
   }

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -34,6 +34,17 @@
     expanded[url] = !expanded[url];
   }
 
+  let selectedInput: string | null = $state(null);
+
+  function selectInput(path: string) {
+    if (selectedInput === path) {
+      selectedInput = null;
+      return;
+    }
+    selectedInput = path;
+    navigator.clipboard?.writeText(path);
+  }
+
   const statsHref = `${window.__mochi_asset_prefix}/client/stats`;
 
   onMount(() => {
@@ -52,10 +63,10 @@
     </div>
     <div class="bundle-inputs">
       {#each bundle.inputs as input (input.path)}
-        <div class="input-row">
+        <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
           <span class="input-path">{input.path}</span>
           <span class="input-size">{formatSize(input.size)}</span>
-        </div>
+        </button>
       {/each}
     </div>
   </div>
@@ -230,10 +241,27 @@
     padding: 2px 4px;
     font-size: 10px;
     line-height: 1.5;
+    width: 100%;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+    color: inherit;
+    border-radius: 3px;
+    transition: background 120ms ease;
   }
   .input-row:hover {
     background: rgba(184, 163, 196, 0.06);
-    border-radius: 3px;
+  }
+  .input-row.selected {
+    background: rgba(184, 163, 196, 0.14);
+  }
+  .input-row.selected .input-path {
+    white-space: normal;
+    word-break: break-all;
+    direction: ltr;
+    color: #d4cce0;
   }
   .input-path {
     color: #a8ada0;
@@ -243,6 +271,7 @@
     white-space: nowrap;
     direction: rtl;
     text-align: left;
+    transition: color 120ms ease;
   }
   .input-size {
     color: #8c9286;

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -14,6 +14,8 @@
     sizeBytes: number;
     kind: 'bootstrap' | 'island' | 'chunk';
     inputs: Array<{ path: string; size: number }>;
+    effectiveSize?: number;
+    effectiveInputs?: Array<{ path: string; size: number }>;
   };
 
   let bundles: BundleInfo[] = $state([]);
@@ -48,16 +50,14 @@
       </button>
       <span class="bundle-size">{formatSize(bundle.sizeBytes)}</span>
     </div>
-    {#if bundle.inputs.length > 0}
-      <div class="bundle-inputs">
-        {#each bundle.inputs as input (input.path)}
-          <div class="input-row">
-            <span class="input-path">{input.path}</span>
-            <span class="input-size">{formatSize(input.size)}</span>
-          </div>
-        {/each}
-      </div>
-    {/if}
+    <div class="bundle-inputs">
+      {#each bundle.inputs as input (input.path)}
+        <div class="input-row">
+          <span class="input-path">{input.path}</span>
+          <span class="input-size">{formatSize(input.size)}</span>
+        </div>
+      {/each}
+    </div>
   </div>
 {/snippet}
 
@@ -70,12 +70,26 @@
         <strong>{formatSize(totalSize)}</strong> total &middot; {bundles.length} bundle{bundles.length !== 1 ? 's' : ''}
       </div>
 
-      {#if bootstrapBundles.length > 0}
+      {#each bootstrapBundles.slice(0, 1) as bootstrap (bootstrap.url)}
         <div class="bundle-group-label">Runtime</div>
-        {#each bootstrapBundles as bundle (bundle.url)}
-          {@render bundleRow(bundle)}
-        {/each}
-      {/if}
+        <div class="bundle-entry" class:open={expanded[bootstrap.url]}>
+          <div class="bundle-row">
+            <button class="bundle-header" type="button" onclick={() => toggleExpand(bootstrap.url)}>
+              <span class="chevron"><ChevronRight size={12} /></span>
+              <span class="bundle-name">{bootstrap.label}</span>
+            </button>
+            <span class="bundle-size">{formatSize(bootstrap.effectiveSize ?? bootstrap.sizeBytes)}</span>
+          </div>
+          <div class="bundle-inputs">
+            {#each bootstrap.effectiveInputs ?? bootstrap.inputs as input (input.path)}
+              <div class="input-row">
+                <span class="input-path">{input.path}</span>
+                <span class="input-size">{formatSize(input.size)}</span>
+              </div>
+            {/each}
+          </div>
+        </div>
+      {/each}
 
       {#if islandBundles.length > 0}
         <div class="bundle-group-label">Islands</div>

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -357,19 +357,19 @@
     0%,
     100% {
       opacity: 0;
-      transform: scale(0.5);
+      transform: scale(0.5) rotate(0deg);
     }
     20% {
       opacity: 1;
-      transform: scale(1.2);
+      transform: scale(1.2) rotate(72deg);
     }
     50% {
       opacity: 0.6;
-      transform: scale(0.8);
+      transform: scale(0.8) rotate(144deg);
     }
     70% {
       opacity: 0;
-      transform: scale(0.4);
+      transform: scale(0.4) rotate(216deg);
     }
   }
   .badge {

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
   import { onMount, onDestroy } from 'svelte';
-  import ArrowUpRight from '../icons/arrow-up-right.svelte';
   import StatusDot from './StatusDot.svelte';
   import RequestPanel from './RequestPanel.svelte';
   import IslandsPanel from './IslandsPanel.svelte';
   import WarningsPanel from './WarningsPanel.svelte';
+  import BundlesPanel from './BundlesPanel.svelte';
   import { cleanupHighlight } from './highlight';
   import { debugBarState } from './state.svelte';
-  import { getPropsWarnLevel } from './utils';
+  import { getPropsWarnLevel, formatSize } from './utils';
 
   const STORAGE_KEY = 'mochi-debug-bar-collapsed';
 
-  type Panel = 'warnings' | 'islands' | 'request' | null;
+  type Panel = 'warnings' | 'islands' | 'request' | 'bundles' | null;
   let activePanel: Panel = $state(null);
 
   let hasDebugInfo = $state(false);
@@ -43,8 +43,7 @@
 
   let warnLevel = $derived(getPropsWarnLevel(debugBarState.totalPropsSize));
 
-  // Mochi.ts seeds window.__mochi_asset_prefix whenever the debug bar is enabled.
-  const statsHref = `${window.__mochi_asset_prefix}/client/stats`;
+  let bundleSizeLabel = $derived(debugBarState.totalBundleSize > 0 ? formatSize(debugBarState.totalBundleSize) : 'JS');
 
   onMount(() => {
     hasDebugInfo = !!window.__mochi_debug;
@@ -68,6 +67,7 @@
 <div class="mochi-debug-bar-root" bind:this={rootEl}>
   <WarningsPanel open={activePanel === 'warnings'} onclose={() => (activePanel = null)} />
   <IslandsPanel open={activePanel === 'islands'} onclose={() => (activePanel = null)} />
+  <BundlesPanel open={activePanel === 'bundles'} onclose={() => (activePanel = null)} />
   <RequestPanel open={activePanel === 'request'} onclose={() => (activePanel = null)} />
 
   <div class="bar" class:is-collapsed={collapsed}>
@@ -99,9 +99,9 @@
           Warnings <span class="badge">{debugBarState.warningCount}</span>
         </button>
       {/if}
-      <a href={statsHref} target="_blank" rel="noopener" class="btn stats-btn" tabindex={collapsed ? -1 : 0}>
-        Bundles <ArrowUpRight size={12} />
-      </a>
+      <button class="btn bundles-btn" onclick={() => toggle('bundles')} tabindex={collapsed ? -1 : 0}>
+        JS <span class="bundle-badge">{bundleSizeLabel}</span>
+      </button>
     </div>
   </div>
 </div>
@@ -301,15 +301,30 @@
     color: #d4e0e8;
     border-color: #6a7a86;
   }
-  .stats-btn {
-    background: transparent;
-    color: #a8ada0;
-    border-color: #4a5040;
+  .bundles-btn {
+    background: #2e2a38;
+    color: #c4b8d4;
+    border-color: #4a4060;
   }
-  .stats-btn:hover {
-    color: #ffffff;
-    border-color: #8ab79a;
-    background: #2a2e25;
+  .bundles-btn:hover {
+    background: #383248;
+    color: #e0d8ee;
+    border-color: #b8a3c4;
+  }
+  .bundle-badge {
+    border-radius: 999px;
+    min-width: 1.4em;
+    height: 1.4em;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.82em;
+    font-weight: 600;
+    padding: 0 0.45em;
+    background: rgba(184, 163, 196, 0.28);
+    color: #e0d8ee;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    letter-spacing: 0;
   }
   .badge {
     border-radius: 999px;

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -43,8 +43,9 @@
 
   let warnLevel = $derived(getPropsWarnLevel(debugBarState.totalPropsSize));
 
-  let bundleSizeLabel = $derived(debugBarState.totalBundleSize > 0 ? formatSize(debugBarState.totalBundleSize) : '0');
+  let bundleSizeLabel = $derived(debugBarState.displayBundleSize > 0 ? formatSize(debugBarState.displayBundleSize) : '0');
   let noJs = $derived(debugBarState.totalBundleSize === 0);
+  let bundleFiltered = $derived(debugBarState.bundleFiltered);
 
   onMount(() => {
     hasDebugInfo = !!window.__mochi_debug;
@@ -102,6 +103,7 @@
       {/if}
       <button class="btn bundles-btn" class:no-js={noJs} onclick={() => toggle('bundles')} tabindex={collapsed ? -1 : 0}>
         JS <span class="bundle-badge" class:sparkle={noJs}>{bundleSizeLabel}</span>
+        {#if bundleFiltered}<span class="filter-dot"></span>{/if}
       </button>
     </div>
   </div>
@@ -303,6 +305,7 @@
     border-color: #6a7a86;
   }
   .bundles-btn {
+    position: relative;
     background: #2e2a38;
     color: #c4b8d4;
     border-color: #4a4060;
@@ -311,6 +314,16 @@
     background: #383248;
     color: #e0d8ee;
     border-color: #b8a3c4;
+  }
+  .filter-dot {
+    position: absolute;
+    top: -2px;
+    right: -2px;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #e85454;
+    pointer-events: none;
   }
   .bundle-badge {
     border-radius: 999px;

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -9,7 +9,7 @@
   import { debugBarState } from './state.svelte';
   import { getPropsWarnLevel, formatSize } from './utils';
 
-  const STORAGE_KEY = 'mochi-debug-bar-collapsed';
+  const STORAGE_KEY = 'mochi:debug:collapsed';
 
   type Panel = 'warnings' | 'islands' | 'request' | 'bundles' | null;
   let activePanel: Panel = $state(null);

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -43,7 +43,8 @@
 
   let warnLevel = $derived(getPropsWarnLevel(debugBarState.totalPropsSize));
 
-  let bundleSizeLabel = $derived(debugBarState.totalBundleSize > 0 ? formatSize(debugBarState.totalBundleSize) : 'JS');
+  let bundleSizeLabel = $derived(debugBarState.totalBundleSize > 0 ? formatSize(debugBarState.totalBundleSize) : '0');
+  let noJs = $derived(debugBarState.totalBundleSize === 0);
 
   onMount(() => {
     hasDebugInfo = !!window.__mochi_debug;
@@ -99,8 +100,8 @@
           Warnings <span class="badge">{debugBarState.warningCount}</span>
         </button>
       {/if}
-      <button class="btn bundles-btn" onclick={() => toggle('bundles')} tabindex={collapsed ? -1 : 0}>
-        JS <span class="bundle-badge">{bundleSizeLabel}</span>
+      <button class="btn bundles-btn" class:no-js={noJs} onclick={() => toggle('bundles')} tabindex={collapsed ? -1 : 0}>
+        JS <span class="bundle-badge" class:sparkle={noJs}>{bundleSizeLabel}</span>
       </button>
     </div>
   </div>
@@ -325,6 +326,51 @@
     color: #e0d8ee;
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     letter-spacing: 0;
+  }
+  .bundles-btn.no-js {
+    background: #1f2a20;
+    color: #a8c9a8;
+    border-color: #3a5040;
+  }
+  .bundles-btn.no-js:hover {
+    background: #263228;
+    color: #c8e8c8;
+    border-color: #8ab79a;
+  }
+  .bundle-badge.sparkle {
+    position: relative;
+    overflow: visible;
+    background: rgba(138, 183, 154, 0.28);
+    color: #c8e8c8;
+  }
+  .bundle-badge.sparkle::after {
+    content: '✦';
+    position: absolute;
+    top: -3px;
+    right: -2px;
+    font-size: 0.9em;
+    color: #ffffff;
+    animation: sparkle-pulse 2s ease-in-out infinite;
+    pointer-events: none;
+  }
+  @keyframes sparkle-pulse {
+    0%,
+    100% {
+      opacity: 0;
+      transform: scale(0.5);
+    }
+    20% {
+      opacity: 1;
+      transform: scale(1.2);
+    }
+    50% {
+      opacity: 0.6;
+      transform: scale(0.8);
+    }
+    70% {
+      opacity: 0;
+      transform: scale(0.4);
+    }
   }
   .badge {
     border-radius: 999px;

--- a/packages/mochi/src/debug-bar/state.svelte.ts
+++ b/packages/mochi/src/debug-bar/state.svelte.ts
@@ -2,4 +2,5 @@ export const debugBarState = $state({
   warningCount: 0,
   islandCount: 0,
   totalPropsSize: 0,
+  totalBundleSize: 0,
 });

--- a/packages/mochi/src/debug-bar/state.svelte.ts
+++ b/packages/mochi/src/debug-bar/state.svelte.ts
@@ -3,4 +3,6 @@ export const debugBarState = $state({
   islandCount: 0,
   totalPropsSize: 0,
   totalBundleSize: 0,
+  displayBundleSize: 0,
+  bundleFiltered: false,
 });

--- a/packages/mochi/src/requestContext.ts
+++ b/packages/mochi/src/requestContext.ts
@@ -95,6 +95,9 @@ export interface DebugBarData {
     sizeBytes: number;
     kind: 'bootstrap' | 'island' | 'chunk';
     inputs: Array<{ path: string; size: number }>;
+    /** Pre-computed web-component inputs and size (bootstrap only). */
+    effectiveSize?: number;
+    effectiveInputs?: Array<{ path: string; size: number }>;
   }>;
 }
 

--- a/packages/mochi/src/requestContext.ts
+++ b/packages/mochi/src/requestContext.ts
@@ -62,8 +62,6 @@ export interface BundleInfo {
   sizeBytes: number;
   kind: 'bootstrap' | 'island' | 'chunk';
   inputs: Array<{ path: string; size: number }>;
-  effectiveSize?: number;
-  effectiveInputs?: Array<{ path: string; size: number }>;
 }
 
 /**

--- a/packages/mochi/src/requestContext.ts
+++ b/packages/mochi/src/requestContext.ts
@@ -94,6 +94,7 @@ export interface DebugBarData {
     label: string;
     sizeBytes: number;
     kind: 'bootstrap' | 'island' | 'chunk';
+    inputs: Array<{ path: string; size: number }>;
   }>;
 }
 

--- a/packages/mochi/src/requestContext.ts
+++ b/packages/mochi/src/requestContext.ts
@@ -88,6 +88,13 @@ export interface DebugBarData {
   liveReloadEnabled?: boolean;
   /** Time in milliseconds the SSR render took (compile check + Svelte render + HTML processing). */
   ssrDurationMs?: number;
+  /** Framework JS bundles injected for this page (bootstrap, island entries, shared chunks). */
+  bundles?: Array<{
+    url: string;
+    label: string;
+    sizeBytes: number;
+    kind: 'bootstrap' | 'island' | 'chunk';
+  }>;
 }
 
 /**

--- a/packages/mochi/src/requestContext.ts
+++ b/packages/mochi/src/requestContext.ts
@@ -56,6 +56,16 @@ export interface MochiRequestContext {
   getClientAddress: () => string | null;
 }
 
+export interface BundleInfo {
+  url: string;
+  label: string;
+  sizeBytes: number;
+  kind: 'bootstrap' | 'island' | 'chunk';
+  inputs: Array<{ path: string; size: number }>;
+  effectiveSize?: number;
+  effectiveInputs?: Array<{ path: string; size: number }>;
+}
+
 /**
  * SSR-side debug-bar payload. These fields are emitted into the cached HTML
  * body and stay stable across cache hits. The dynamic per-request fields
@@ -89,16 +99,7 @@ export interface DebugBarData {
   /** Time in milliseconds the SSR render took (compile check + Svelte render + HTML processing). */
   ssrDurationMs?: number;
   /** Framework JS bundles injected for this page (bootstrap, island entries, shared chunks). */
-  bundles?: Array<{
-    url: string;
-    label: string;
-    sizeBytes: number;
-    kind: 'bootstrap' | 'island' | 'chunk';
-    inputs: Array<{ path: string; size: number }>;
-    /** Pre-computed web-component inputs and size (bootstrap only). */
-    effectiveSize?: number;
-    effectiveInputs?: Array<{ path: string; size: number }>;
-  }>;
+  bundles?: BundleInfo[];
 }
 
 /**

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -301,6 +301,7 @@ export interface MochiManifest {
       name: string;
       size: number;
       inputs: { path: string; size: number }[];
+      imports: string[];
     }[];
   } | null;
   /** Maps server island component name → resolved file path */

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -75,6 +75,15 @@ Hello from Mochi! Inserted via transformPage
   });
 };
 
+const ANALYTICS_SCRIPT = `<script defer src="https://u.khromov.se/u.js" data-website-id="8dceb8f5-6533-4c03-9cd6-1ce74accd63a"></script>`;
+const analytics: Handle = async ({ event, resolve }) => {
+  return resolve(event, {
+    transformPage({ html }) {
+      return html.replace('{{mochi.analytics}}', process.env.MODE === 'development' ? '' : ANALYTICS_SCRIPT);
+    },
+  });
+};
+
 const PORT = Number(process.env.PORT) || 3333;
 const CSRF_PORT = Number(process.env.MOCHI_PORT) || 3333;
 const CSRF_DOMAIN = process.env.MOCHI_DOMAIN ?? 'localhost';
@@ -89,7 +98,7 @@ await Mochi.serve({
   liveReload: process.env.MOCHI_LIVE_RELOAD === 'false' ? false : undefined,
   htmlShell: './src/shell.html',
   trailingSlash: 'always',
-  handle: sequence(compress(), immutableAssets, helloWorld, asciiDog, noCache, cookieVaryTestHandle),
+  handle: sequence(compress(), immutableAssets, helloWorld, asciiDog, analytics, noCache, cookieVaryTestHandle),
   handleError,
   idleTimeout: 60,
   compressServerIslandProps: true,

--- a/packages/site/src/shell.html
+++ b/packages/site/src/shell.html
@@ -327,7 +327,6 @@
     {{mochi.css}}
   </head>
   <body>
-    {{mochi.body}} {{mochi.script}}
-    <script defer src="https://u.khromov.se/u.js" data-website-id="8dceb8f5-6533-4c03-9cd6-1ce74accd63a"></script>
+    {{mochi.body}} {{mochi.script}} {{mochi.analytics}}
   </body>
 </html>


### PR DESCRIPTION
## Summary

- Replaces the old external "Bundles ↗" link in the debug bar with an inline **JS bundle panel** showing per-page framework JS breakdown
- Badge shows total JS weight (e.g. `48 KB`); pages with no islands show a green `0` with a sparkle animation
- Panel groups bundles by kind (Runtime, Islands, Shared Chunks) with expandable rows showing input source files and click-to-copy paths
- Bundle data is scoped per page — only includes bootstrap, rendered island entries, and shared chunks; excludes the debug bar bundle itself
- Data is populated server-side in `ComponentRegistry.renderComponent()` from `clientStats` and seeded via `window.__mochi_debug.bundles`
- CI review workflow now packs `mochi-framework` as a downloadable artifact with "Try this PR" install instructions in the review comment
- LOC comment sections for non-mochi packages are now collapsible

## Test plan

- [ ] Run `bun run dev:site`, open a page with islands — badge should show total JS size
- [ ] Click the badge — panel should list bootstrap, island entries, and chunks with individual sizes
- [ ] Expand a bundle row — input files should appear with sizes, click to copy path
- [ ] Open a page with no islands — badge should show green `0` with sparkle
- [ ] Verify "Full bundle analysis" link inside the panel still works
- [ ] Push to a PR branch and verify the review workflow uploads the tarball artifact and renders install instructions