### PR TITLE
refactor: replace `cookie` npm package with Bun native cookie APIs

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -83,7 +83,6 @@
       "dependencies": {
         "@types/negotiator": "^0.6.4",
         "chokidar": "^4.0.3",
-        "cookie": "^1.1.1",
         "debounce": "^3.0.0",
         "deepmerge": "^4.3.1",
         "devalue": "^5.8.1",
@@ -324,8 +323,6 @@
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
-
-    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "create-mochi": ["create-mochi@workspace:packages/cli"],
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -85,7 +85,6 @@
   "dependencies": {
     "@types/negotiator": "^0.6.4",
     "chokidar": "^4.0.3",
-    "cookie": "^1.1.1",
     "debounce": "^3.0.0",
     "deepmerge": "^4.3.1",
     "devalue": "^5.8.1",

--- a/packages/mochi/src/cookies.ts
+++ b/packages/mochi/src/cookies.ts
@@ -1,4 +1,4 @@
-import { parse, serialize } from 'cookie';
+import type { CookieInit, CookieSameSite } from 'bun';
 import { appendVary } from './utils';
 
 export interface CookieSerializeOptions {
@@ -23,21 +23,20 @@ function parseCookieHeader(header: string | null): Map<string, string> {
   if (!header) {
     return map;
   }
-  const parsed = parse(header);
-  for (const [name, value] of Object.entries(parsed)) {
-    if (value !== undefined) {
-      map.set(name, value);
-    }
+  for (const [name, value] of new Bun.CookieMap(header)) {
+    map.set(name, value);
   }
   return map;
 }
 
 function serializeCookie(name: string, value: string, options?: CookieSerializeOptions): string {
   if (!options) {
-    return serialize(name, value);
+    return new Bun.Cookie(name, value).serialize();
   }
 
-  const cookieOpts: import('cookie').SerializeOptions = {
+  const init: CookieInit = {
+    name,
+    value,
     path: options.path,
     domain: options.domain,
     maxAge: options.maxAge,
@@ -47,18 +46,20 @@ function serializeCookie(name: string, value: string, options?: CookieSerializeO
   };
 
   if (options.expires != null) {
-    cookieOpts.expires = typeof options.expires === 'number' ? new Date(Date.now() + options.expires * 864e5) : options.expires;
+    init.expires = typeof options.expires === 'number' ? new Date(Date.now() + options.expires * 864e5) : options.expires;
   }
 
   if (options.sameSite) {
-    cookieOpts.sameSite = options.sameSite.toLowerCase() as 'lax' | 'strict' | 'none';
+    init.sameSite = options.sameSite.toLowerCase() as CookieSameSite;
   }
+
+  let serialized = new Bun.Cookie(init).serialize();
 
   if (options.priority) {
-    cookieOpts.priority = options.priority.toLowerCase() as 'low' | 'medium' | 'high';
+    serialized += `; Priority=${options.priority}`;
   }
 
-  return serialize(name, value, cookieOpts);
+  return serialized;
 }
 
 export class MochiCookieJar {


### PR DESCRIPTION
## Summary
- Replace `parse`/`serialize` from the `cookie` npm package with `Bun.CookieMap` and `Bun.Cookie`
- Remove `cookie` dependency from `packages/mochi/package.json`
- One fewer runtime dependency — Bun ships these APIs natively since 1.2

## Test plan
- [x] All 16 existing cookie tests pass (`bun test packages/mochi/src/cookies.test.ts`)
- [x] Full checks pass (`bun run checks` — lint, format, typecheck, 86 tests across all workspaces)