### PR TITLE
refactor: replace picocolors with Node built-in styleText

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ Run a single test file: `bun test packages/mochi/src/forms.test.ts` (or pass `-t
 
 ### Testing: split bun-test invocations
 
-Compiling the same Svelte entrypoint via `Bun.build` twice in one `bun:test` process trips a Bun bundler bug (spurious EISDIR errors against transitive deps like `picocolors`/`stale-while-revalidate-cache`) once the SSR plugin pulls in the `mochi-framework` virtual module. `Mochi.serve()` pre-compiles `DefaultError.svelte` at startup, so any test that boots the server already does one compile. Separately, `Mochi.serve()` pins state on `globalThis.__mochi_config__` and throws on a second call in the same process, and `enhance.client.test.ts` uses `GlobalRegistrator` which pollutes process globals.
+Compiling the same Svelte entrypoint via `Bun.build` twice in one `bun:test` process trips a Bun bundler bug (spurious EISDIR errors against transitive deps like `stale-while-revalidate-cache`) once the SSR plugin pulls in the `mochi-framework` virtual module. `Mochi.serve()` pre-compiles `DefaultError.svelte` at startup, so any test that boots the server already does one compile. Separately, `Mochi.serve()` pins state on `globalThis.__mochi_config__` and throws on a second call in the same process, and `enhance.client.test.ts` uses `GlobalRegistrator` which pollutes process globals.
 
 Tests that need isolation use the `*.isolated.test.ts` suffix. `packages/mochi/scripts/run-tests.ts` globs `src/**/*.test.ts`, runs everything that doesn't match the suffix in one `bun test` batch, then runs each `.isolated.test.ts` file in its own `bun test` invocation sequentially, aggregating exit codes. To isolate a new test: name (or `git mv`) it to `*.isolated.test.ts` and add a header comment noting why (which conflict it dodges).
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,6 @@
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.17.1",
-        "picocolors": "^1.1.1",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^3.5.2",
         "rimraf": "^6.1.3",
@@ -29,7 +28,6 @@
         "@bluwy/giget-core": "^0.1.7",
         "@clack/prompts": "^1.3.0",
         "commander": "^14.0.3",
-        "picocolors": "^1.1.1",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -78,7 +76,7 @@
     },
     "packages/mochi": {
       "name": "mochi-framework",
-      "version": "0.2.0",
+      "version": "0.3.2",
       "bin": {
         "mochi-framework": "src/cli.js",
       },
@@ -96,7 +94,6 @@
         "nanoid": "^5.1.7",
         "negotiator": "^1.0.0",
         "p-retry": "^6.2.1",
-        "picocolors": "^1.1.1",
         "stale-while-revalidate-cache": "^3.4.1",
         "zimmerframe": "^1.1.2",
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.17.1",
-    "picocolors": "^1.1.1",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^3.5.2",
     "rimraf": "^6.1.3",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -55,8 +55,7 @@
   "dependencies": {
     "@bluwy/giget-core": "^0.1.7",
     "@clack/prompts": "^1.3.0",
-    "commander": "^14.0.3",
-    "picocolors": "^1.1.1"
+    "commander": "^14.0.3"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,7 @@
 import path from 'node:path';
 import { Command, Option } from 'commander';
 import * as p from '@clack/prompts';
-import pc from 'picocolors';
+import { styleText } from 'node:util';
 import pkg from '../package.json' with { type: 'json' };
 import { create, SCAFFOLDED_PORT } from './create.ts';
 import { TEMPLATES, TEMPLATE_IDS, type TemplateId } from './templates.ts';
@@ -40,7 +40,7 @@ interface CliOptions {
 }
 
 async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise<void> {
-  p.intro(`${pc.bgMagenta(pc.black(' create-mochi '))} ${pc.dim(`v${pkg.version}`)}`);
+  p.intro(`${styleText(['bgMagenta', 'black'], ' create-mochi ')} ${styleText('dim', `v${pkg.version}`)}`);
 
   const dir = await promptDirectory(rawPath);
   const force = await maybePromptForce(dir, opts.force === true);
@@ -48,38 +48,38 @@ async function runCreate(rawPath: string | undefined, opts: CliOptions): Promise
   const name = defaultNameFor(dir);
 
   const spinner = p.spinner();
-  spinner.start(`Downloading ${pc.cyan(template)} template`);
+  spinner.start(`Downloading ${styleText('cyan', template)} template`);
   let result;
   try {
     result = await create({ dir, template, name, force });
   } catch (err) {
-    spinner.stop(pc.red('Failed to download template.'));
+    spinner.stop(styleText('red', 'Failed to download template.'));
     p.cancel(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
-  spinner.stop(`Downloaded ${pc.cyan(template)} template`);
+  spinner.stop(`Downloaded ${styleText('cyan', template)} template`);
 
   const rel = path.relative(process.cwd(), result.dir) || '.';
   p.note(
     [
-      pc.dim('Run this to get started:'),
+      styleText('dim', 'Run this to get started:'),
       '',
-      `${pc.dim('1.')} cd ${rel}`,
-      `${pc.dim('2.')} bun install`,
-      `${pc.dim('3.')} bun run dev`,
+      `${styleText('dim', '1.')} cd ${rel}`,
+      `${styleText('dim', '2.')} bun install`,
+      `${styleText('dim', '3.')} bun run dev`,
       '',
-      pc.dim(`mochi-framework pinned to ${result.mochiVersion}`),
+      styleText('dim', `mochi-framework pinned to ${result.mochiVersion}`),
     ].join('\n'),
     "You're all set!",
   );
   p.outro(
     [
-      pc.italic('Server renders calm'),
-      `   ${pc.italic("Islands wake to user's touch")}`,
-      `   ${pc.italic('Mochi blooms in code')}`,
+      styleText('italic', 'Server renders calm'),
+      `   ${styleText('italic', "Islands wake to user's touch")}`,
+      `   ${styleText('italic', 'Mochi blooms in code')}`,
       '',
-      `   ${pc.dim('Docs:')}  ${pc.cyan('https://mochi.fast/')}`,
-      `   ${pc.dim('Local:')} ${pc.cyan(`http://localhost:${SCAFFOLDED_PORT}/`)}`,
+      `   ${styleText('dim', 'Docs:')}  ${styleText('cyan', 'https://mochi.fast/')}`,
+      `   ${styleText('dim', 'Local:')} ${styleText('cyan', `http://localhost:${SCAFFOLDED_PORT}/`)}`,
     ].join('\n'),
   );
 }
@@ -120,7 +120,7 @@ async function maybePromptForce(dir: string, alreadyForced: boolean): Promise<bo
     return true;
   }
   const confirm = await p.confirm({
-    message: `${pc.cyan(dir)} is not empty. Continue and overwrite conflicting files?`,
+    message: `${styleText('cyan', dir)} is not empty. Continue and overwrite conflicting files?`,
     initialValue: false,
   });
   if (p.isCancel(confirm) || confirm !== true) {

--- a/packages/docs/162-extensions.md
+++ b/packages/docs/162-extensions.md
@@ -255,7 +255,7 @@ A `Mochi.page` / `Mochi.api` route on the same URL still wins — the filter onl
 
 #### `consoleLogger:line`
 
-Mutate or drop a formatted line right before `consoleLogger()` writes it. The first argument is the fully-rendered string (timestamp, label, kind, path, status, duration — with picocolors codes already applied). The second is a structured context with the underlying values, so you can filter without grepping ANSI-coloured strings. Return the string to log it, a rewritten string to substitute, or `null` to drop the line entirely. Sync.
+Mutate or drop a formatted line right before `consoleLogger()` writes it. The first argument is the fully-rendered string (timestamp, label, kind, path, status, duration — with ANSI colour codes already applied). The second is a structured context with the underlying values, so you can filter without grepping ANSI-coloured strings. Return the string to log it, a rewritten string to substitute, or `null` to drop the line entirely. Sync.
 
 Mochi ships `silenceInternalRoutes`, a built-in filter that drops two routinely-noisy paths from the console: Chrome's `/.well-known/appspecific/com.chrome.devtools.json` probe and the framework admin routes under `/__mochi/admin/*`.
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -97,7 +97,6 @@
     "nanoid": "^5.1.7",
     "negotiator": "^1.0.0",
     "p-retry": "^6.2.1",
-    "picocolors": "^1.1.1",
     "stale-while-revalidate-cache": "^3.4.1",
     "zimmerframe": "^1.1.2"
   },

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -284,7 +284,7 @@ export class ComponentRegistry {
    *
    * Boot-time and dev-watcher paths should call `compileAll` directly with
    * the full set of entrypoints — that produces a single shared SSR bundle
-   * (deduplicates `picocolors`/`devalue`/etc. via Bun's `splitting: true`)
+   * (deduplicates `devalue`/etc. via Bun's `splitting: true`)
    * and avoids the second-`Bun.build`-in-one-process EISDIR bug.
    */
   async compile(filename: string, opts: { force?: boolean } = {}): Promise<void> {
@@ -463,8 +463,8 @@ export class ComponentRegistry {
       target: 'bun',
       conditions: ['svelte'],
       // Svelte stays external because it's a peer dep the consumer already
-      // provides. Everything else (devalue, cookie, nanoid, picocolors, etc.)
-      // gets bundled — but with `splitting: true` Bun emits shared transitive
+      // provides. Everything else (devalue, cookie, nanoid, etc.) gets bundled
+      // — but with `splitting: true` Bun emits shared transitive
       // deps into separate chunk files alongside each entry's `.server.js`,
       // so they're written exactly once across the cohort. Two
       // `Bun.build` calls that touch the same transitive deps in one process

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -286,8 +286,8 @@ export class Mochi {
 
     // Collect every page entrypoint (error page + every Mochi.page route) so
     // we can compile them in one Bun.build below. Splitting deduplicates
-    // shared transitive deps (devalue, picocolors, mochi-framework internals,
-    // etc.) into chunk files instead of inlining them per page; collapsing
+    // shared transitive deps (devalue, mochi-framework internals, etc.) into
+    // chunk files instead of inlining them per page; collapsing
     // the boot-time pre-compiles into one Bun.build also dodges the
     // documented EISDIR bug that fires when two `Bun.build` calls in the
     // same process touch the same transitive deps.

--- a/packages/mochi/src/build.ts
+++ b/packages/mochi/src/build.ts
@@ -9,7 +9,7 @@ import { loadSvelteConfig } from './svelteConfig';
 import { logger, setLogLevel } from './log';
 import { consoleLogger } from './consoleLogger';
 import { mochiEvents } from './events';
-import pc from 'picocolors';
+import { styleText } from 'node:util';
 import prettyBytes from './lib/prettyBytes';
 
 export interface MochiBuildOptions {
@@ -53,7 +53,7 @@ export async function build(options: MochiBuildOptions): Promise<void> {
   consoleLogger({ compile: false });
   printHeader();
   const version = await readMochiVersion();
-  console.log(pc.dim(`Mochi v${version}`));
+  console.log(styleText('dim', `Mochi v${version}`));
   console.log('Starting build...\n');
   const startedAt = performance.now();
   const development = options.development ?? false;
@@ -76,9 +76,8 @@ export async function build(options: MochiBuildOptions): Promise<void> {
   });
 
   // Compile all Mochi.page() handlers in one Bun.build so transitive deps
-  // (devalue, picocolors, mochi-framework internals) emit as shared chunks
-  // alongside the per-page `.server.js` files instead of being inlined into
-  // every page.
+  // (devalue, mochi-framework internals) emit as shared chunks alongside the
+  // per-page `.server.js` files instead of being inlined into every page.
   const compiledPages: string[] = [];
   const ssrEntrypoints: string[] = [];
   const allRoutes: RouteEntry[] = [];
@@ -184,23 +183,23 @@ function printHeader(): void {
   ];
   console.log('');
   for (let i = 0; i < wordmark.length; i++) {
-    console.log(pc.cyan(art[i]!) + pc.bold(wordmark[i]!));
+    console.log(styleText('cyan', art[i]!) + styleText('bold', wordmark[i]!));
   }
   console.log('');
 }
 
 function pageSymbol(hyd: number | null): string {
-  return hyd != null && hyd > 0 ? pc.green('●') : pc.cyan('○');
+  return hyd != null && hyd > 0 ? styleText('green', '●') : styleText('cyan', '○');
 }
 
 function kindSymbol(kind: Exclude<RouteKind, 'page'>): string {
   switch (kind) {
     case 'api':
-      return pc.magenta('λ');
+      return styleText('magenta', 'λ');
     case 'ws':
-      return pc.blue('⇄');
+      return styleText('blue', '⇄');
     case 'sse':
-      return pc.green('→');
+      return styleText('green', '→');
   }
 }
 
@@ -219,35 +218,35 @@ function printRouteTree(routes: RouteEntry[], stats: Map<string, { ssrSizeBytes:
   const bundleWidth = Math.max('bundle'.length, ...rows.map((r) => r.ssr?.length ?? 0));
 
   // "  ┌ ● " = 6 chars — header indent matches
-  console.log(pc.dim(`      ${'Route'.padEnd(patternWidth + 2)}  ${'islands'.padStart(islandsWidth)}  ${'bundle'.padStart(bundleWidth)}`));
+  console.log(styleText('dim', `      ${'Route'.padEnd(patternWidth + 2)}  ${'islands'.padStart(islandsWidth)}  ${'bundle'.padStart(bundleWidth)}`));
 
   const n = routes.length;
   for (let i = 0; i < n; i++) {
     const { pattern, kind, hyd, ssr } = rows[i]!;
-    const char = pc.dim(n === 1 ? '─' : i === 0 ? '┌' : i === n - 1 ? '└' : '├');
+    const char = styleText('dim', n === 1 ? '─' : i === 0 ? '┌' : i === n - 1 ? '└' : '├');
     const symbol = kind === 'page' ? pageSymbol(hyd) : kindSymbol(kind);
-    const coloredPattern = pattern.padEnd(patternWidth + 2).replace(/:[^/\s]+/g, (s: string) => pc.cyan(s));
+    const coloredPattern = pattern.padEnd(patternWidth + 2).replace(/:[^/\s]+/g, (s: string) => styleText('cyan', s));
     const isPage = kind === 'page';
-    const hydStr = isPage && hyd != null ? pc.green(String(hyd).padStart(islandsWidth)) : pc.dim('-'.padStart(islandsWidth));
-    const ssrStr = isPage && ssr != null ? pc.dim(ssr.padStart(bundleWidth)) : pc.dim('-'.padStart(bundleWidth));
+    const hydStr = isPage && hyd != null ? styleText('green', String(hyd).padStart(islandsWidth)) : styleText('dim', '-'.padStart(islandsWidth));
+    const ssrStr = isPage && ssr != null ? styleText('dim', ssr.padStart(bundleWidth)) : styleText('dim', '-'.padStart(bundleWidth));
     console.log(`  ${char} ${symbol} ${coloredPattern}  ${hydStr}  ${ssrStr}`);
   }
 
   const legendEntries: string[] = [];
   if (rows.some((r) => r.kind === 'page' && r.hyd != null && r.hyd > 0)) {
-    legendEntries.push(`${pc.green('●')} page with islands`);
+    legendEntries.push(`${styleText('green', '●')} page with islands`);
   }
   if (rows.some((r) => r.kind === 'page' && (r.hyd === null || r.hyd === 0))) {
-    legendEntries.push(`${pc.cyan('○')} ssr-only page`);
+    legendEntries.push(`${styleText('cyan', '○')} ssr-only page`);
   }
   if (rows.some((r) => r.kind === 'api')) {
-    legendEntries.push(`${pc.magenta('λ')} api`);
+    legendEntries.push(`${styleText('magenta', 'λ')} api`);
   }
   if (rows.some((r) => r.kind === 'ws')) {
-    legendEntries.push(`${pc.blue('⇄')} websocket`);
+    legendEntries.push(`${styleText('blue', '⇄')} websocket`);
   }
   if (rows.some((r) => r.kind === 'sse')) {
-    legendEntries.push(`${pc.green('→')} sse`);
+    legendEntries.push(`${styleText('green', '→')} sse`);
   }
-  console.log(`\n  ${legendEntries.join(pc.dim('  ·  '))}`);
+  console.log(`\n  ${legendEntries.join(styleText('dim', '  ·  '))}`);
 }

--- a/packages/mochi/src/consoleLogger.ts
+++ b/packages/mochi/src/consoleLogger.ts
@@ -1,4 +1,4 @@
-import pc from 'picocolors';
+import { styleText } from 'node:util';
 import prettyBytes from './lib/prettyBytes';
 import { mochiEvents } from './events';
 import type { MochiEventMap, MochiRequestKind } from './events';
@@ -82,7 +82,7 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
   subscribe('ws:open', (payload) => ({
     label: 'WS  ',
     path: payload.path,
-    note: pc.cyan('open'),
+    note: styleText('cyan', 'open'),
     duration: payload.duration,
     slow,
     verySlow,
@@ -91,13 +91,13 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
   subscribe('ws:message', (payload) => ({
     label: 'WS  ',
     path: payload.path,
-    note: `${pc.cyan('recv')} ${prettyBytes(payload.size)} ${pc.dim(payload.type)}`,
+    note: `${styleText('cyan', 'recv')} ${prettyBytes(payload.size)} ${styleText('dim', payload.type)}`,
   }));
 
   subscribe('ws:close', (payload) => ({
     label: 'WS  ',
     path: payload.path,
-    note: pc.dim(`close ${payload.code}`),
+    note: styleText('dim', `close ${payload.code}`),
     duration: payload.duration,
     neutral: true,
   }));
@@ -105,13 +105,13 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
   subscribe('sse:open', (payload) => ({
     label: 'SSE ',
     path: payload.path,
-    note: pc.cyan('open'),
+    note: styleText('cyan', 'open'),
   }));
 
   subscribe('sse:message', (payload) => {
-    const parts = [pc.cyan('send'), prettyBytes(payload.size)];
+    const parts = [styleText('cyan', 'send'), prettyBytes(payload.size)];
     if (payload.event) {
-      parts.push(pc.dim(`[${payload.event}]`));
+      parts.push(styleText('dim', `[${payload.event}]`));
     }
     return { label: 'SSE ', path: payload.path, note: parts.join(' ') };
   });
@@ -119,28 +119,28 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
   subscribe('sse:close', (payload) => ({
     label: 'SSE ',
     path: payload.path,
-    note: pc.dim('close'),
+    note: styleText('dim', 'close'),
     duration: payload.duration,
     neutral: true,
   }));
 
   subscribe('server:start', ({ port, hostname, development, routes }) => {
     const where = `${hostname ?? 'localhost'}:${port}`;
-    const mode = pc.dim(development ? 'dev' : 'prod');
-    const counts = pc.dim(`page=${routes.page} api=${routes.api} ws=${routes.ws} sse=${routes.sse}`);
+    const mode = styleText('dim', development ? 'dev' : 'prod');
+    const counts = styleText('dim', `page=${routes.page} api=${routes.api} ws=${routes.ws} sse=${routes.sse}`);
     return { label: 'BOOT', path: where, note: `${mode} ${counts}` };
   });
 
   subscribe('server:stop', ({ reason, signal }) => {
     const tag = signal ? `${reason} ${signal.toLowerCase()}` : reason;
-    return { label: 'STOP', path: '-', note: pc.dim(tag) };
+    return { label: 'STOP', path: '-', note: styleText('dim', tag) };
   });
 
   subscribe('error', ({ kind, method, path, status, message }) => ({
     label: 'ERR ',
     path,
     status,
-    note: `${pc.dim(`${method} ${kind}`)} ${pc.red(message)}`,
+    note: `${styleText('dim', `${method} ${kind}`)} ${styleText('red', message)}`,
   }));
 
   // Per-read cache lookups are high-volume; route them through `logger.debug`
@@ -154,19 +154,19 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
   subscribe('cache:revalidate', (payload) => ({
     label: 'CACHE',
     path: payload.key,
-    note: pc.cyan('revalidate'),
+    note: styleText('cyan', 'revalidate'),
   }));
 
   subscribe('preprocess-cache:hit', ({ filePath }) => ({
     label: 'PCACHE',
     path: relPath(filePath),
-    note: pc.green('hit'),
+    note: styleText('green', 'hit'),
     level: 'debug',
   }));
   subscribe('preprocess-cache:miss', ({ filePath }) => ({
     label: 'PCACHE',
     path: relPath(filePath),
-    note: pc.yellow('miss'),
+    note: styleText('yellow', 'miss'),
     level: 'debug',
   }));
   subscribe('preprocess-cache:summary', ({ hits, misses, files }) => {
@@ -174,7 +174,7 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     return {
       label: 'PCACHE',
       path: '-',
-      note: pc.dim(`${hits} hit / ${misses} miss across ${files} files (${rate}%)`),
+      note: styleText('dim', `${hits} hit / ${misses} miss across ${files} files (${rate}%)`),
       level: 'log',
     };
   });
@@ -183,7 +183,7 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     subscribe('compile:complete', ({ path, ssrSizeBytes, hydratableCount, serverIslandCount }) => ({
       label: 'BUILD',
       path: relPath(path),
-      note: pc.dim(`hyd=${hydratableCount} srv=${serverIslandCount} ssr=${prettyBytes(ssrSizeBytes)}`),
+      note: styleText('dim', `hyd=${hydratableCount} srv=${serverIslandCount} ssr=${prettyBytes(ssrSizeBytes)}`),
     }));
     subscribe('compile:batch-complete', ({ count, durationMs }) => ({
       label: 'BUILD',
@@ -195,7 +195,7 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     subscribe('client-bundle:complete', ({ entryCount, outputBytes, durationMs }) => ({
       label: 'BNDL',
       path: '-',
-      note: pc.dim(`entries=${entryCount} ${prettyBytes(outputBytes)}`),
+      note: styleText('dim', `entries=${entryCount} ${prettyBytes(outputBytes)}`),
       duration: durationMs,
       slow,
       verySlow,
@@ -211,7 +211,7 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
       } else {
         action = `rebuilt ${pages}, ${bundles}`;
       }
-      return { label: 'HMR ', path: relPath(path), note: pc.dim(action), duration: durationMs, slow, verySlow };
+      return { label: 'HMR ', path: relPath(path), note: styleText('dim', action), duration: durationMs, slow, verySlow };
     });
   }
 }
@@ -252,13 +252,13 @@ function relPath(p: string): string {
 function colorCacheStatus(status: 'fresh' | 'stale' | 'expired' | 'miss'): string {
   switch (status) {
     case 'fresh':
-      return pc.green(status);
+      return styleText('green', status);
     case 'stale':
-      return pc.yellow(status);
+      return styleText('yellow', status);
     case 'expired':
-      return pc.red(status);
+      return styleText('red', status);
     case 'miss':
-      return pc.dim(status);
+      return styleText('dim', status);
   }
 }
 
@@ -293,27 +293,27 @@ const KIND_WIDTH = 'fallback'.length;
 function colorKind(kind: MochiRequestKind): string {
   switch (kind) {
     case 'page':
-      return pc.cyan(kind.padEnd(KIND_WIDTH));
+      return styleText('cyan', kind.padEnd(KIND_WIDTH));
     case 'api':
-      return pc.magenta(kind.padEnd(KIND_WIDTH));
+      return styleText('magenta', kind.padEnd(KIND_WIDTH));
     case 'asset':
-      return pc.dim(kind.padEnd(KIND_WIDTH));
+      return styleText('dim', kind.padEnd(KIND_WIDTH));
     case 'fallback':
-      return pc.yellow(kind.padEnd(KIND_WIDTH));
+      return styleText('yellow', kind.padEnd(KIND_WIDTH));
     case 'error':
-      return pc.red(kind.padEnd(KIND_WIDTH));
+      return styleText('red', kind.padEnd(KIND_WIDTH));
   }
 }
 
 function emit({ label, kind, path, status, note, duration, neutral = false, slow = DEFAULT_SLOW, verySlow = DEFAULT_VERY_SLOW, level = 'info', source }: EmitInput): void {
-  const ts = pc.dim(formatTimestamp(new Date()));
-  const labelStr = pc.cyan(label);
+  const ts = styleText('dim', formatTimestamp(new Date()));
+  const labelStr = styleText('cyan', label);
   const kindStr = kind ? ' ' + colorKind(kind) : '';
-  const pathStr = pc.dim(path);
+  const pathStr = styleText('dim', path);
   const statusPart = status != null ? colorStatus(status) : '';
   const notePart = note ?? '';
   const middle = [statusPart, notePart].filter(Boolean).join(' ');
-  const durationStr = duration != null ? ' ' + (neutral ? pc.dim(formatMs(duration)) : colorDuration(duration, slow, verySlow)) : '';
+  const durationStr = duration != null ? ' ' + (neutral ? styleText('dim', formatMs(duration)) : colorDuration(duration, slow, verySlow)) : '';
 
   const line = `${ts} ${labelStr}${kindStr} ${pathStr} ${middle}${durationStr}`;
 
@@ -348,18 +348,18 @@ function formatTimestamp(date: Date): string {
 function colorStatus(status: number): string {
   const s = String(status);
   if (status >= 500) {
-    return pc.red(s);
+    return styleText('red', s);
   }
   if (status >= 400) {
-    return pc.yellow(s);
+    return styleText('yellow', s);
   }
   if (status >= 300) {
-    return pc.cyan(s);
+    return styleText('cyan', s);
   }
   if (status >= 200) {
-    return pc.green(s);
+    return styleText('green', s);
   }
-  return pc.dim(s);
+  return styleText('dim', s);
 }
 
 function formatMs(duration: number): string {
@@ -369,10 +369,10 @@ function formatMs(duration: number): string {
 function colorDuration(duration: number, slow: number, verySlow: number): string {
   const ms = formatMs(duration);
   if (duration >= verySlow) {
-    return pc.red(ms);
+    return styleText('red', ms);
   }
   if (duration >= slow) {
-    return pc.yellow(ms);
+    return styleText('yellow', ms);
   }
-  return pc.green(ms);
+  return styleText('green', ms);
 }

--- a/packages/mochi/src/log.ts
+++ b/packages/mochi/src/log.ts
@@ -1,4 +1,3 @@
-import pc from 'picocolors';
 import { pinGlobal } from './globalState';
 
 export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'log' | 'debug';
@@ -13,6 +12,13 @@ const LEVELS: Record<LogLevel, number> = {
 };
 
 const PREFIX = '[mochi]';
+
+// Inline ANSI escapes — log.ts is isomorphic (bundled for both server and
+// client), so it cannot import node:util whose browser polyfill lacks styleText.
+const red = (s: string) => `\x1b[31m${s}\x1b[39m`;
+const yellow = (s: string) => `\x1b[33m${s}\x1b[39m`;
+const green = (s: string) => `\x1b[32m${s}\x1b[39m`;
+const dim = (s: string) => `\x1b[2m${s}\x1b[22m`;
 
 export const DEFAULT_LOG_LEVEL: LogLevel = 'warn';
 
@@ -33,30 +39,30 @@ export const logger = {
     if (LEVELS[state.level] < LEVELS.error) {
       return;
     }
-    console.error(pc.red(PREFIX), ...args);
+    console.error(red(PREFIX), ...args);
   },
   warn: (...args: unknown[]): void => {
     if (LEVELS[state.level] < LEVELS.warn) {
       return;
     }
-    console.warn(pc.yellow(PREFIX), ...args);
+    console.warn(yellow(PREFIX), ...args);
   },
   info: (...args: unknown[]): void => {
     if (LEVELS[state.level] < LEVELS.info) {
       return;
     }
-    console.info(pc.green(PREFIX), ...args);
+    console.info(green(PREFIX), ...args);
   },
   log: (...args: unknown[]): void => {
     if (LEVELS[state.level] < LEVELS.log) {
       return;
     }
-    console.log(pc.dim(PREFIX), ...args);
+    console.log(dim(PREFIX), ...args);
   },
   debug: (...args: unknown[]): void => {
     if (LEVELS[state.level] < LEVELS.debug) {
       return;
     }
-    console.debug(pc.dim(PREFIX), ...args);
+    console.debug(dim(PREFIX), ...args);
   },
 };

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -1,7 +1,7 @@
 import { spawn, type Subprocess } from 'bun';
 import { readdirSync } from 'node:fs';
 import path from 'node:path';
-import pc from 'picocolors';
+import { styleText } from 'node:util';
 
 const packagesDir = path.resolve(import.meta.dir, '..', 'packages');
 
@@ -24,7 +24,14 @@ if (targets.length === 0) {
   process.exit(1);
 }
 
-const palette = [pc.cyan, pc.magenta, pc.yellow, pc.green, pc.blue, pc.red];
+const palette = [
+  (s: string) => styleText('cyan', s),
+  (s: string) => styleText('magenta', s),
+  (s: string) => styleText('yellow', s),
+  (s: string) => styleText('green', s),
+  (s: string) => styleText('blue', s),
+  (s: string) => styleText('red', s),
+];
 
 const pipePrefixed = async (src: ReadableStream<Uint8Array>, dst: NodeJS.WriteStream, prefix: string): Promise<void> => {
   const decoder = new TextDecoder();

--- a/scripts/flamegraph.ts
+++ b/scripts/flamegraph.ts
@@ -1,6 +1,6 @@
 import { spawn, type Subprocess } from 'bun';
 import path from 'node:path';
-import pc from 'picocolors';
+import { styleText } from 'node:util';
 
 type Args = {
   url: string;
@@ -134,7 +134,7 @@ const main = async (): Promise<void> => {
   const env = { ...process.env, PORT: String(args.port), MOCHI_PROFILER: '1', FORCE_COLOR: '1' };
   delete env.MODE;
 
-  console.log(pc.cyan(`[flamegraph] spawning site on port ${args.port} (production mode, MOCHI_PROFILER=1)`));
+  console.log(styleText('cyan', `[flamegraph] spawning site on port ${args.port} (production mode, MOCHI_PROFILER=1)`));
   const proc = spawn({
     cmd: ['bun', 'src/index.ts'],
     cwd: siteCwd,
@@ -143,12 +143,12 @@ const main = async (): Promise<void> => {
     stderr: 'pipe',
     stdin: 'ignore',
   });
-  const prefix = pc.gray('[server] ');
+  const prefix = styleText('gray', '[server] ');
   void pipePrefixed(proc.stdout as ReadableStream<Uint8Array>, process.stdout, prefix);
   void pipePrefixed(proc.stderr as ReadableStream<Uint8Array>, process.stderr, prefix);
 
   const onExit = async (signal: NodeJS.Signals): Promise<never> => {
-    console.log(pc.yellow(`[flamegraph] received ${signal}, tearing down server`));
+    console.log(styleText('yellow', `[flamegraph] received ${signal}, tearing down server`));
     await killGracefully(proc);
     process.exit(1);
   };
@@ -157,28 +157,28 @@ const main = async (): Promise<void> => {
 
   try {
     await waitForReady(altOrigin);
-    console.log(pc.cyan(`[flamegraph] server ready, warming up (${args.warmup} requests)`));
+    console.log(styleText('cyan', `[flamegraph] server ready, warming up (${args.warmup} requests)`));
 
     for (let i = 0; i < args.warmup; i++) {
       const res = await fetch(targetUrl, { redirect: 'manual' });
       await drainResponse(res);
     }
 
-    console.log(pc.cyan(`[flamegraph] starting profiler`));
+    console.log(styleText('cyan', `[flamegraph] starting profiler`));
     const startRes = await fetch(`${altOrigin}/_profiler/start`);
     if (!startRes.ok) {
       throw new Error(`/_profiler/start returned ${startRes.status}`);
     }
     await drainResponse(startRes);
 
-    console.log(pc.cyan(`[flamegraph] sampling ${args.samples} request(s) to ${target.pathname}`));
+    console.log(styleText('cyan', `[flamegraph] sampling ${args.samples} request(s) to ${target.pathname}`));
     const tStart = performance.now();
     for (let i = 0; i < args.samples; i++) {
       const res = await fetch(targetUrl, { redirect: 'manual' });
       await drainResponse(res);
     }
     const tEnd = performance.now();
-    console.log(pc.cyan(`[flamegraph] sampling complete in ${(tEnd - tStart).toFixed(0)}ms`));
+    console.log(styleText('cyan', `[flamegraph] sampling complete in ${(tEnd - tStart).toFixed(0)}ms`));
 
     const stopRes = await fetch(`${altOrigin}/_profiler/stop`);
     if (!stopRes.ok) {
@@ -191,12 +191,12 @@ const main = async (): Promise<void> => {
 
     const rel = path.relative(process.cwd(), outPath);
     const profileMs = (profile.endTime - profile.startTime) / 1000;
-    console.log(pc.green(`[flamegraph] profile: ${profile.samples.length} samples, ${profile.nodes.length} nodes, ${profileMs.toFixed(1)}ms captured`));
+    console.log(styleText('green', `[flamegraph] profile: ${profile.samples.length} samples, ${profile.nodes.length} nodes, ${profileMs.toFixed(1)}ms captured`));
     if (profile.samples.length < 50) {
-      console.log(pc.yellow(`[flamegraph] few samples — bump --samples for better resolution (e.g. --samples 500)`));
+      console.log(styleText('yellow', `[flamegraph] few samples — bump --samples for better resolution (e.g. --samples 500)`));
     }
-    console.log(pc.green(`[flamegraph] wrote ${rel}`));
-    console.log(pc.green(`[flamegraph] open in Chrome DevTools: Performance panel → drag-and-drop, or ⋮ → More tools → JavaScript Profiler → Load`));
+    console.log(styleText('green', `[flamegraph] wrote ${rel}`));
+    console.log(styleText('green', `[flamegraph] open in Chrome DevTools: Performance panel → drag-and-drop, or ⋮ → More tools → JavaScript Profiler → Load`));
   } finally {
     await killGracefully(proc);
   }


### PR DESCRIPTION
## Summary
- Replace all `picocolors` usage with `styleText` from `node:util` (Node 20.12+ / Bun built-in)
- Remove `picocolors` as a direct dependency from `mochi-framework`, `create-mochi`, and root `devDependencies`
- `log.ts` uses inline ANSI escapes since it's isomorphic (bundled for client where `node:util` browser polyfill lacks `styleText`)
- Update comments and docs that referenced picocolors

## Test plan
- [x] `bun run checks` passes (lint, format, typecheck, tests)
- [ ] Verify colored terminal output in `bun run dev`
- [ ] Verify `bunx create-mochi` shows colored output