### PR TITLE
refactor: vendor json-format-highlight, drop npm dependency

### DIFF
--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -2,7 +2,7 @@
 /**
  * Renders the markdown body for the review-bot PR comment by diffing two
  * loc-report.ts JSON outputs.
- * Usage: bun loc-comment.ts <main.json> <pr.json> [--repo <owner/repo> --run-id <id>]
+ * Usage: bun loc-comment.ts <main.json> <pr.json> [--repo <owner/repo> --run-id <id> --dep-report <dep-report.txt>]
  */
 
 import { readFileSync } from 'node:fs';
@@ -56,6 +56,10 @@ function renderPackageSection(name: string, mainReport: Report | undefined, prRe
   return [detailsTag, `<summary><strong>${name}</strong></summary>`, '', ...table, '', '</details>'];
 }
 
+function renderDepReportSection(content: string): string[] {
+  return ['#### Dependency report', '', '<details>', '<summary>Expand report</summary>', '', '```', content.trimEnd(), '```', '', '</details>'];
+}
+
 function renderInstallSection(repo: string, runId: string): string[] {
   const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
   return [
@@ -82,6 +86,8 @@ function main() {
   const repo = repoIdx !== -1 ? args[repoIdx + 1] : undefined;
   const runIdIdx = args.indexOf('--run-id');
   const runId = runIdIdx !== -1 ? args[runIdIdx + 1] : undefined;
+  const depIdx = args.indexOf('--dep-report');
+  const depReportPath = depIdx !== -1 ? args[depIdx + 1] : undefined;
 
   if (!mainPath || !prPath) {
     console.error('Usage: bun loc-comment.ts <main.json> <pr.json> [--repo <owner/repo> --run-id <id>]');
@@ -98,6 +104,16 @@ function main() {
   if (repo && runId) {
     lines.push(...renderInstallSection(repo, runId));
     lines.push('');
+  }
+
+  if (depReportPath) {
+    try {
+      const depContent = readFileSync(depReportPath, 'utf8');
+      lines.push(...renderDepReportSection(depContent));
+      lines.push('');
+    } catch {
+      // dep-report is optional — skip if the file is missing or unreadable
+    }
   }
 
   lines.push('**Lines of code** (non-blank lines)', '');

--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -57,13 +57,13 @@ function renderPackageSection(name: string, mainReport: Report | undefined, prRe
 }
 
 function renderDepReportSection(content: string): string[] {
-  return ['#### Dependency report', '', '<details>', '<summary>Expand report</summary>', '', '```', content.trimEnd(), '```', '', '</details>'];
+  return ['### Dependency report', '', '<details>', '<summary>Expand report</summary>', '', '```', content.trimEnd(), '```', '', '</details>'];
 }
 
 function renderInstallSection(repo: string, runId: string): string[] {
   const runUrl = `https://github.com/${repo}/actions/runs/${runId}`;
   return [
-    '#### Try this PR',
+    '### Try this PR',
     '',
     '<details>',
     '<summary>Expand instructions</summary>',
@@ -99,7 +99,7 @@ function main() {
 
   const allPackages = new Set([...mainDoc.packages.map((p) => p.name), ...prDoc.packages.map((p) => p.name)]);
 
-  const lines: string[] = [MARKER, '### Mochi review report', ''];
+  const lines: string[] = [MARKER, '## Mochi review report', ''];
 
   if (repo && runId) {
     lines.push(...renderInstallSection(repo, runId));
@@ -116,7 +116,7 @@ function main() {
     }
   }
 
-  lines.push('**Lines of code** (non-blank lines)', '');
+  lines.push('### Lines of code', '');
   for (const pkgName of allPackages) {
     const m = mainDoc.packages.find((p) => p.name === pkgName);
     const p = prDoc.packages.find((pp) => pp.name === pkgName);

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,6 +30,9 @@ jobs:
           (cd ../main-tree && bun .github/scripts/loc-report.ts --json) > main.json
           git worktree remove --force ../main-tree
 
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
       - name: Dependency report
         run: bun packages/mochi/scripts/dep-report.ts > dep-report.txt
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -30,6 +30,9 @@ jobs:
           (cd ../main-tree && bun .github/scripts/loc-report.ts --json) > main.json
           git worktree remove --force ../main-tree
 
+      - name: Dependency report
+        run: bun packages/mochi/scripts/dep-report.ts > dep-report.txt
+
       - name: Pack mochi-framework
         run: |
           cd packages/mochi
@@ -45,7 +48,7 @@ jobs:
           if-no-files-found: warn
 
       - name: Render comment
-        run: bun .github/scripts/loc-comment.ts main.json pr.json --repo ${{ github.repository }} --run-id ${{ github.run_id }} > comment.md
+        run: bun .github/scripts/loc-comment.ts main.json pr.json --repo ${{ github.repository }} --run-id ${{ github.run_id }} --dep-report dep-report.txt > comment.md
 
       - name: Post or update sticky comment
         uses: actions/github-script@v9

--- a/bun.lock
+++ b/bun.lock
@@ -87,7 +87,6 @@
         "deepmerge": "^4.3.1",
         "devalue": "^5.8.1",
         "js-cookie": "^3.0.7",
-        "json-format-highlight": "^1.0.4",
         "magic-string": "^0.30.21",
         "mitt": "^3.0.1",
         "nanoid": "^5.1.11",
@@ -441,8 +440,6 @@
     "js-cookie": ["js-cookie@3.0.7", "", {}, "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
-
-    "json-format-highlight": ["json-format-highlight@1.0.4", "", {}, "sha512-RqenIjKr1I99XfXPAml9G7YlEZg/GnsH7emWyWJh2yuGXqHW8spN7qx6/ME+MoIBb35/fxrMC9Jauj6nvGe4Mg=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -89,7 +89,6 @@
     "deepmerge": "^4.3.1",
     "devalue": "^5.8.1",
     "js-cookie": "^3.0.7",
-    "json-format-highlight": "^1.0.4",
     "magic-string": "^0.30.21",
     "mitt": "^3.0.1",
     "nanoid": "^5.1.11",

--- a/packages/mochi/scripts/dep-report.ts
+++ b/packages/mochi/scripts/dep-report.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env bun
-import { type Dirent, readdirSync, readFileSync, statSync } from 'node:fs';
+import { type Dirent, existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
 interface PkgJson {
@@ -31,16 +31,18 @@ async function indexPackages(): Promise<Map<string, IndexEntry>> {
     new Bun.Glob('*/node_modules/*/package.json'), // unscoped
     new Bun.Glob('*/node_modules/@*/*/package.json'), // scoped
   ];
-  for (const glob of globs) {
-    for await (const rel of glob.scan({ cwd: BUN_STORE })) {
-      const full = join(BUN_STORE, rel);
-      try {
-        const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
-        if (pkg.name && !index.has(pkg.name)) {
-          index.set(pkg.name, { pkg, dir: dirname(full) });
+  if (existsSync(BUN_STORE)) {
+    for (const glob of globs) {
+      for await (const rel of glob.scan({ cwd: BUN_STORE })) {
+        const full = join(BUN_STORE, rel);
+        try {
+          const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
+          if (pkg.name && !index.has(pkg.name)) {
+            index.set(pkg.name, { pkg, dir: dirname(full) });
+          }
+        } catch {
+          // Skip unreadable/invalid package.json files
         }
-      } catch {
-        // Skip unreadable/invalid package.json files
       }
     }
   }

--- a/packages/mochi/scripts/dep-report.ts
+++ b/packages/mochi/scripts/dep-report.ts
@@ -51,16 +51,19 @@ async function indexPackages(): Promise<Map<string, IndexEntry>> {
     new Bun.Glob('*/package.json'), // unscoped
     new Bun.Glob('@*/*/package.json'), // scoped
   ];
-  for (const glob of topGlobs) {
-    for await (const rel of glob.scan({ cwd: join(REPO_ROOT, 'node_modules') })) {
-      const full = join(REPO_ROOT, 'node_modules', rel);
-      try {
-        const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
-        if (pkg.name && !index.has(pkg.name)) {
-          index.set(pkg.name, { pkg, dir: dirname(full) });
+  const topNodeModules = join(REPO_ROOT, 'node_modules');
+  if (existsSync(topNodeModules)) {
+    for (const glob of topGlobs) {
+      for await (const rel of glob.scan({ cwd: topNodeModules })) {
+        const full = join(topNodeModules, rel);
+        try {
+          const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
+          if (pkg.name && !index.has(pkg.name)) {
+            index.set(pkg.name, { pkg, dir: dirname(full) });
+          }
+        } catch {
+          // skip
         }
-      } catch {
-        // skip
       }
     }
   }

--- a/packages/mochi/src/debug-bar/IslandRow.svelte
+++ b/packages/mochi/src/debug-bar/IslandRow.svelte
@@ -5,7 +5,7 @@
   import type { IslandInfo } from './types';
   import { formatSize } from './utils';
   import { locateIsland } from './highlight';
-  import formatHighlight from 'json-format-highlight';
+  import formatHighlight from '../vendor/json-format-highlight/index.ts';
 
   let { island }: { island: IslandInfo } = $props();
 

--- a/packages/mochi/src/types/json-format-highlight.d.ts
+++ b/packages/mochi/src/types/json-format-highlight.d.ts
@@ -1,3 +1,0 @@
-declare module 'json-format-highlight' {
-  export default function jsonFormatHighlight(json: unknown, colors?: Record<string, string>): string;
-}

--- a/packages/mochi/src/vendor/json-format-highlight/LICENSE
+++ b/packages/mochi/src/vendor/json-format-highlight/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) luyilin <luyilin12@gmail.com> (https://github.com/luyilin)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/packages/mochi/src/vendor/json-format-highlight/index.ts
+++ b/packages/mochi/src/vendor/json-format-highlight/index.ts
@@ -18,20 +18,23 @@ const entityMap = {
   '=': '&#x3D;',
 };
 
-function escapeHtml(html) {
+function escapeHtml(html: string) {
   return String(html).replace(/[&<>"'`=]/g, function (s) {
-    return entityMap[s];
+    return entityMap[s as keyof typeof entityMap];
   });
 }
 
-export default function (json, colorOptions = {}) {
+export default function (json: unknown, colorOptions = {}) {
   const valueType = typeof json;
+  let str: string;
   if (valueType !== 'string') {
-    json = JSON.stringify(json, null, 2) || valueType;
+    str = JSON.stringify(json, null, 2) || valueType;
+  } else {
+    str = json as string;
   }
   let colors = Object.assign({}, defaultColors, colorOptions);
-  json = json.replace(/&/g, '&').replace(/</g, '<').replace(/>/g, '>');
-  return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+]?\d+)?)/g, (match) => {
+  str = str.replace(/&/g, '&').replace(/</g, '<').replace(/>/g, '>');
+  return str.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+]?\d+)?)/g, (match: string) => {
     let color = colors.numberColor;
     let style = '';
     if (/^"/.test(match)) {

--- a/packages/mochi/src/vendor/json-format-highlight/index.ts
+++ b/packages/mochi/src/vendor/json-format-highlight/index.ts
@@ -1,0 +1,50 @@
+// Vendored from https://github.com/luyilin/json-format-highlight/tree/master 1.0.4
+const defaultColors = {
+  keyColor: 'dimgray',
+  numberColor: 'lightskyblue',
+  stringColor: 'lightcoral',
+  trueColor: 'lightseagreen',
+  falseColor: '#f66578',
+  nullColor: 'cornflowerblue',
+};
+
+const entityMap = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+  '`': '&#x60;',
+  '=': '&#x3D;',
+};
+
+function escapeHtml(html) {
+  return String(html).replace(/[&<>"'`=]/g, function (s) {
+    return entityMap[s];
+  });
+}
+
+export default function (json, colorOptions = {}) {
+  const valueType = typeof json;
+  if (valueType !== 'string') {
+    json = JSON.stringify(json, null, 2) || valueType;
+  }
+  let colors = Object.assign({}, defaultColors, colorOptions);
+  json = json.replace(/&/g, '&').replace(/</g, '<').replace(/>/g, '>');
+  return json.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+]?\d+)?)/g, (match) => {
+    let color = colors.numberColor;
+    let style = '';
+    if (/^"/.test(match)) {
+      if (/:$/.test(match)) {
+        color = colors.keyColor;
+      } else {
+        color = colors.stringColor;
+        match = '"' + escapeHtml(match.substr(1, match.length - 2)) + '"';
+        style = 'word-wrap:break-word;white-space:pre-wrap;';
+      }
+    } else {
+      color = /true/.test(match) ? colors.trueColor : /false/.test(match) ? colors.falseColor : /null/.test(match) ? colors.nullColor : color;
+    }
+    return `<span style="${style}color:${color}">${match}</span>`;
+  });
+}

--- a/packages/mochi/src/vendor/json-format-highlight/index.ts
+++ b/packages/mochi/src/vendor/json-format-highlight/index.ts
@@ -32,7 +32,7 @@ export default function (json: unknown, colorOptions = {}) {
   } else {
     str = json as string;
   }
-  let colors = Object.assign({}, defaultColors, colorOptions);
+  const colors = Object.assign({}, defaultColors, colorOptions);
   str = str.replace(/&/g, '&').replace(/</g, '<').replace(/>/g, '>');
   return str.replace(/("(\\u[a-zA-Z0-9]{4}|\\[^u]|[^\\"])*"(\s*:)?|\b(true|false|null)\b|-?\d+(?:\.\d*)?(?:[eE][+]?\d+)?)/g, (match: string) => {
     let color = colors.numberColor;


### PR DESCRIPTION
## Summary
- Vendors `json-format-highlight` as a TypeScript source file in `packages/mochi/src/vendor/json-format-highlight/`
- Switches the only consumer (`IslandRow.svelte` debug bar) to import from the vendored copy
- Removes the `json-format-highlight` npm dependency and its ambient type declaration

## Test plan
- [x] `bun run checks` passes (lint, format, typecheck, tests)
- [ ] Open debug bar on dev site, expand an island row — JSON props should render with syntax highlighting