### PR TITLE
fix: stray {{mochi.script}} text rendered on pages that mention the placeholder

### DIFF
--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -162,11 +162,7 @@ export class Mochi {
     const warnShim = registry.debugBarEnabled
       ? `<script>window.__mochi_warnings=[];window.__mochi_warn=function(m){console.warn("[mochi] "+m);window.__mochi_warnings.push(m)}</script>`
       : '';
-    // Single global-regex pass, not four sequential string-form `.replace`s.
-    // `.replace` never re-scans its own replacement output, so body content
-    // spliced in mid-pass is never searched for further placeholders — docs
-    // pages can show literal `{{mochi.script}}` text without it colliding with
-    // the real shell placeholder. The function-form replacer is also required
+    // Single global-regex pass. The function-form replacer is also required
     // for safety: string-form replacements interpret `$&`, `$'`, `` $` ``, `$$`
     // as special patterns, which minified JS and serialized props can contain.
     const slots: Record<'head' | 'css' | 'body' | 'script', () => string> = {

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -162,29 +162,27 @@ export class Mochi {
     const warnShim = registry.debugBarEnabled
       ? `<script>window.__mochi_warnings=[];window.__mochi_warn=function(m){console.warn("[mochi] "+m);window.__mochi_warnings.push(m)}</script>`
       : '';
-    // Use function-form replacements: string-form `.replace` interprets `$&`,
-    // `$'`, `` $` ``, `$$` in the replacement as special patterns. Minified JS
-    // and user-serialized props can legitimately contain those sequences.
-    return template
-      .replace('{{mochi.head}}', () => logLevelScript + warnShim + result.head)
-      .replace(
-        '{{mochi.css}}',
-        () =>
-          `<style>mochi-hydratable-island, mochi-server-island { display: contents; } mochi-server-island[defer-on="visible"]:empty { display: block; min-height: 1px; }${ISLAND_FAILURE_CSS}${
-            registry.development ? ISLAND_FAILURE_DEV_CSS : ''
-          }</style>\n${cssLinks}`,
-      )
-      .replace('{{mochi.body}}', () => result.body + debugInfoScript + pageEntryScript + (registry.debugBarEnabled ? '<div id="mochi-dev-toolbar"></div>' : ''))
-      .replace(
-        '{{mochi.script}}',
-        () =>
-          (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
-          serverIslandScript +
-          (opts.debugBarUrl
-            ? `<script type="module" src="${opts.debugBarUrl}"></script><script>window.__mochi_asset_prefix=${JSON.stringify(registry.assetPrefix)}</script>`
-            : '') +
-          (opts.liveReloadClientJs ? `<script>${opts.liveReloadClientJs}</script><mochi-live-reload></mochi-live-reload>` : ''),
-      );
+    // Single global-regex pass, not four sequential string-form `.replace`s.
+    // `.replace` never re-scans its own replacement output, so body content
+    // spliced in mid-pass is never searched for further placeholders — docs
+    // pages can show literal `{{mochi.script}}` text without it colliding with
+    // the real shell placeholder. The function-form replacer is also required
+    // for safety: string-form replacements interpret `$&`, `$'`, `` $` ``, `$$`
+    // as special patterns, which minified JS and serialized props can contain.
+    const slots: Record<'head' | 'css' | 'body' | 'script', () => string> = {
+      head: () => logLevelScript + warnShim + result.head,
+      css: () =>
+        `<style>mochi-hydratable-island, mochi-server-island { display: contents; } mochi-server-island[defer-on="visible"]:empty { display: block; min-height: 1px; }${ISLAND_FAILURE_CSS}${
+          registry.development ? ISLAND_FAILURE_DEV_CSS : ''
+        }</style>\n${cssLinks}`,
+      body: () => result.body + debugInfoScript + pageEntryScript + (registry.debugBarEnabled ? '<div id="mochi-dev-toolbar"></div>' : ''),
+      script: () =>
+        (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
+        serverIslandScript +
+        (opts.debugBarUrl ? `<script type="module" src="${opts.debugBarUrl}"></script><script>window.__mochi_asset_prefix=${JSON.stringify(registry.assetPrefix)}</script>` : '') +
+        (opts.liveReloadClientJs ? `<script>${opts.liveReloadClientJs}</script><mochi-live-reload></mochi-live-reload>` : ''),
+    };
+    return template.replace(/\{\{mochi\.(head|css|body|script)\}\}/g, (_match, key: keyof typeof slots) => slots[key]());
   }
 
   static async serve(options: MochiServeOptions): Promise<Server<undefined>> {

--- a/packages/mochi/src/__fixtures__/shell-placeholder/Page.svelte
+++ b/packages/mochi/src/__fixtures__/shell-placeholder/Page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  // Rendered as literal text, the way a docs page shows the placeholder name.
+  // Svelte treats `{` as an expression delimiter, so it comes from a string.
+  const placeholder = '{{mochi.script}}';
+</script>
+
+<p>Use {placeholder} in your shell.</p>

--- a/packages/mochi/src/__fixtures__/shell-placeholder/Page.svelte
+++ b/packages/mochi/src/__fixtures__/shell-placeholder/Page.svelte
@@ -2,6 +2,13 @@
   // Rendered as literal text, the way a docs page shows the placeholder name.
   // Svelte treats `{` as an expression delimiter, so it comes from a string.
   const placeholder = '{{mochi.script}}';
+
+  // `$&`, `` $` ``, `$'`, `$$` are special replacement patterns for string-form
+  // `String.prototype.replace`. Minified JS and serialized props can contain
+  // them; the function-form replacer must emit them verbatim. Body slot text
+  // flows through the replacer, so put the sequences here to exercise it.
+  const dollars = "a$&b$`c$'d$$e";
 </script>
 
 <p>Use {placeholder} in your shell.</p>
+<pre>{dollars}</pre>

--- a/packages/mochi/src/shellPlaceholder.test.ts
+++ b/packages/mochi/src/shellPlaceholder.test.ts
@@ -1,0 +1,50 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+
+// Regression: a page body that contains the literal text `{{mochi.script}}`
+// (docs pages do) used to clobber the real shell placeholder. The shell filled
+// placeholders with four sequential `.replace(string, fn)` calls; since the
+// body is injected before the script slot, `.replace` matched the in-body copy
+// and left the genuine bottom placeholder printed verbatim. The single-pass
+// regex fill must instead fill the template placeholder and leave body text be.
+describe('shell placeholders do not collide with placeholder-looking body text', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let port: number;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-shell-placeholder-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      debugBar: false,
+      outDir,
+      routes: {
+        '/': Mochi.page(path.join(import.meta.dir, '__fixtures__', 'shell-placeholder', 'Page.svelte')),
+      },
+    });
+    if (server.port == null) {
+      throw new Error('server.port not set');
+    }
+    port = server.port;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('literal body text survives and the real placeholder is filled', async () => {
+    const html = await (await fetch(`http://localhost:${port}/`)).text();
+
+    // The literal text from the component body is preserved verbatim.
+    expect(html).toContain('Use {{mochi.script}} in your shell.');
+
+    // The genuine shell placeholder before </body> is gone (filled, not printed).
+    expect(html).not.toMatch(/\{\{mochi\.script\}\}\s*<\/body>/);
+  });
+});

--- a/packages/mochi/src/shellPlaceholder.test.ts
+++ b/packages/mochi/src/shellPlaceholder.test.ts
@@ -47,4 +47,16 @@ describe('shell placeholders do not collide with placeholder-looking body text',
     // The genuine shell placeholder before </body> is gone (filled, not printed).
     expect(html).not.toMatch(/\{\{mochi\.script\}\}\s*<\/body>/);
   });
+
+  // `$&`, `` $` ``, `$'`, `$$` are special-pattern sequences that string-form
+  // `.replace(str, replacement)` would interpret. The function-form replacer
+  // must emit slot content (minified JS, serialized props, plain body text)
+  // verbatim — this guards against a regression that swaps it for string form.
+  test('special replacement sequences in body text are emitted verbatim', async () => {
+    const html = await (await fetch(`http://localhost:${port}/`)).text();
+    // The `&` is HTML-escaped to `&amp;` (orthogonal to the replace concern);
+    // every `$`-sequence is otherwise untouched. A string-form replacement
+    // would expand `$&`/`` $` ``/`$'`/`$$` against the matched placeholder.
+    expect(html).toContain("a$&amp;b$`c$'d$$e");
+  });
 });


