### PR TITLE
docs: add deployment options page

### DIFF
--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -10,32 +10,27 @@ import Callout from './_components/Callout.svelte';
 
 # Deployment options
 
-Mochi is at its heart a _serverful_ application. That means it doesn't run on _some_ serverless hosts. While this can seem like a limitation, it is actually what gives Mochi its superpowers - features like built-in SQLite support, in-memory cache and built-in support for WebSockets and Server-Sent Events. You can easily build complex, data-driven realtime applications with Mochi without any additional external cloud services or npm dependencies. It's both leaner _and_ cheaper.
+Mochi is at its heart a _serverful_ application. That means it doesn't run on _some_ serverless hosts. While this can seem like a limitation, it is actually what gives Mochi its superpowers - features like built-in SQLite support, in-memory cache and built-in support for WebSockets and Server-Sent Events. You can easily build complex, data-driven realtime applications with Mochi without a single extra dependency or any external cloud services. It's both leaner _and_ cheaper.
 
 You can host Bun and Mochi at hundreds of different hosts. We list some of the most popular options below.
 
 <Callout type="info">
-None of the links below are affiliate links.
+None of the links below are affiliate links, nor should any of the links be seen as endorsements.
 </Callout>
 
 ## PaaS
 
 Deploy code or containers — the platform manages infrastructure, scaling, and networking.
 
