### PR TITLE
fix(mochi-framework): surface svelte-shaker failures and point users at its tracker

### DIFF
--- a/packages/mochi/src/ComponentRegistry.shakeFallback.test.ts
+++ b/packages/mochi/src/ComponentRegistry.shakeFallback.test.ts
@@ -16,8 +16,9 @@ function shakenSources(registry: InstanceType<typeof ComponentRegistry>): Map<st
 }
 
 describe('ComponentRegistry.prepareShake (failure fallback)', () => {
-  test('falls back to an empty cache and warns when the shake throws', async () => {
-    const warn = spyOn(logger, 'warn');
+  test('falls back to an empty cache, warns, and surfaces the error for reporting', async () => {
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    const error = spyOn(logger, 'error').mockImplementation(() => {});
     const registry = new ComponentRegistry({ development: false, optimize: true });
     // Pre-seed so we can prove the catch resets it rather than leaving stale source.
     shakenSources(registry).set('/stale.svelte', 'stale');
@@ -25,8 +26,15 @@ describe('ComponentRegistry.prepareShake (failure fallback)', () => {
     // Resolves (does not throw) despite the engine error.
     await registry.prepareShake(process.cwd());
 
+    // Empty cache -> every onLoad reads the original on-disk source (unshaken).
     expect(shakenSources(registry).size).toBe(0);
     expect(warn.mock.calls.some((c) => String(c[0]).includes('skipped'))).toBe(true);
+    // The user is pointed at svelte-shaker's tracker so the bug can be reported,
+    // and the underlying error itself is dumped so that report can be actionable.
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('github.com/baseballyama/svelte-shaker/issues'))).toBe(true);
+    expect(error.mock.calls.some((c) => c[0] instanceof Error && c[0].message === 'boom')).toBe(true);
+
     warn.mockRestore();
+    error.mockRestore();
   });
 });

--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -317,7 +317,11 @@ export class ComponentRegistry {
       logger.info(`svelte-shaker: slimmed ${changed.length} of ${shaken.size} component(s)${excluded > 0 ? `, ${excluded} excluded` : ''}`);
       this.reportShake(changed);
     } catch (e) {
-      logger.warn(`svelte-shaker: skipped (${e instanceof Error ? e.message : e})`);
+      // Empty cache -> every onLoad reads the original source, so a failed shake
+      // never breaks the build (`shakenSources.get(path) ?? Bun.file(path)`).
+      logger.warn('svelte-shaker: optimization skipped; building from original sources (output is unaffected).');
+      logger.warn('svelte-shaker: this looks like a svelte-shaker bug — please report it with the error below at https://github.com/baseballyama/svelte-shaker/issues');
+      logger.error(e);
       this.shakenSources = new Map();
     }
   }


### PR DESCRIPTION
A failed whole-program shake already falls back to unshaken disk reads, so the build never breaks. It logged only the error message, though — not enough to diagnose or report the issue. Log the full error and direct users to the svelte-shaker issue tracker, keeping the build-safe fallback.