### PR DESCRIPTION
## Problem

On docs pages that mention the literal text `{{mochi.script}}` in their content (e.g. `/docs/extensions/` and `/docs/custom-html-shell/`), a stray `{{mochi.script}}` string was printed at the bottom of the page instead of the placeholder being filled with the hydration / live-reload scripts.

## Root cause

`Mochi.resolveHtmlShell()` filled the four shell placeholders with **four sequential `String.prototype.replace(string, fn)` calls**, each of which matches only the **first** occurrence. The order was head → css → body → script, and the shell has `{{mochi.body}}` before `{{mochi.script}}`.

By the time the script replacement ran, the rendered markdown body had already been spliced in. Those pages render the literal text `` `{{mochi.script}}` `` (inside inline `<code>`), which sits earlier in the document than the real shell placeholder — so `.replace('{{mochi.script}}', …)` matched the in-body copy and replaced *that*, leaving the genuine bottom placeholder printed verbatim.

This affected **only** `{{mochi.script}}`, since it's the one placeholder resolved *after* the body is injected.

## Fix

Fill all placeholders in a **single global-regex pass** keyed off a slot map. `String.prototype.replace` never re-scans its own replacement output, so body content spliced in mid-pass is never searched for further placeholders — eliminating the whole class of "in-body text collides with a placeholder" bug, not just body-vs-script. The function-form replacer is retained, preserving the existing `$&`/`$'`/`` $` ``/`$$` special-pattern safety.

## Verification

- Reproduced on `/docs/extensions/` and `/docs/custom-html-shell/`; after the fix the closing `</body>` is preceded by real `<mochi-live-reload>` output and the in-prose `{{mochi.script}}` text is preserved inside `<code>`.
- Home page still ships its hydration bootstrap and island markers.
- Added a regression test (`packages/mochi/src/shellPlaceholder.test.ts`) that serves a page whose body contains the literal `{{mochi.script}}` and asserts both that the literal survives and that the real placeholder is filled. Confirmed it fails without the fix.
- `bun run typecheck` and the new test pass.