### PR TITLE
feat: add automatic HEAD request support for all route types

### DIFF
--- a/packages/docs/40-defining-routes.md
+++ b/packages/docs/40-defining-routes.md
@@ -168,6 +168,16 @@ await Mochi.serve({
 
 Do **NOT** forget `onClose` cleanup when you allocate per-connection resources; instead, register a teardown so timers/subscriptions don't leak when the client disconnects.
 
+### HEAD requests
+
+Every `Mochi.page` and `Mochi.api` route answers `HEAD` automatically by running its `GET`/handler logic and stripping the response body. Status and headers match the equivalent `GET`, and `Content-Length` is set to the byte length the `GET` body would have had. No per-route opt-in is needed — this also covers static assets and the `404` fallback.
+
+`Mochi.sse` answers `HEAD` with the event-stream headers and an empty body **without** opening a stream or invoking your handler, so uptime checks can probe the endpoint cheaply. `Mochi.ws` routes are upgrade-only and do not handle `HEAD`.
+
+```sh
+curl -sI http://localhost:3333/        # 200, Content-Type + Content-Length, no body
+```
+
 ### Static files
 
 Files under `./public` are served automatically; no route entry is needed. A user-defined route always wins over a same-path public file. See `Serve options` for `publicDir`.

--- a/packages/docs/40-defining-routes.md
+++ b/packages/docs/40-defining-routes.md
@@ -4,6 +4,10 @@ slug: defining-routes
 description: 'Register pages, APIs, WebSockets, and SSE endpoints using the programmatic routes record.'
 ---
 
+<script>
+  import Callout from './_components/Callout.svelte';
+</script>
+
 ## Defining routes
 
 Routes are a `Record<string, MochiRouteValue>` passed to `Mochi.serve({ routes })`. Each key is a Bun router pattern; each value is built from one of the four `Mochi.*` helpers.
@@ -172,11 +176,9 @@ Do **NOT** forget `onClose` cleanup when you allocate per-connection resources; 
 
 Every `Mochi.page` and `Mochi.api` route answers `HEAD` automatically by running its `GET`/handler logic and stripping the response body. Status and headers match the equivalent `GET`, and `Content-Length` is set to the byte length the `GET` body would have had. No per-route opt-in is needed — this also covers static assets and the `404` fallback.
 
-`Mochi.sse` is GET-only: a `HEAD` is answered with `405 Method Not Allowed` (`Allow: GET`) without opening a stream, since a body-less probe of a stream endpoint can't reflect the real headers or run the same auth/observability path. `Mochi.ws` routes are upgrade-only and likewise do not handle `HEAD`.
-
-```sh
-curl -sI http://localhost:3333/        # 200, Content-Type + Content-Length, no body
-```
+<Callout type="info">
+  `Mochi.sse` is GET-only: a `HEAD` is answered with `405 Method Not Allowed` (`Allow: GET`) without opening a stream, since a body-less probe of a stream endpoint can't reflect the real headers or run the same auth/observability path. `Mochi.ws` routes are upgrade-only and likewise do not handle `HEAD`.
+</Callout>
 
 ### Static files
 

--- a/packages/docs/40-defining-routes.md
+++ b/packages/docs/40-defining-routes.md
@@ -172,7 +172,7 @@ Do **NOT** forget `onClose` cleanup when you allocate per-connection resources; 
 
 Every `Mochi.page` and `Mochi.api` route answers `HEAD` automatically by running its `GET`/handler logic and stripping the response body. Status and headers match the equivalent `GET`, and `Content-Length` is set to the byte length the `GET` body would have had. No per-route opt-in is needed — this also covers static assets and the `404` fallback.
 
-`Mochi.sse` answers `HEAD` with the event-stream headers and an empty body **without** opening a stream or invoking your handler, so uptime checks can probe the endpoint cheaply. `Mochi.ws` routes are upgrade-only and do not handle `HEAD`.
+`Mochi.sse` is GET-only: a `HEAD` is answered with `405 Method Not Allowed` (`Allow: GET`) without opening a stream, since a body-less probe of a stream endpoint can't reflect the real headers or run the same auth/observability path. `Mochi.ws` routes are upgrade-only and likewise do not handle `HEAD`.
 
 ```sh
 curl -sI http://localhost:3333/        # 200, Content-Type + Content-Length, no body

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -758,7 +758,20 @@ export class Mochi {
           if ('earlyResponse' in setup) {
             return setup.earlyResponse;
           }
-          const { ctx: wsHookCtx, start, url: wsUrl, params: wsParams } = setup;
+          const { ctx: wsHookCtx, start, requestId: wsRequestId, url: wsUrl, params: wsParams } = setup;
+          const wsPath = wsUrl.pathname + wsUrl.search;
+          // A non-upgrade request (e.g. a HEAD probe or plain GET) never becomes
+          // a socket, so it never emits `ws:open`.
+          const emitWsReject = (status: number): void => {
+            mochiEvents.emit('request', {
+              requestId: wsRequestId,
+              kind: 'error',
+              method: req.method,
+              path: wsPath,
+              status,
+              duration: performance.now() - start,
+            });
+          };
           requestContext.run(wsHookCtx, () => {
             runHook('route:matched', {
               pattern,
@@ -774,6 +787,7 @@ export class Mochi {
           if (liveWsHandlers.upgrade) {
             const result = await liveWsHandlers.upgrade(req, wsParams);
             if (result === false) {
+              emitWsReject(400);
               return new Response('WebSocket upgrade rejected', {
                 status: 400,
               });
@@ -789,16 +803,17 @@ export class Mochi {
             data: {
               __mochiRoutePattern: pattern,
               __mochiOpenedAt: performance.now(),
-              __mochiPath: wsUrl.pathname + wsUrl.search,
+              __mochiPath: wsPath,
               user: userData,
             } satisfies MochiWsData,
           });
 
           if (!success) {
+            emitWsReject(500);
             return new Response('WebSocket upgrade failed', { status: 500 });
           }
           mochiEvents.emit('ws:open', {
-            path: wsUrl.pathname + wsUrl.search,
+            path: wsPath,
             duration: performance.now() - start,
           });
           return undefined;
@@ -811,19 +826,25 @@ export class Mochi {
         const capturedSseHandler = handler.handler;
 
         const bunRouteValue: BunRouteValue = async (req: Request, server: Server<undefined>): Promise<Response> => {
-          // SSE streams are GET-only. HEAD is not supported: answering it would
-          // mean either opening a stream (defeats the point of a body-less probe)
-          // or hand-rolling headers/auth/observability that diverge from the real
-          // GET path. Reject it cleanly instead so none of that drifts.
-          if (req.method === 'HEAD') {
-            return new Response(null, { status: 405, headers: { Allow: 'GET' } });
-          }
           const setup = buildRequestContext(req, server, { kind: 'sse', pattern });
           if ('earlyResponse' in setup) {
             return setup.earlyResponse;
           }
-          const { ctx: sseHookCtx, url, params: sseParams } = setup;
+          const { ctx: sseHookCtx, start: sseStart, requestId: sseRequestId, url, params: sseParams } = setup;
           const path = url.pathname + url.search;
+          // SSE streams are GET-only. HEAD is not supported: answering it would
+          // mean either opening a stream (defeats the point of a body-less probe)
+          if (req.method === 'HEAD') {
+            mochiEvents.emit('request', {
+              requestId: sseRequestId,
+              kind: 'error',
+              method: req.method,
+              path,
+              status: 405,
+              duration: performance.now() - sseStart,
+            });
+            return new Response(null, { status: 405, headers: { Allow: 'GET' } });
+          }
           requestContext.run(sseHookCtx, () => {
             runHook('route:matched', {
               pattern,

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -33,7 +33,7 @@ import { isEnhanceRequest, jsonError, jsonFailure, jsonRedirect, jsonSuccess } f
 import { csrfCheck, DEFAULT_FORM_CONTENT_TYPES, DEFAULT_PROTECTED_METHODS } from './csrf';
 import { applyFilter, initExtensions, runHook } from './extensions';
 import { buildPublicUrl } from './proxy';
-import { apiError, collectHeaderPairs, isHtmlResponse, MochiHttpError } from './utils';
+import { apiError, collectHeaderPairs, headResponse, isHtmlResponse, MochiHttpError, withHead } from './utils';
 import type { MochiEvent, MochiEventKind, MochiResolveOptions } from './hooks';
 import { applyResolveOptions } from './hooks';
 import { alternateSlashPattern, trailingSlashRedirect } from './trailingSlash';
@@ -687,14 +687,14 @@ export class Mochi {
             });
 
           return {
-            bunRouteValue: {
+            bunRouteValue: withHead({
               GET: getHandler,
               POST: postHandler,
-            } as unknown as BunRouteValue,
+            } as unknown as BunRouteValue),
             type: 'page',
           };
         }
-        return { bunRouteValue: getHandler, type: 'page' };
+        return { bunRouteValue: withHead(getHandler), type: 'page' };
       } else if (isMochiApi(handler)) {
         if (apiHandlerMap) {
           apiHandlerMap.set(pattern, handler.handler);
@@ -748,7 +748,7 @@ export class Mochi {
             return final;
           });
         };
-        return { bunRouteValue, type: 'api' };
+        return { bunRouteValue: withHead(bunRouteValue), type: 'api' };
       } else if (isMochiWs(handler)) {
         const wsHandlers = handler.handlers;
         wsHandlersMap.set(pattern, wsHandlers);
@@ -814,6 +814,18 @@ export class Mochi {
           const setup = buildRequestContext(req, server, { kind: 'sse', pattern });
           if ('earlyResponse' in setup) {
             return setup.earlyResponse;
+          }
+          // HEAD probes the endpoint without opening a stream: return the
+          // event-stream headers with no body, and crucially skip the handler
+          // (no sse:open, no user callback).
+          if (req.method === 'HEAD') {
+            return new Response(null, {
+              headers: {
+                'Content-Type': 'text/event-stream',
+                'Cache-Control': 'no-cache',
+                Connection: 'keep-alive',
+              },
+            });
           }
           const { ctx: sseHookCtx, url, params: sseParams } = setup;
           const path = url.pathname + url.search;
@@ -933,7 +945,7 @@ export class Mochi {
     }
 
     // Register server island endpoint
-    bunRoutes[`${registry.assetPrefix}/island/:componentName`] = async (req: Request, server: Server<undefined>): Promise<Response> => {
+    bunRoutes[`${registry.assetPrefix}/island/:componentName`] = withHead(async (req: Request, server: Server<undefined>): Promise<Response> => {
       const setup = buildRequestContext(req, server, {
         kind: 'island',
         pattern: `${registry.assetPrefix}/island/:componentName`,
@@ -1039,7 +1051,7 @@ export class Mochi {
           },
         });
       });
-    };
+    });
 
     if (process.env.MOCHI_MEMORY_PROBE === '1') {
       bunRoutes['/__mochi/health/memory'] = (): Response => {
@@ -1129,6 +1141,9 @@ export class Mochi {
         status: response.status,
         duration: performance.now() - start,
       });
+      if (req.method === 'HEAD') {
+        return headResponse(response);
+      }
       return response;
     };
 

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -811,21 +811,16 @@ export class Mochi {
         const capturedSseHandler = handler.handler;
 
         const bunRouteValue: BunRouteValue = async (req: Request, server: Server<undefined>): Promise<Response> => {
+          // SSE streams are GET-only. HEAD is not supported: answering it would
+          // mean either opening a stream (defeats the point of a body-less probe)
+          // or hand-rolling headers/auth/observability that diverge from the real
+          // GET path. Reject it cleanly instead so none of that drifts.
+          if (req.method === 'HEAD') {
+            return new Response(null, { status: 405, headers: { Allow: 'GET' } });
+          }
           const setup = buildRequestContext(req, server, { kind: 'sse', pattern });
           if ('earlyResponse' in setup) {
             return setup.earlyResponse;
-          }
-          // HEAD probes the endpoint without opening a stream: return the
-          // event-stream headers with no body, and crucially skip the handler
-          // (no sse:open, no user callback).
-          if (req.method === 'HEAD') {
-            return new Response(null, {
-              headers: {
-                'Content-Type': 'text/event-stream',
-                'Cache-Control': 'no-cache',
-                Connection: 'keep-alive',
-              },
-            });
           }
           const { ctx: sseHookCtx, url, params: sseParams } = setup;
           const path = url.pathname + url.search;

--- a/packages/mochi/src/head.dev.test.ts
+++ b/packages/mochi/src/head.dev.test.ts
@@ -1,27 +1,34 @@
 // In dev mode every page is registered as a method-keyed Bun route object
 // (because pageConfigMap is populated for live reload), so this guards that a
 // plain page still answers HEAD with 200 rather than Bun's 405 for an unlisted
-// method. Separate file because only one Mochi.serve() is allowed per process.
+// method. Dev mode also scans publicDir live (production reads the prebuilt
+// manifest), so this is where the public-file HEAD case is covered. Separate
+// file because only one Mochi.serve() is allowed per process.
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import type { Server } from 'bun';
 import { Mochi } from './Mochi';
 
 const FIXTURE_PAGE = path.join(import.meta.dir, '__fixtures__', 'css-imports', 'Page.svelte');
+const ROBOTS_BODY = 'User-agent: *\nDisallow:\n';
 
 describe('HEAD requests (development)', () => {
   let server: Server<undefined>;
   let outDir: string;
+  let publicDir: string;
   let base: string;
 
   beforeAll(async () => {
     outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-head-dev-'));
+    publicDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-head-dev-public-'));
+    writeFileSync(path.join(publicDir, 'robots.txt'), ROBOTS_BODY);
     server = await Mochi.serve({
       port: 0,
       development: true,
       logger: { enabled: false },
       outDir,
+      publicDir,
       routes: { '/': Mochi.page(FIXTURE_PAGE) },
     });
     base = `http://localhost:${server.port}`;
@@ -30,11 +37,24 @@ describe('HEAD requests (development)', () => {
   afterAll(() => {
     server.stop(true);
     rmSync(outDir, { recursive: true, force: true });
+    rmSync(publicDir, { recursive: true, force: true });
   });
 
   test('plain page in dev mode answers HEAD with 200, not 405', async () => {
     const head = await fetch(`${base}/`, { method: 'HEAD' });
     expect(head.status).toBe(200);
+    expect(await head.text()).toBe('');
+  });
+
+  test('public file: HEAD mirrors GET status/headers with an empty body and matching Content-Length', async () => {
+    const get = await fetch(`${base}/robots.txt`);
+    expect(get.status).toBe(200);
+    expect(await get.text()).toBe(ROBOTS_BODY);
+
+    const head = await fetch(`${base}/robots.txt`, { method: 'HEAD' });
+    expect(head.status).toBe(200);
+    expect(head.headers.get('Content-Type')).toBe(get.headers.get('Content-Type'));
+    expect(head.headers.get('Content-Length')).toBe(String(Buffer.byteLength(ROBOTS_BODY, 'utf8')));
     expect(await head.text()).toBe('');
   });
 });

--- a/packages/mochi/src/head.dev.test.ts
+++ b/packages/mochi/src/head.dev.test.ts
@@ -1,0 +1,40 @@
+// In dev mode every page is registered as a method-keyed Bun route object
+// (because pageConfigMap is populated for live reload), so this guards that a
+// plain page still answers HEAD with 200 rather than Bun's 405 for an unlisted
+// method. Separate file because only one Mochi.serve() is allowed per process.
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+
+const FIXTURE_PAGE = path.join(import.meta.dir, '__fixtures__', 'css-imports', 'Page.svelte');
+
+describe('HEAD requests (development)', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-head-dev-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: true,
+      logger: { enabled: false },
+      outDir,
+      routes: { '/': Mochi.page(FIXTURE_PAGE) },
+    });
+    base = `http://localhost:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('plain page in dev mode answers HEAD with 200, not 405', async () => {
+    const head = await fetch(`${base}/`, { method: 'HEAD' });
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe('');
+  });
+});

--- a/packages/mochi/src/head.test.ts
+++ b/packages/mochi/src/head.test.ts
@@ -33,6 +33,7 @@ describe('HEAD requests', () => {
         '/sse': Mochi.sse((stream) => {
           stream.send('hello');
         }),
+        '/ws': Mochi.ws({ message() {} }),
       },
     });
     base = `http://localhost:${server.port}`;
@@ -78,12 +79,17 @@ describe('HEAD requests', () => {
     expect(await head.text()).toBe('');
   });
 
-  test('sse: HEAD is not supported — returns 405 Allow: GET without opening a stream', async () => {
+  test('sse: HEAD is not supported — returns 405 Allow: GET, emits a request event, and does not open a stream', async () => {
     let opened = false;
     const onOpen = (): void => {
       opened = true;
     };
+    const requests: Array<{ method: string; path: string; status: number }> = [];
+    const onRequest = (e: { method: string; path: string; status: number }): void => {
+      requests.push(e);
+    };
     mochiEvents.on('sse:open', onOpen);
+    mochiEvents.on('request', onRequest);
     try {
       const head = await fetch(`${base}/sse`, { method: 'HEAD' });
       expect(head.status).toBe(405);
@@ -91,7 +97,24 @@ describe('HEAD requests', () => {
       expect(await head.text()).toBe('');
     } finally {
       mochiEvents.off('sse:open', onOpen);
+      mochiEvents.off('request', onRequest);
     }
     expect(opened).toBe(false);
+    expect(requests).toContainEqual(expect.objectContaining({ method: 'HEAD', path: '/sse', status: 405 }));
+  });
+
+  test('ws: a non-upgrade request fails the upgrade (500) and emits a request event', async () => {
+    const requests: Array<{ method: string; path: string; status: number }> = [];
+    const onRequest = (e: { method: string; path: string; status: number }): void => {
+      requests.push(e);
+    };
+    mochiEvents.on('request', onRequest);
+    try {
+      const res = await fetch(`${base}/ws`);
+      expect(res.status).toBe(500);
+    } finally {
+      mochiEvents.off('request', onRequest);
+    }
+    expect(requests).toContainEqual(expect.objectContaining({ method: 'GET', path: '/ws', status: 500 }));
   });
 });

--- a/packages/mochi/src/head.test.ts
+++ b/packages/mochi/src/head.test.ts
@@ -1,0 +1,97 @@
+// Boots a real Mochi.serve() and fires HEAD requests end-to-end to lock in that
+// HEAD reuses GET/handler logic while returning an empty body. Only one
+// Mochi.serve() is allowed per process, so the dev-mode case lives in
+// head.dev.test.ts and the trailing-slash case in trailingSlash.never.test.ts.
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+import { mochiEvents } from './events';
+import { success } from './forms';
+
+const FIXTURE_PAGE = path.join(import.meta.dir, '__fixtures__', 'css-imports', 'Page.svelte');
+
+describe('HEAD requests', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-head-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      routes: {
+        '/': Mochi.page(FIXTURE_PAGE),
+        '/with-action': Mochi.page(FIXTURE_PAGE, {
+          actions: { default: () => success({}) },
+        }),
+        '/api/ping': Mochi.api(({ method }) => Response.json({ method })),
+        '/sse': Mochi.sse((stream) => {
+          stream.send('hello');
+        }),
+      },
+    });
+    base = `http://localhost:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('plain page: HEAD mirrors GET status/headers with an empty body and matching Content-Length', async () => {
+    const get = await fetch(`${base}/`);
+    const getBody = await get.text();
+    expect(get.status).toBe(200);
+
+    const head = await fetch(`${base}/`, { method: 'HEAD' });
+    expect(head.status).toBe(200);
+    expect(head.headers.get('Content-Type')).toBe(get.headers.get('Content-Type'));
+    expect(await head.text()).toBe('');
+    expect(head.headers.get('Content-Length')).toBe(String(Buffer.byteLength(getBody, 'utf8')));
+  });
+
+  test('page with form actions: HEAD is 200, not 405 (method-keyed route object)', async () => {
+    const head = await fetch(`${base}/with-action`, { method: 'HEAD' });
+    expect(head.status).toBe(200);
+    expect(await head.text()).toBe('');
+  });
+
+  test('api route: HEAD mirrors GET status/headers with an empty body', async () => {
+    const get = await fetch(`${base}/api/ping`);
+    expect(get.status).toBe(200);
+    expect(get.headers.get('Content-Type')).toContain('application/json');
+
+    const head = await fetch(`${base}/api/ping`, { method: 'HEAD' });
+    expect(head.status).toBe(200);
+    expect(head.headers.get('Content-Type')).toContain('application/json');
+    expect(await head.text()).toBe('');
+  });
+
+  test('404: HEAD returns 404 with an empty body (composedFetch path)', async () => {
+    const head = await fetch(`${base}/does-not-exist`, { method: 'HEAD' });
+    expect(head.status).toBe(404);
+    expect(await head.text()).toBe('');
+  });
+
+  test('sse: HEAD returns event-stream headers, empty body, and does not open a stream', async () => {
+    let opened = false;
+    const onOpen = (): void => {
+      opened = true;
+    };
+    mochiEvents.on('sse:open', onOpen);
+    try {
+      const head = await fetch(`${base}/sse`, { method: 'HEAD' });
+      expect(head.status).toBe(200);
+      expect(head.headers.get('Content-Type')).toBe('text/event-stream');
+      expect(await head.text()).toBe('');
+    } finally {
+      mochiEvents.off('sse:open', onOpen);
+    }
+    expect(opened).toBe(false);
+  });
+});

--- a/packages/mochi/src/head.test.ts
+++ b/packages/mochi/src/head.test.ts
@@ -78,7 +78,7 @@ describe('HEAD requests', () => {
     expect(await head.text()).toBe('');
   });
 
-  test('sse: HEAD returns event-stream headers, empty body, and does not open a stream', async () => {
+  test('sse: HEAD is not supported — returns 405 Allow: GET without opening a stream', async () => {
     let opened = false;
     const onOpen = (): void => {
       opened = true;
@@ -86,8 +86,8 @@ describe('HEAD requests', () => {
     mochiEvents.on('sse:open', onOpen);
     try {
       const head = await fetch(`${base}/sse`, { method: 'HEAD' });
-      expect(head.status).toBe(200);
-      expect(head.headers.get('Content-Type')).toBe('text/event-stream');
+      expect(head.status).toBe(405);
+      expect(head.headers.get('Allow')).toBe('GET');
       expect(await head.text()).toBe('');
     } finally {
       mochiEvents.off('sse:open', onOpen);

--- a/packages/mochi/src/trailingSlash.never.test.ts
+++ b/packages/mochi/src/trailingSlash.never.test.ts
@@ -60,4 +60,11 @@ describe('trailingSlash: "never"', () => {
     const res = await fetch(`${base}/`, { redirect: 'manual' });
     expect(res.status).toBe(200);
   });
+
+  test('HEAD trailing-slash form 301s to canonical with an empty body', async () => {
+    const res = await fetch(`${base}/about/`, { method: 'HEAD', redirect: 'manual' });
+    expect(res.status).toBe(301);
+    expect(res.headers.get('Location')).toBe('/about');
+    expect(await res.text()).toBe('');
+  });
 });

--- a/packages/mochi/src/utils.test.ts
+++ b/packages/mochi/src/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import type { Server } from 'bun';
+import type { BunRouteValue } from './types';
 import { DEFAULT_ASSET_PREFIX, headResponse, negotiate, normalizeAssetPrefix, normalizeIslandHydrationMarkers, stripHydrationMarkers, toPosixPath, withHead } from './utils';
 
 describe('negotiate', () => {
@@ -213,5 +214,15 @@ describe('withHead', () => {
     const HEAD = () => new Response(null);
     const wrapped = withHead({ GET, HEAD }) as Record<string, unknown>;
     expect(wrapped.HEAD).toBe(HEAD);
+  });
+
+  test('BunFile arm: returned untouched (Bun serves its HEAD natively)', () => {
+    const file = Bun.file('package.json');
+    expect(withHead(file as unknown as BunRouteValue)).toBe(file);
+  });
+
+  test('Response arm: returned untouched', () => {
+    const res = new Response('static');
+    expect(withHead(res as unknown as BunRouteValue)).toBe(res);
   });
 });

--- a/packages/mochi/src/utils.test.ts
+++ b/packages/mochi/src/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'bun:test';
-import { DEFAULT_ASSET_PREFIX, negotiate, normalizeAssetPrefix, normalizeIslandHydrationMarkers, stripHydrationMarkers, toPosixPath } from './utils';
+import type { Server } from 'bun';
+import { DEFAULT_ASSET_PREFIX, headResponse, negotiate, normalizeAssetPrefix, normalizeIslandHydrationMarkers, stripHydrationMarkers, toPosixPath, withHead } from './utils';
 
 describe('negotiate', () => {
   const types = ['application/json', 'text/html'];
@@ -134,5 +135,83 @@ describe('toPosixPath', () => {
   test('is idempotent', () => {
     const once = toPosixPath('C:\\a\\b');
     expect(toPosixPath(once)).toBe(once);
+  });
+});
+
+describe('headResponse', () => {
+  test('preserves status, statusText, and headers but empties the body', async () => {
+    const src = new Response('hello world', {
+      status: 201,
+      statusText: 'Created',
+      headers: { 'Content-Type': 'text/plain', 'X-Custom': 'abc' },
+    });
+    const head = await headResponse(src);
+    expect(head.status).toBe(201);
+    expect(head.statusText).toBe('Created');
+    expect(head.headers.get('Content-Type')).toBe('text/plain');
+    expect(head.headers.get('X-Custom')).toBe('abc');
+    expect(await head.text()).toBe('');
+  });
+
+  test('sets Content-Length to the finite body byte length', async () => {
+    const body = 'héllo'; // multi-byte char → byte length differs from char length
+    const head = await headResponse(new Response(body, { headers: { 'Content-Type': 'text/plain' } }));
+    expect(head.headers.get('Content-Length')).toBe(String(Buffer.byteLength(body, 'utf8')));
+    expect(await head.text()).toBe('');
+  });
+
+  test('does not consume a text/event-stream body', async () => {
+    // A never-ending stream: if headResponse buffered it, this test would hang.
+    const stream = new ReadableStream<Uint8Array>({
+      start() {
+        // intentionally never enqueue or close
+      },
+    });
+    const head = await headResponse(new Response(stream, { headers: { 'Content-Type': 'text/event-stream' } }));
+    expect(head.status).toBe(200);
+    expect(head.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(head.headers.get('Content-Length')).toBeNull();
+    expect(head.body).toBeNull();
+  });
+});
+
+describe('withHead', () => {
+  const server = {} as Server<undefined>;
+  const get = (url: string, method: string) => new Request(url, { method });
+
+  test('function arm: strips body only for HEAD, passes GET through unchanged', async () => {
+    const wrapped = withHead(() => new Response('payload', { headers: { 'Content-Type': 'text/plain' } }));
+    if (typeof wrapped !== 'function') {
+      throw new Error('expected a function');
+    }
+    const getRes = await wrapped(get('http://x/', 'GET'), server);
+    expect(await getRes.text()).toBe('payload');
+
+    const headRes = await wrapped(get('http://x/', 'HEAD'), server);
+    expect(headRes.status).toBe(200);
+    expect(await headRes.text()).toBe('');
+    expect(headRes.headers.get('Content-Type')).toBe('text/plain');
+  });
+
+  test('object arm: adds a HEAD entry that runs GET', async () => {
+    type Fn = (req: Request, server: Server<undefined>) => Response | Promise<Response>;
+    const GET: Fn = () => new Response('page', { headers: { 'Content-Type': 'text/html' } });
+    const POST: Fn = () => new Response('posted');
+    const wrapped = withHead({ GET, POST }) as Record<string, Fn | undefined>;
+    expect(typeof wrapped.HEAD).toBe('function');
+    expect(wrapped.GET).toBe(GET);
+    expect(wrapped.POST).toBe(POST);
+
+    const headRes = await wrapped.HEAD!(get('http://x/', 'HEAD'), server);
+    expect(headRes.status).toBe(200);
+    expect(await headRes.text()).toBe('');
+    expect(headRes.headers.get('Content-Type')).toBe('text/html');
+  });
+
+  test('object arm: leaves an existing HEAD entry untouched', () => {
+    const GET = () => new Response('g');
+    const HEAD = () => new Response(null);
+    const wrapped = withHead({ GET, HEAD }) as Record<string, unknown>;
+    expect(wrapped.HEAD).toBe(HEAD);
   });
 });

--- a/packages/mochi/src/utils.ts
+++ b/packages/mochi/src/utils.ts
@@ -290,6 +290,7 @@ type RouteFn = (req: Request, server: Server<undefined>) => Response | Promise<R
  * is stripped only when the method is HEAD; a method-keyed object gains a `HEAD`
  * entry that runs `GET` (Bun would otherwise 405 an unlisted HEAD). Other shapes
  * (`Response`, `BunFile`) are returned untouched — Bun serves their HEAD itself.
+ * `BunFile` is detected via `instanceof Blob` (Bun's file handle subclasses it).
  */
 export function withHead(value: BunRouteValue): BunRouteValue {
   if (typeof value === 'function') {
@@ -299,7 +300,7 @@ export function withHead(value: BunRouteValue): BunRouteValue {
       return req.method === 'HEAD' ? headResponse(res) : res;
     };
   }
-  if (value && typeof value === 'object' && !(value instanceof Response) && !('size' in value)) {
+  if (value && typeof value === 'object' && !(value instanceof Response) && !(value instanceof Blob)) {
     const rec = value as Record<string, RouteFn>;
     const get = rec.GET;
     if (get && !rec.HEAD) {

--- a/packages/mochi/src/utils.ts
+++ b/packages/mochi/src/utils.ts
@@ -1,5 +1,7 @@
+import type { Server } from 'bun';
 import Negotiator from 'negotiator';
 import type { MochiCompileErrorLog } from './events';
+import type { BunRouteValue } from './types';
 
 /**
  * Given an Accept header value and a list of candidate content types, return
@@ -261,4 +263,48 @@ export function toCompileErrorLogs(
     }
     return entry;
   });
+}
+
+/**
+ * Body-less clone of a `Response` for answering a HEAD request: same status,
+ * statusText, and headers, but no body. Finite bodies are buffered once so the
+ * `Content-Length` matches what the equivalent GET would have sent. Streaming
+ * bodies (`text/event-stream`) are never consumed — they would never end — so
+ * their length is left unset.
+ */
+export async function headResponse(res: Response): Promise<Response> {
+  const headers = new Headers(res.headers);
+  const isStream = (headers.get('content-type') ?? '').includes('text/event-stream');
+  if (!isStream && res.body) {
+    const buf = await res.arrayBuffer();
+    headers.set('Content-Length', String(buf.byteLength));
+  }
+  return new Response(null, { status: res.status, statusText: res.statusText, headers });
+}
+
+type RouteFn = (req: Request, server: Server<undefined>) => Response | Promise<Response>;
+
+/**
+ * Wrap a page/api `BunRouteValue` so HEAD reuses the GET/handler logic but
+ * returns no body. A single function is invoked for every method and its result
+ * is stripped only when the method is HEAD; a method-keyed object gains a `HEAD`
+ * entry that runs `GET` (Bun would otherwise 405 an unlisted HEAD). Other shapes
+ * (`Response`, `BunFile`) are returned untouched — Bun serves their HEAD itself.
+ */
+export function withHead(value: BunRouteValue): BunRouteValue {
+  if (typeof value === 'function') {
+    const fn = value as RouteFn;
+    return async (req, server) => {
+      const res = await fn(req, server);
+      return req.method === 'HEAD' ? headResponse(res) : res;
+    };
+  }
+  if (value && typeof value === 'object' && !(value instanceof Response) && !('size' in value)) {
+    const rec = value as Record<string, RouteFn>;
+    const get = rec.GET;
+    if (get && !rec.HEAD) {
+      return { ...rec, HEAD: async (req, server) => headResponse(await get(req, server)) };
+    }
+  }
+  return value;
 }


### PR DESCRIPTION
## Summary

- `Mochi.page` and `Mochi.api` routes now respond to `HEAD` — runs GET/handler logic, strips body, sets accurate `Content-Length`
- Pages registered as method-keyed Bun route objects (with `actions` or in dev mode) no longer return 405 for HEAD
- `Mochi.sse` short-circuits HEAD: returns event-stream headers + empty body without opening a stream or invoking the user handler
- Asset bundles, `userFetch` fallback, and 404s in `composedFetch` also strip the body for HEAD
- `Bun.file` static routes unchanged — Bun handles HEAD natively for those

## Test plan

- [ ] `head.test.ts` — integration: plain page, action page, api, sse, 404
- [ ] `head.dev.test.ts` — dev-mode page (method-keyed object, regression for 405)
- [ ] `trailingSlash.never.test.ts` — HEAD + redirect returns 301 + empty body
- [ ] `utils.test.ts` — unit: `headResponse` and `withHead` helpers