### PR TITLE
fix: drop @types/negotiator runtime dep via local ambient declaration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,6 @@
         "mochi-framework": "src/cli.js",
       },
       "dependencies": {
-        "@types/negotiator": "^0.6.4",
         "chokidar": "^4.0.3",
         "deepmerge": "^4.3.1",
         "devalue": "^5.8.1",
@@ -142,8 +141,8 @@
     "packages/video-animations": {
       "name": "mochi-video-animations",
       "dependencies": {
-        "@fontsource-variable/fraunces": "5.2.9",
-        "@fontsource/jetbrains-mono": "5.2.8",
+        "@fontsource-variable/fraunces": "^5.2.9",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@resvg/resvg-js": "2.6.2",
         "satori": "0.26.0",
         "subset-font": "2.5.0",
@@ -304,8 +303,6 @@
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
-
-    "@types/negotiator": ["@types/negotiator@0.6.4", "", {}, "sha512-elf6BsTq+AkyNsb2h5cGNst2Mc7dPliVoAPm1fXglC/BM3f2pFA40BaSSv3E5lyHteEawVKLP+8TwiY1DMNb3A=="],
 
     "@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -83,7 +83,6 @@
     }
   },
   "dependencies": {
-    "@types/negotiator": "^0.6.4",
     "chokidar": "^4.0.3",
     "deepmerge": "^4.3.1",
     "devalue": "^5.8.1",

--- a/packages/mochi/src/negotiator.d.ts
+++ b/packages/mochi/src/negotiator.d.ts
@@ -1,0 +1,13 @@
+// negotiator ships no types, and @types/negotiator can't be a devDependency:
+// consumers typecheck our published .ts sources, so the types would have to
+// ship as a runtime dependency. Instead we pin the tiny slice of the API we
+// use here. This file is intentionally a *script* (no top-level import/export)
+// so `declare module` registers as an ambient declaration; it is pulled in via
+// the triple-slash reference in `utils.ts`.
+declare module 'negotiator' {
+  export default class Negotiator {
+    constructor(request: { headers: Record<string, string | undefined> });
+    mediaType(availableMediaTypes?: string[]): string | undefined;
+    encodings(availableEncodings?: string[]): string[];
+  }
+}

--- a/packages/mochi/src/utils.ts
+++ b/packages/mochi/src/utils.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="./negotiator.d.ts" />
 import type { Server } from 'bun';
 import Negotiator from 'negotiator';
 import type { MochiCompileErrorLog } from './events';


### PR DESCRIPTION
- `@types/negotiator` had to ship as a runtime dependency because consumers typecheck the published raw `.ts` sources and hit the untyped `negotiator` import in `utils.ts` (TS7016)
- replace it with a minimal `declare module 'negotiator'` shim in `src/negotiator.d.ts`, triple-slash-referenced from `utils.ts` (same pattern as `mochi-framework.d.ts`)
- remove `@types/negotiator` entirely — no devDep needed either
- verified: packed tarball consumer typechecks with no `@types/negotiator` installed, and with it hoisted (no duplicate-declaration conflict); full `bun run checks` passes