### PR TITLE
fix: resolve Svelte 5 state warnings and add autofixer tooling

### DIFF
--- a/.claude/autofixer-report.ts
+++ b/.claude/autofixer-report.ts
@@ -1,0 +1,169 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { basename } from "node:path";
+import { Glob } from "bun";
+
+const MCP_URL = "https://mcp.svelte.dev/mcp";
+
+interface AutofixerResult {
+  issues: string[];
+  suggestions: string[];
+}
+
+interface FileReport {
+  file: string;
+  issues: string[];
+  suggestions: string[];
+}
+
+let sessionId: string | null = null;
+let requestId = 0;
+
+function parseSSE(text: string): unknown {
+  for (const line of text.split("\n")) {
+    if (line.startsWith("data: ")) {
+      return JSON.parse(line.slice(6));
+    }
+  }
+  throw new Error("No data line in SSE response");
+}
+
+async function rpc(method: string, params: Record<string, unknown> = {}) {
+  const id = ++requestId;
+  const res = await fetch(MCP_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...(sessionId ? { "Mcp-Session-Id": sessionId } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method, params, id }),
+  });
+
+  const sid = res.headers.get("mcp-session-id");
+  if (sid) sessionId = sid;
+
+  if (!res.ok) throw new Error(`MCP error ${res.status}: ${await res.text()}`);
+
+  const contentType = res.headers.get("content-type") ?? "";
+  if (contentType.includes("text/event-stream")) {
+    return parseSSE(await res.text());
+  }
+  return res.json();
+}
+
+async function notify(method: string, params: Record<string, unknown> = {}) {
+  await fetch(MCP_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+      ...(sessionId ? { "Mcp-Session-Id": sessionId } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", method, params }),
+  });
+}
+
+async function connect() {
+  await rpc("initialize", {
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: { name: "autofixer-report", version: "1.0.0" },
+  });
+  await notify("notifications/initialized");
+}
+
+async function callTool(name: string, args: Record<string, unknown>): Promise<AutofixerResult> {
+  const res = await rpc("tools/call", { name, arguments: args });
+  const text = res.result?.content?.[0]?.text;
+  if (text) return JSON.parse(text);
+  return { issues: [], suggestions: [] };
+}
+
+function generateReport(files: string[], withIssues: FileReport[], withoutIssues: string[]): string {
+  const lines: string[] = [
+    "# Svelte Autofixer Report",
+    "",
+    `**Date:** ${new Date().toISOString().split("T")[0]}`,
+    `**Target version:** Svelte 5`,
+    `**Files scanned:** ${files.length}`,
+    `**Files with issues:** ${withIssues.length}`,
+    `**Files without issues:** ${withoutIssues.length}`,
+    "",
+    "---",
+    "",
+  ];
+
+  if (withIssues.length > 0) {
+    lines.push("## Files with Issues", "");
+    for (const { file, issues, suggestions } of withIssues) {
+      lines.push(`### \`${file}\``, "");
+      for (const issue of issues) {
+        for (const part of issue.split("\n")) {
+          lines.push(`- ${part}`);
+        }
+      }
+      if (suggestions.length > 0) {
+        lines.push("", "**Suggestions:**", "");
+        for (const s of suggestions) {
+          lines.push(`- ${s}`);
+        }
+      }
+      lines.push("");
+    }
+  }
+
+  if (withoutIssues.length > 0) {
+    lines.push("## Files without Issues", "");
+    for (const file of withoutIssues) {
+      lines.push(`- \`${file}\``);
+    }
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+async function main() {
+  const glob = new Glob("**/*.svelte");
+  const files = Array.from(glob.scanSync({ cwd: ".", dot: false })).sort();
+
+  if (files.length === 0) {
+    console.log("No .svelte files found.");
+    process.exit(0);
+  }
+
+  console.log(`Found ${files.length} .svelte file(s)\n`);
+
+  await connect();
+  console.log("Connected to Svelte MCP server\n");
+
+  const withIssues: FileReport[] = [];
+  const withoutIssues: string[] = [];
+
+  for (const file of files) {
+    process.stdout.write(`Checking ${file}...`);
+    const code = readFileSync(file, "utf-8");
+
+    const parsed = await callTool("svelte-autofixer", {
+      code,
+      desired_svelte_version: 5,
+      filename: basename(file),
+    });
+
+    if (parsed.issues.length > 0) {
+      withIssues.push({ file, issues: parsed.issues, suggestions: parsed.suggestions });
+      console.log(` ${parsed.issues.length} issue(s)`);
+    } else {
+      withoutIssues.push(file);
+      console.log(" OK");
+    }
+  }
+
+  writeFileSync("REPORT.md", generateReport(files, withIssues, withoutIssues));
+  console.log("\nReport written to REPORT.md");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/.claude/autofixer-report.ts
+++ b/.claude/autofixer-report.ts
@@ -1,8 +1,8 @@
-import { readFileSync, writeFileSync } from "node:fs";
-import { basename } from "node:path";
-import { Glob } from "bun";
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename } from 'node:path';
+import { Glob } from 'bun';
 
-const MCP_URL = "https://mcp.svelte.dev/mcp";
+const MCP_URL = 'https://mcp.svelte.dev/mcp';
 
 interface AutofixerResult {
   issues: string[];
@@ -19,33 +19,33 @@ let sessionId: string | null = null;
 let requestId = 0;
 
 function parseSSE(text: string): unknown {
-  for (const line of text.split("\n")) {
-    if (line.startsWith("data: ")) {
+  for (const line of text.split('\n')) {
+    if (line.startsWith('data: ')) {
       return JSON.parse(line.slice(6));
     }
   }
-  throw new Error("No data line in SSE response");
+  throw new Error('No data line in SSE response');
 }
 
 async function rpc(method: string, params: Record<string, unknown> = {}) {
   const id = ++requestId;
   const res = await fetch(MCP_URL, {
-    method: "POST",
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      ...(sessionId ? { "Mcp-Session-Id": sessionId } : {}),
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...(sessionId ? { 'Mcp-Session-Id': sessionId } : {}),
     },
-    body: JSON.stringify({ jsonrpc: "2.0", method, params, id }),
+    body: JSON.stringify({ jsonrpc: '2.0', method, params, id }),
   });
 
-  const sid = res.headers.get("mcp-session-id");
+  const sid = res.headers.get('mcp-session-id');
   if (sid) sessionId = sid;
 
   if (!res.ok) throw new Error(`MCP error ${res.status}: ${await res.text()}`);
 
-  const contentType = res.headers.get("content-type") ?? "";
-  if (contentType.includes("text/event-stream")) {
+  const contentType = res.headers.get('content-type') ?? '';
+  if (contentType.includes('text/event-stream')) {
     return parseSSE(await res.text());
   }
   return res.json();
@@ -53,27 +53,27 @@ async function rpc(method: string, params: Record<string, unknown> = {}) {
 
 async function notify(method: string, params: Record<string, unknown> = {}) {
   await fetch(MCP_URL, {
-    method: "POST",
+    method: 'POST',
     headers: {
-      "Content-Type": "application/json",
-      Accept: "application/json, text/event-stream",
-      ...(sessionId ? { "Mcp-Session-Id": sessionId } : {}),
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...(sessionId ? { 'Mcp-Session-Id': sessionId } : {}),
     },
-    body: JSON.stringify({ jsonrpc: "2.0", method, params }),
+    body: JSON.stringify({ jsonrpc: '2.0', method, params }),
   });
 }
 
 async function connect() {
-  await rpc("initialize", {
-    protocolVersion: "2025-03-26",
+  await rpc('initialize', {
+    protocolVersion: '2025-03-26',
     capabilities: {},
-    clientInfo: { name: "autofixer-report", version: "1.0.0" },
+    clientInfo: { name: 'autofixer-report', version: '1.0.0' },
   });
-  await notify("notifications/initialized");
+  await notify('notifications/initialized');
 }
 
 async function callTool(name: string, args: Record<string, unknown>): Promise<AutofixerResult> {
-  const res = await rpc("tools/call", { name, arguments: args });
+  const res = await rpc('tools/call', { name, arguments: args });
   const text = res.result?.content?.[0]?.text;
   if (text) return JSON.parse(text);
   return { issues: [], suggestions: [] };
@@ -81,70 +81,70 @@ async function callTool(name: string, args: Record<string, unknown>): Promise<Au
 
 function generateReport(files: string[], withIssues: FileReport[], withoutIssues: string[]): string {
   const lines: string[] = [
-    "# Svelte Autofixer Report",
-    "",
-    `**Date:** ${new Date().toISOString().split("T")[0]}`,
+    '# Svelte Autofixer Report',
+    '',
+    `**Date:** ${new Date().toISOString().split('T')[0]}`,
     `**Target version:** Svelte 5`,
     `**Files scanned:** ${files.length}`,
     `**Files with issues:** ${withIssues.length}`,
     `**Files without issues:** ${withoutIssues.length}`,
-    "",
-    "---",
-    "",
+    '',
+    '---',
+    '',
   ];
 
   if (withIssues.length > 0) {
-    lines.push("## Files with Issues", "");
+    lines.push('## Files with Issues', '');
     for (const { file, issues, suggestions } of withIssues) {
-      lines.push(`### \`${file}\``, "");
+      lines.push(`### \`${file}\``, '');
       for (const issue of issues) {
-        for (const part of issue.split("\n")) {
+        for (const part of issue.split('\n')) {
           lines.push(`- ${part}`);
         }
       }
       if (suggestions.length > 0) {
-        lines.push("", "**Suggestions:**", "");
+        lines.push('', '**Suggestions:**', '');
         for (const s of suggestions) {
           lines.push(`- ${s}`);
         }
       }
-      lines.push("");
+      lines.push('');
     }
   }
 
   if (withoutIssues.length > 0) {
-    lines.push("## Files without Issues", "");
+    lines.push('## Files without Issues', '');
     for (const file of withoutIssues) {
       lines.push(`- \`${file}\``);
     }
-    lines.push("");
+    lines.push('');
   }
 
-  return lines.join("\n");
+  return lines.join('\n');
 }
 
 async function main() {
-  const glob = new Glob("**/*.svelte");
-  const files = Array.from(glob.scanSync({ cwd: ".", dot: false })).sort();
+  const glob = new Glob('**/*.svelte');
+  const files = Array.from(glob.scanSync({ cwd: '.', dot: false })).sort();
 
   if (files.length === 0) {
-    console.log("No .svelte files found.");
+    console.log('No .svelte files found.');
     process.exit(0);
   }
 
   console.log(`Found ${files.length} .svelte file(s)\n`);
 
   await connect();
-  console.log("Connected to Svelte MCP server\n");
+  console.log('Connected to Svelte MCP server\n');
 
   const withIssues: FileReport[] = [];
   const withoutIssues: string[] = [];
 
   for (const file of files) {
     process.stdout.write(`Checking ${file}...`);
-    const code = readFileSync(file, "utf-8");
+    const code = readFileSync(file, 'utf-8');
 
-    const parsed = await callTool("svelte-autofixer", {
+    const parsed = await callTool('svelte-autofixer', {
       code,
       desired_svelte_version: 5,
       filename: basename(file),
@@ -155,12 +155,12 @@ async function main() {
       console.log(` ${parsed.issues.length} issue(s)`);
     } else {
       withoutIssues.push(file);
-      console.log(" OK");
+      console.log(' OK');
     }
   }
 
-  writeFileSync("REPORT.md", generateReport(files, withIssues, withoutIssues));
-  console.log("\nReport written to REPORT.md");
+  writeFileSync('REPORT.md', generateReport(files, withIssues, withoutIssues));
+  console.log('\nReport written to REPORT.md');
 }
 
 main().catch((err) => {

--- a/.claude/commands/autofixer-report.md
+++ b/.claude/commands/autofixer-report.md
@@ -1,0 +1,9 @@
+Run the Svelte autofixer report script:
+
+```
+bun .claude/autofixer-report.ts
+```
+
+This scans all `.svelte` files in the project, runs each through the Svelte MCP server's `svelte-autofixer` tool (targeting Svelte 5), and writes `REPORT.md` with the findings.
+
+After the script completes, read `REPORT.md` and present a summary to the user: how many files were scanned, how many had issues, and list the key issues found.

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ db
 reports
 .claude/*
 !.claude/skills/
+!.claude/commands/
+!.claude/autofixer-report.ts
 IMPROVEMENTS.md
 flamegraphs
 REPORT.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ reports
 !.claude/skills/
 IMPROVEMENTS.md
 flamegraphs
+REPORT.md

--- a/packages/mochi/src/templates/ClientStats/ClientStats.svelte
+++ b/packages/mochi/src/templates/ClientStats/ClientStats.svelte
@@ -6,7 +6,7 @@
 
   let { stats }: { stats: { outputs: Output[] } } = $props();
 
-  const totalSize = stats.outputs.reduce((sum, o) => sum + o.size, 0);
+  const totalSize = $derived(stats.outputs.reduce((sum, o) => sum + o.size, 0));
 </script>
 
 <svelte:head>

--- a/packages/site/src/demos/error-boundaries/ThrowOnClient.svelte
+++ b/packages/site/src/demos/error-boundaries/ThrowOnClient.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { isBrowser } from 'mochi-framework';
 
-  let { label = 'ThrowOnClient' }: { label?: string } = $props();
+  const props = $props<{ label?: string }>();
 
   if (isBrowser) {
-    throw new Error(`Client throw from <${label}>`);
+    throw new Error(`Client throw from <${props.label ?? 'ThrowOnClient'}>`);
   }
 </script>
 

--- a/packages/site/src/demos/error-boundaries/ThrowOnSsr.svelte
+++ b/packages/site/src/demos/error-boundaries/ThrowOnSsr.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
   import { isBrowser } from 'mochi-framework';
 
-  let { label = 'ThrowOnSsr' }: { label?: string } = $props();
+  const props = $props<{ label?: string }>();
 
   if (!isBrowser) {
-    throw new Error(`SSR throw from <${label}>`);
+    throw new Error(`SSR throw from <${props.label ?? 'ThrowOnSsr'}>`);
   }
 </script>
 

--- a/packages/site/src/demos/your-first-mochi-app/LikeButton.svelte
+++ b/packages/site/src/demos/your-first-mochi-app/LikeButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  let { initialLikes } = $props<{ initialLikes: number }>();
-  let likes = $state(initialLikes);
+  const props = $props<{ initialLikes: number }>();
+  let likes = $state(props.initialLikes);
 </script>
 
 <button onclick={() => likes++}>♥ {likes}</button>


### PR DESCRIPTION
## Summary
- Fix `state_referenced_locally` warnings in demo/template Svelte components by switching destructured `$props()` to `const props = $props<T>()` or wrapping derived values with `$derived()`
- Add a Svelte autofixer report script (`.claude/autofixer-report.ts`) and slash command that scans all `.svelte` files via the Svelte MCP server
- Update `.gitignore` to track the new `.claude/commands/` and autofixer script

## Test plan
- [ ] Verify `bun run dev:site` starts without Svelte warnings
- [ ] Confirm error-boundaries demo still works (ThrowOnClient / ThrowOnSsr)
- [ ] Confirm LikeButton demo still hydrates and increments
- [ ] Run `bun .claude/autofixer-report.ts` and verify it produces a valid `REPORT.md`