-- [Railway](https://railway.app) — auto-detects Bun, native `Bun.serve()` support
+- [Railway](https://railway.app) — Both dedicated Bun and Docker support
 - [Render](https://render.com) — Docker-based web services, Git-push deploys
 - [Fly.io](https://fly.io) — Docker-native, global edge, scale-to-zero
 - [Heroku](https://heroku.com) — supports Docker deployments
 - [Koyeb](https://koyeb.com) — Git or Docker, 250+ edge locations
-- [Clever Cloud](https://clever-cloud.com) — native Bun support (French, Nantes)
-- [Zeabur](https://zeabur.com) — auto-detects Bun, set `Bun.env.PORT`
-- [Northflank](https://northflank.com) — containers, jobs, APIs; bring-your-own-cloud
-- [Kuberns](https://kuberns.com) — Git-push deploy on AWS infra, no Dockerfile needed
-- [Scaleway Serverless Containers](https://www.scaleway.com/en/serverless-containers/) — deploy from any registry, billed per millisecond (French, Paris)
+- [Clever Cloud](https://www.clever.cloud) — native Bun / Docker support
+- [Zeabur](https://zeabur.com) — auto-detects Bun
+- [Scaleway Serverless Containers](https://www.scaleway.com/en/serverless-containers/) — deploy from any registry, billed per millisecond
 - [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform) — Git or Docker deploy
-- [Google Cloud Run](https://cloud.google.com/run) — serverless containers, scale-to-zero
-- [AWS App Runner](https://aws.amazon.com/apprunner/) — fully managed container service
-- [Azure Container Apps](https://azure.microsoft.com/en-us/products/container-apps) — serverless containers with auto-scaling
 
 ## Traditional VPS / IaaS
 
@@ -43,13 +38,11 @@ You get a server, install Bun yourself, and manage the process (systemd, Docker,
 
 - [Hetzner](https://hetzner.com) — very cheap, popular with indie devs (German)
 - [DigitalOcean Droplets](https://www.digitalocean.com/products/droplets) — simple cloud VMs
-- [OVHcloud](https://ovhcloud.com) — dedicated servers, VPS, private cloud; strong GDPR compliance (French, Roubaix)
-- [Scaleway Instances](https://www.scaleway.com/en/virtual-instances/) — VMs alongside their serverless offering (French, Paris)
+- [OVHcloud](https://ovhcloud.com) — dedicated servers, VPS, private cloud; strong GDPR compliance
+- [Scaleway Instances](https://www.scaleway.com/en/virtual-instances/) — Offers VMs alongside their serverless offering
 - [Vultr](https://vultr.com)
 - [Akamai / Linode](https://www.linode.com)
 - [Kamatera](https://kamatera.com) — pay-as-you-go cloud VMs
-- [IONOS](https://ionos.com)
-- [Oracle Cloud](https://cloud.oracle.com) — generous always-free tier (ARM VMs)
 
 ## Big Cloud (multiple deployment options)
 
@@ -58,6 +51,7 @@ Each of these offers VPS, serverless, containers, and Kubernetes — pick the mo
 - [AWS](https://aws.amazon.com) — EC2 (VPS), Lambda + Web Adapter (serverless), Fargate (serverless containers), App Runner (PaaS), ECS/EKS (orchestrated)
 - [Google Cloud](https://cloud.google.com) — Compute Engine (VPS), Cloud Run (serverless containers), GKE (Kubernetes), Cloud Functions
 - [Azure](https://azure.microsoft.com) — VMs (VPS), Container Apps (serverless), ACI (containers), AKS (Kubernetes)
+- [Oracle Cloud](https://cloud.oracle.com) — generous always-free tier (ARM VMs)
 
 ## Self-hosted tools
 
@@ -67,6 +61,10 @@ Not platforms themselves — you install these on a VPS from one of the provider
 - [Dokku](https://dokku.com) — open-source mini-Heroku
 - [CapRover](https://caprover.com) — open-source PaaS with web UI
 
----
+## Hosted tools
 
-**Applies to all:** make sure `Bun.serve()` binds to `0.0.0.0` (not `localhost`) and reads the port from `process.env.PORT` or `Bun.env.PORT`.
+Connect to your existing infrastructure at different cloud providers
+
+- [Northflank](https://northflank.com) — containers, jobs, APIs; bring-your-own-cloud
+- [Kuberns](https://kuberns.com) — Git-push deploy on AWS infra, no Dockerfile needed
+- [Convox](https://www.convox.com/)

--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -1,0 +1,70 @@
+---
+title: 'Deployment options'
+slug: deployment-options
+description: 'Where to deploy your Mochi app — PaaS, VPS, big cloud, and self-hosted options.'
+---
+
+<script>
+import Callout from './_components/Callout.svelte';
+</script>
+
+# Deployment options
+
+Mochi is at its heart a _serverful_ application. That means it doesn't run on _some_ serverless hosts. While this can seem like a limitation, it is actually what enabled Bun and Mochis superpowers - features like built-in SQLite support, in-memory cache,
+
+<Callout type="info">
+None of the links below are affiliate links.
+</Callout>
+
+## PaaS
+
+Deploy code or containers — the platform manages infrastructure, scaling, and networking.
+
+- [Railway](https://railway.app) — auto-detects Bun, native `Bun.serve()` support
+- [Render](https://render.com) — Docker-based web services, Git-push deploys
+- [Fly.io](https://fly.io) — Docker-native, global edge, scale-to-zero
+- [Heroku](https://heroku.com) — supports Docker deployments
+- [Koyeb](https://koyeb.com) — Git or Docker, 250+ edge locations
+- [Clever Cloud](https://clever-cloud.com) — native Bun support (French, Nantes)
+- [Zeabur](https://zeabur.com) — auto-detects Bun, set `Bun.env.PORT`
+- [Northflank](https://northflank.com) — containers, jobs, APIs; bring-your-own-cloud
+- [Kuberns](https://kuberns.com) — Git-push deploy on AWS infra, no Dockerfile needed
+- [Scaleway Serverless Containers](https://www.scaleway.com/en/serverless-containers/) — deploy from any registry, billed per millisecond (French, Paris)
+- [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform) — Git or Docker deploy
+- [Google Cloud Run](https://cloud.google.com/run) — serverless containers, scale-to-zero
+- [AWS App Runner](https://aws.amazon.com/apprunner/) — fully managed container service
+- [Azure Container Apps](https://azure.microsoft.com/en-us/products/container-apps) — serverless containers with auto-scaling
+
+## Traditional VPS / IaaS
+
+You get a server, install Bun yourself, and manage the process (systemd, Docker, etc.).
+
+- [Hetzner](https://hetzner.com) — very cheap, popular with indie devs (German)
+- [DigitalOcean Droplets](https://www.digitalocean.com/products/droplets) — simple cloud VMs
+- [OVHcloud](https://ovhcloud.com) — dedicated servers, VPS, private cloud; strong GDPR compliance (French, Roubaix)
+- [Scaleway Instances](https://www.scaleway.com/en/virtual-instances/) — VMs alongside their serverless offering (French, Paris)
+- [Vultr](https://vultr.com)
+- [Akamai / Linode](https://www.linode.com)
+- [Kamatera](https://kamatera.com) — pay-as-you-go cloud VMs
+- [IONOS](https://ionos.com)
+- [Oracle Cloud](https://cloud.oracle.com) — generous always-free tier (ARM VMs)
+
+## Big Cloud (multiple deployment options)
+
+Each of these offers VPS, serverless, containers, and Kubernetes — pick the model that fits.
+
+- [AWS](https://aws.amazon.com) — EC2 (VPS), Lambda + Web Adapter (serverless), Fargate (serverless containers), App Runner (PaaS), ECS/EKS (orchestrated)
+- [Google Cloud](https://cloud.google.com) — Compute Engine (VPS), Cloud Run (serverless containers), GKE (Kubernetes), Cloud Functions
+- [Azure](https://azure.microsoft.com) — VMs (VPS), Container Apps (serverless), ACI (containers), AKS (Kubernetes)
+
+## Self-hosted tools
+
+Not platforms themselves — you install these on a VPS from one of the providers above.
+
+- [Coolify](https://coolify.io) — open-source, self-hosted PaaS
+- [Dokku](https://dokku.com) — open-source mini-Heroku
+- [CapRover](https://caprover.com) — open-source PaaS with web UI
+
+---
+
+**Applies to all:** make sure `Bun.serve()` binds to `0.0.0.0` (not `localhost`) and reads the port from `process.env.PORT` or `Bun.env.PORT`.

--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -10,7 +10,9 @@ import Callout from './_components/Callout.svelte';
 
 # Deployment options
 
-Mochi is at its heart a _serverful_ application. That means it doesn't run on _some_ serverless hosts. While this can seem like a limitation, it is actually what enabled Bun and Mochis superpowers - features like built-in SQLite support, in-memory cache,
+Mochi is at its heart a _serverful_ application. That means it doesn't run on _some_ serverless hosts. While this can seem like a limitation, it is actually what gives Mochi its superpowers - features like built-in SQLite support, in-memory cache and built-in support for WebSockets and Server-Sent Events. You can easily build complex, data-driven realtime applications with Mochi without any additional external cloud services or npm dependencies. It's both leaner _and_ cheaper.
+
+You can host Bun and Mochi at hundreds of different hosts. We list some of the most popular options below.
 
 <Callout type="info">
 None of the links below are affiliate links.

--- a/packages/site/src/lib/rehypeExternalLinks.test.ts
+++ b/packages/site/src/lib/rehypeExternalLinks.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'bun:test';
+import rehypeExternalLinks from './rehypeExternalLinks';
+
+type HastNode = {
+  type: string;
+  tagName?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
+function makeLink(href: string, extra?: Record<string, unknown>): HastNode {
+  return {
+    type: 'element',
+    tagName: 'a',
+    properties: { href, ...extra },
+    children: [{ type: 'text' }],
+  };
+}
+
+function run(tree: HastNode): HastNode {
+  rehypeExternalLinks()(tree);
+  return tree;
+}
+
+describe('rehypeExternalLinks', () => {
+  test('adds target and rel to external links', () => {
+    const link = makeLink('https://example.com');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBe('_blank');
+    expect(link.properties!.rel).toBe('noopener noreferrer nofollow');
+  });
+
+  test('skips absolute path links', () => {
+    const link = makeLink('/docs/intro');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBeUndefined();
+    expect(link.properties!.rel).toBeUndefined();
+  });
+
+  test('skips anchor links', () => {
+    const link = makeLink('#section');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBeUndefined();
+    expect(link.properties!.rel).toBeUndefined();
+  });
+
+  test('skips mochi.fast domain', () => {
+    const link = makeLink('https://mochi.fast/docs/intro');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBeUndefined();
+    expect(link.properties!.rel).toBeUndefined();
+  });
+
+  test('skips mochi.fast subdomains', () => {
+    const link = makeLink('https://demos.mochi.fast/hn');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBeUndefined();
+    expect(link.properties!.rel).toBeUndefined();
+  });
+
+  test('skips mailto links', () => {
+    const link = makeLink('mailto:hello@example.com');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBeUndefined();
+    expect(link.properties!.rel).toBeUndefined();
+  });
+
+  test('skips tel links', () => {
+    const link = makeLink('tel:+1234567890');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBeUndefined();
+    expect(link.properties!.rel).toBeUndefined();
+  });
+
+  test('preserves existing rel values', () => {
+    const link = makeLink('https://example.com', { rel: 'sponsored' });
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.rel).toBe('sponsored noopener noreferrer nofollow');
+  });
+
+  test('deduplicates rel values', () => {
+    const link = makeLink('https://example.com', { rel: 'noopener' });
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.rel).toBe('noopener noreferrer nofollow');
+  });
+
+  test('finds nested links in deep trees', () => {
+    const link = makeLink('https://example.com');
+    const tree: HastNode = {
+      type: 'root',
+      children: [
+        {
+          type: 'element',
+          tagName: 'div',
+          children: [{ type: 'element', tagName: 'p', children: [link] }],
+        },
+      ],
+    };
+    run(tree);
+    expect(link.properties!.target).toBe('_blank');
+    expect(link.properties!.rel).toBe('noopener noreferrer nofollow');
+  });
+
+  test('does not treat similar domains as internal', () => {
+    const link = makeLink('https://notmochi.fast/foo');
+    run({ type: 'root', children: [link] });
+    expect(link.properties!.target).toBe('_blank');
+  });
+});

--- a/packages/site/src/lib/rehypeExternalLinks.ts
+++ b/packages/site/src/lib/rehypeExternalLinks.ts
@@ -1,0 +1,61 @@
+type HastNode = {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
+const INTERNAL_DOMAIN = 'mochi.fast';
+
+function isInternalLink(href: string): boolean {
+  if (href.startsWith('/') || href.startsWith('#')) {
+    return true;
+  }
+  try {
+    const url = new URL(href);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return true;
+    }
+    const host = url.hostname;
+    return host === INTERNAL_DOMAIN || host.endsWith(`.${INTERNAL_DOMAIN}`);
+  } catch {
+    return true;
+  }
+}
+
+function processLink(node: HastNode): void {
+  const props = node.properties;
+  if (!props) {
+    return;
+  }
+
+  const href = typeof props.href === 'string' ? props.href : '';
+  if (!href || isInternalLink(href)) {
+    return;
+  }
+
+  props.target = '_blank';
+
+  const required = ['noopener', 'noreferrer', 'nofollow'];
+  const existing = typeof props.rel === 'string' ? props.rel.split(/\s+/).filter(Boolean) : [];
+  const merged = new Set([...existing, ...required]);
+  props.rel = [...merged].join(' ');
+}
+
+function visitLinks(node: HastNode): void {
+  if (node.type === 'element' && node.tagName === 'a') {
+    processLink(node);
+  }
+  if (node.children) {
+    for (const child of node.children) {
+      visitLinks(child);
+    }
+  }
+}
+
+export default function rehypeExternalLinks(): (tree: HastNode) => void {
+  return (tree) => {
+    visitLinks(tree);
+  };
+}

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -1,5 +1,6 @@
 import { compile as mdsvexCompile } from 'mdsvex';
 import rehypeSlug from 'rehype-slug';
+import rehypeExternalLinks from './lib/rehypeExternalLinks';
 import { Mochi, error, getRequestContext } from 'mochi-framework';
 import type { MochiBuildOptions, MarkdownConfig, MochiRouteValue } from 'mochi-framework';
 import { highlightCode } from './lib/highlightCode';
@@ -151,7 +152,7 @@ export const routes: Record<string, MochiRouteValue> = {
 
 export const markdownConfig: MarkdownConfig = {
   compile: mdsvexCompile,
-  rehypePlugins: [rehypeSlug],
+  rehypePlugins: [rehypeSlug, rehypeExternalLinks],
   highlight: { highlighter: (code, lang) => highlightCode(code, lang) },
 };
 


### PR DESCRIPTION
## Summary
- Adds a new docs page listing deployment options for Mochi apps (PaaS, VPS, big cloud, self-hosted tools)
- Explains Mochi's serverful architecture and why it's a strength
- Uses Callout component for the affiliate disclaimer

## Test plan
- [ ] Verify the docs page renders correctly on the dev site
- [ ] Confirm Callout component displays properly