### PR TITLE
refactor: replace $props<T>() with annotated let destructuring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Default to Bun instead of Node.js:
 
 - Hydration is all-or-nothing per island: `mochi:hydrate` hydrates the entire subtree together, no per-child opt-in.
 - All island components (`mochi:hydrate`, `mochi:hydrate:visible`, `mochi:defer`, `mochi:defer:visible`) implicitly receive an `islandId` prop matching the wrapper's `island-id` attribute. Accept it with `let { islandId } = $props()` if needed.
-- Hydratable invocations (`mochi:hydrate`, `mochi:hydrate:visible`, `mochi:defer`, `mochi:defer:visible`, `mochi:defer mochi:hydrate`) also implicitly receive `isHydratable: true` as a prop; pure SSR-only invocations leave it undefined. Use it to branch SSR-only fallback logic at the same call site that hydrates client-side: `let { isHydratable } = $props<{ isHydratable?: boolean }>()`.
+- Hydratable invocations (`mochi:hydrate`, `mochi:hydrate:visible`, `mochi:defer`, `mochi:defer:visible`, `mochi:defer mochi:hydrate`) also implicitly receive `isHydratable: true` as a prop; pure SSR-only invocations leave it undefined. Use it to branch SSR-only fallback logic at the same call site that hydrates client-side: `let { isHydratable }: { isHydratable?: boolean } = $props()`.
 
 ## Conventions
 

--- a/packages/demos/src/admin/AdminLayout.svelte
+++ b/packages/demos/src/admin/AdminLayout.svelte
@@ -11,7 +11,7 @@
   import Settings from '@lucide/svelte/icons/settings';
   import AdminThemeToggle from './AdminThemeToggle.svelte';
   import { mergeMetaTags } from '../lib/baseMetaTags';
-  import type { Component } from 'svelte';
+  import type { Component, Snippet } from 'svelte';
 
   type Section = {
     key: string;
@@ -20,15 +20,13 @@
     live: boolean;
   };
 
-  let {
-    activeNav,
-    metaTags = {},
-    children,
-  } = $props<{
+  interface Props {
     activeNav?: string;
     metaTags?: MetaTagsProps;
-    children: () => unknown;
-  }>();
+    children: Snippet;
+  }
+
+  let { activeNav, metaTags = {}, children }: Props = $props();
 
   const mergedMetaTags = $derived(mergeMetaTags({ canonical: `https://demos.mochi.fast${url.pathname}`, ...metaTags }));
 

--- a/packages/demos/src/hn/HNLayout.svelte
+++ b/packages/demos/src/hn/HNLayout.svelte
@@ -1,18 +1,17 @@
 <script lang="ts">
+  import type { Snippet } from 'svelte';
   import { url } from 'mochi-framework';
   import { MetaTags, type MetaTagsProps } from 'svelte-meta-tags';
   import { mergeMetaTags } from '../lib/baseMetaTags';
   import MochiBanner from './MochiBanner.svelte';
 
-  let {
-    activeNav,
-    metaTags = {},
-    children,
-  } = $props<{
+  interface Props {
     activeNav?: string;
     metaTags?: MetaTagsProps;
-    children: () => unknown;
-  }>();
+    children: Snippet;
+  }
+
+  let { activeNav, metaTags = {}, children }: Props = $props();
 
   const mergedMetaTags = $derived(mergeMetaTags({ canonical: `https://demos.mochi.fast${url.pathname}`, ...metaTags }));
 </script>

--- a/packages/docs/11-your-first-mochi-app.md
+++ b/packages/docs/11-your-first-mochi-app.md
@@ -79,7 +79,7 @@ Next, let's write the page itself. `Hello.svelte` stays server-only (all `Mochi.
   import LikeButton from './LikeButton.svelte';
   import Visitor from './Visitor.svelte';
 
-  let { siteName, renderedAt } = $props<{ siteName: string; renderedAt: string }>();
+  let { siteName, renderedAt }: { siteName: string; renderedAt: string } = $props();
 </script>
 
 <h1>Welcome to {siteName}</h1>
@@ -107,7 +107,7 @@ Now let's give the user something to click! `LikeButton.svelte` is a normal Svel
 ```svelte
 <!-- file: src/LikeButton.svelte -->
 <script lang="ts">
-  let { initialLikes } = $props<{ initialLikes: number }>();
+  let { initialLikes }: { initialLikes: number } = $props();
   let likes = $state(initialLikes);
 </script>
 
@@ -141,7 +141,7 @@ Update `Hello.svelte` to read `?name=` and pass it through to `Visitor`:
   import LikeButton from './LikeButton.svelte';
   import Visitor from './Visitor.svelte';
 
-  let { siteName, renderedAt } = $props<{ siteName: string; renderedAt: string }>();
+  let { siteName, renderedAt }: { siteName: string; renderedAt: string } = $props();
 
   const { url } = getRequestContext();
   const visitorName = url.searchParams.get('name') ?? 'friend';

--- a/packages/docs/50-selective-hydration.md
+++ b/packages/docs/50-selective-hydration.md
@@ -38,11 +38,11 @@ Accept them in the component's `$props()` to branch on hydration state at the sa
     islandId,
     isHydratable,
     count = 0,
-  } = $props<{
+  }: {
     islandId?: string;
     isHydratable?: boolean;
     count?: number;
-  }>();
+  } = $props();
 </script>
 
 {#if isHydratable}

--- a/packages/docs/71-island-props.md
+++ b/packages/docs/71-island-props.md
@@ -4,6 +4,10 @@ slug: island-props
 description: 'How props are serialized and passed to hydratable islands, including supported types and auto-injected framework props.'
 ---
 
+<script>
+  import Callout from './_components/Callout.svelte';
+</script>
+
 ## Passing props to islands
 
 Pass props to a component marked with `mochi:hydrate`, `mochi:hydrate:visible`, or `mochi:defer` exactly as you would to any Svelte component — the framework serializes them with [`devalue`](https://github.com/Rich-Harris/devalue) so the same values reach the hydrating client.
@@ -20,6 +24,60 @@ Pass props to a component marked with `mochi:hydrate`, `mochi:hydrate:visible`, 
 ```
 
 Do **NOT** pass functions, class instances, or `Symbol` values as props; instead, send a plain-data representation and rebuild the value inside the island.
+
+### Typing props
+
+Put the type on the `let { … } = $props()` declaration — don't pass a type argument to `$props()` itself. For a handful of props, inline the type after the destructuring:
+
+```svelte
+<script lang="ts">
+  let { adjective }: { adjective: string } = $props();
+</script>
+```
+
+For larger or reused shapes, pull it out into a `Props` interface:
+
+```svelte
+<script lang="ts">
+  interface Props {
+    title: string;
+    count?: number;
+    user: { name: string; id: number };
+  }
+
+  let { title, count = 0, user }: Props = $props();
+</script>
+```
+
+<Callout type="warning">
+
+Avoid `$props<{ … }>()`. The `<…>` type-argument form isn't the recommended convention — type the `let { … }` declaration instead, e.g. `let { adjective }: { adjective: string } = $props()`.
+
+</Callout>
+
+Snippet props (including `children`) are typed with the `Snippet` interface from `svelte`:
+
+```svelte
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+
+  let { children }: { children: Snippet } = $props();
+</script>
+
+{@render children()}
+```
+
+When a component wraps a native element and forwards the rest of its attributes, type the spread with the matching interface from [`svelte/elements`](https://svelte.dev/docs/svelte/typescript#Typing-wrapper-components):
+
+```svelte
+<script lang="ts">
+  import type { HTMLButtonAttributes } from 'svelte/elements';
+
+  let { children, ...rest }: HTMLButtonAttributes = $props();
+</script>
+
+<button {...rest}>{@render children?.()}</button>
+```
 
 ### Wire format
 
@@ -47,11 +105,15 @@ The framework appends two read-only props to every island invocation. Destructur
 ```svelte
 <!-- file: src/lib/UserCard.svelte -->
 <script lang="ts">
-  let { islandId, isHydratable, user } = $props<{
+  let {
+    islandId,
+    isHydratable,
+    user,
+  }: {
     islandId?: string;
     isHydratable?: boolean;
     user: { name: string; id: number };
-  }>();
+  } = $props();
 </script>
 ```
 

--- a/packages/docs/71-island-props.md
+++ b/packages/docs/71-island-props.md
@@ -51,7 +51,7 @@ For larger or reused shapes, pull it out into a `Props` interface:
 
 <Callout type="warning">
 
-Avoid `$props<{ … }>()`. The `<…>` type-argument form isn't the recommended convention — type the `let { … }` declaration instead, e.g. `let { adjective }: { adjective: string } = $props()`.
+Avoid the `$props<{ … }>()` type-argument form — always annotate the `let { … }` declaration as shown above.
 
 </Callout>
 

--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -74,8 +74,8 @@ Accept them with `$props`:
 
 ```svelte
 <!-- file: src/lib/Counter.svelte -->
-<script>
-  let { islandId, isHydratable } = $props<{ islandId?: string; isHydratable?: boolean }>();
+<script lang="ts">
+  let { islandId, isHydratable }: { islandId?: string; isHydratable?: boolean } = $props();
 </script>
 ```
 
@@ -85,10 +85,10 @@ Use `isHydratable` to peek request-scoped state only when the client won't take 
 
 ```svelte
 <!-- file: src/lib/RandomRoll.svelte -->
-<script>
+<script lang="ts">
   import { isServer, getRequestContext } from 'mochi-framework';
 
-  let { isHydratable } = $props<{ isHydratable?: boolean }>();
+  let { isHydratable }: { isHydratable?: boolean } = $props();
 
   const initial = isHydratable || !isServer ? null : peekForm();
 

--- a/packages/mochi/src/__fixtures__/island-context/Probe.svelte
+++ b/packages/mochi/src/__fixtures__/island-context/Probe.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // `isHydratable` is auto-injected as a prop on hydratable children
   // (alongside `islandId`); plain SSR-only invocations leave it undefined.
-  let { isHydratable } = $props<{ isHydratable?: boolean }>();
+  let { isHydratable }: { isHydratable?: boolean } = $props();
 </script>
 
 <span data-hydratable={String(isHydratable === true)}>probe</span>

--- a/packages/site/src/demos/data-loading/PokemonSelector.svelte
+++ b/packages/site/src/demos/data-loading/PokemonSelector.svelte
@@ -1,8 +1,5 @@
 <script lang="ts">
-  let { current, options } = $props<{
-    current: string;
-    options: { name: string }[];
-  }>();
+  let { current, options }: { current: string; options: { name: string }[] } = $props();
 
   function onChange(event: Event) {
     (event.currentTarget as HTMLSelectElement).form?.requestSubmit();

--- a/packages/site/src/demos/error-boundaries/ThrowOnClient.svelte
+++ b/packages/site/src/demos/error-boundaries/ThrowOnClient.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { isBrowser } from 'mochi-framework';
 
-  const props = $props<{ label?: string }>();
+  const props: { label?: string } = $props();
 
   if (isBrowser) {
     throw new Error(`Client throw from <${props.label ?? 'ThrowOnClient'}>`);

--- a/packages/site/src/demos/error-boundaries/ThrowOnSsr.svelte
+++ b/packages/site/src/demos/error-boundaries/ThrowOnSsr.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { isBrowser } from 'mochi-framework';
 
-  const props = $props<{ label?: string }>();
+  const props: { label?: string } = $props();
 
   if (!isBrowser) {
     throw new Error(`SSR throw from <${props.label ?? 'ThrowOnSsr'}>`);

--- a/packages/site/src/demos/file-upload/FileUpload.svelte
+++ b/packages/site/src/demos/file-upload/FileUpload.svelte
@@ -5,7 +5,7 @@
 
   type UploadResult = { filename: string; content: string; size: number };
 
-  let { label, isHydratable } = $props<{ label: string; isHydratable?: boolean }>();
+  let { label, isHydratable }: { label: string; isHydratable?: boolean } = $props();
 
   // svelte-ignore state_referenced_locally
   const _form = !isHydratable && isServer ? getRequestContext().form : null;

--- a/packages/site/src/demos/form-cancel/AbortDemo.svelte
+++ b/packages/site/src/demos/form-cancel/AbortDemo.svelte
@@ -2,7 +2,7 @@
   import { enhance } from 'mochi-framework';
   import type { MochiEnhanceOptions, MochiSubmitFunction } from 'mochi-framework';
 
-  let { label } = $props<{ label: string }>();
+  let { label }: { label: string } = $props();
 
   let pending = $state(false);
   let result = $state<string | null>(null);

--- a/packages/site/src/demos/form-cancel/CancelDemo.svelte
+++ b/packages/site/src/demos/form-cancel/CancelDemo.svelte
@@ -2,7 +2,7 @@
   import { enhance } from 'mochi-framework';
   import type { MochiEnhanceOptions, MochiSubmitFunction } from 'mochi-framework';
 
-  let { label } = $props<{ label: string }>();
+  let { label }: { label: string } = $props();
 
   let pending = $state(false);
   let result = $state<string | null>(null);

--- a/packages/site/src/demos/form-cancel/PlainDemo.svelte
+++ b/packages/site/src/demos/form-cancel/PlainDemo.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { isServer, getRequestContext } from 'mochi-framework';
 
-  let { label } = $props<{ label: string }>();
+  let { label }: { label: string } = $props();
 
   const _form = isServer ? getRequestContext().form : null;
   const initialResult: string | null = _form?.ok && _form.action === 'lookup' ? String(_form.data.result ?? '') : null;

--- a/packages/site/src/demos/form-errors/ErrorDemo.svelte
+++ b/packages/site/src/demos/form-errors/ErrorDemo.svelte
@@ -2,7 +2,7 @@
   import { enhance } from 'mochi-framework';
   import type { MochiSubmitFunction } from 'mochi-framework';
 
-  let { label } = $props<{ label: string }>();
+  let { label }: { label: string } = $props();
 
   let errorMessage = $state<string | null>(null);
   let pending = $state(false);

--- a/packages/site/src/demos/form-redirects/FormRedirects.svelte
+++ b/packages/site/src/demos/form-redirects/FormRedirects.svelte
@@ -10,7 +10,7 @@
     { label: 'index.ts', path: './src/demoIndex.ts' },
   ]);
 
-  let { redirected } = $props<{ redirected: boolean }>();
+  let { redirected }: { redirected: boolean } = $props();
 </script>
 
 <DemoPage

--- a/packages/site/src/demos/form-redirects/RedirectDemo.svelte
+++ b/packages/site/src/demos/form-redirects/RedirectDemo.svelte
@@ -2,7 +2,7 @@
   import { enhance } from 'mochi-framework';
   import type { MochiSubmitFunction, MochiEnhanceResult } from 'mochi-framework';
 
-  let { label } = $props<{ label: string }>();
+  let { label }: { label: string } = $props();
 
   let redirectResult = $state<{ status: number; location: string } | null>(null);
   let pending = $state(false);

--- a/packages/site/src/demos/form-return-data/RandomRoll.svelte
+++ b/packages/site/src/demos/form-return-data/RandomRoll.svelte
@@ -2,7 +2,7 @@
   import { enhance, isServer, getRequestContext } from 'mochi-framework';
   import type { MochiSubmitFunction } from 'mochi-framework';
 
-  let { label, isHydratable } = $props<{ label: string; isHydratable?: boolean }>();
+  let { label, isHydratable }: { label: string; isHydratable?: boolean } = $props();
 
   // svelte-ignore state_referenced_locally
   const _form = !isHydratable && isServer ? getRequestContext().form : null;

--- a/packages/site/src/demos/hydratable/FactCardProps.svelte
+++ b/packages/site/src/demos/hydratable/FactCardProps.svelte
@@ -3,7 +3,7 @@
   // passes it in as a prop. Mochi devalue-serialises island props into the
   // HTML and re-hydrates them on the client, so the data still crosses the
   // wire without re-running the SSR work — just via a different channel.
-  let { fact } = $props<{ fact: { sqliteVersion: string; computedAt: string } }>();
+  let { fact }: { fact: { sqliteVersion: string; computedAt: string } } = $props();
 
   let clicks = $state(0);
 </script>

--- a/packages/site/src/demos/login/EnhancedLoginForm.svelte
+++ b/packages/site/src/demos/login/EnhancedLoginForm.svelte
@@ -2,7 +2,7 @@
   import { enhance, isServer, getRequestContext } from 'mochi-framework';
   import type { MochiEnhanceOptions, MochiSubmitFunction } from 'mochi-framework';
 
-  let { initialUser, isHydratable } = $props<{ initialUser: string | null; isHydratable?: boolean }>();
+  let { initialUser, isHydratable }: { initialUser: string | null; isHydratable?: boolean } = $props();
 
   // For SSR-only (plain HTML) renders, read the form action result so errors
   // and the prefilled username survive the re-render after a failed POST.

--- a/packages/site/src/demos/login/Login.svelte
+++ b/packages/site/src/demos/login/Login.svelte
@@ -11,7 +11,7 @@
     { label: 'index.ts', path: './src/demoIndex.ts' },
   ]);
 
-  let { currentUser } = $props<{ currentUser: string | null }>();
+  let { currentUser }: { currentUser: string | null } = $props();
 </script>
 
 <DemoPage

--- a/packages/site/src/demos/reload-form-data/Guestbook.svelte
+++ b/packages/site/src/demos/reload-form-data/Guestbook.svelte
@@ -4,7 +4,7 @@
 
   type GuestbookEntry = { id: string; name: string; at: number };
 
-  let { entries: initialEntries } = $props<{ entries: GuestbookEntry[] }>();
+  let { entries: initialEntries }: { entries: GuestbookEntry[] } = $props();
 
   // svelte-ignore state_referenced_locally
   let entries = $state<GuestbookEntry[]>(initialEntries);

--- a/packages/site/src/demos/reload-form-data/ReloadFormData.svelte
+++ b/packages/site/src/demos/reload-form-data/ReloadFormData.svelte
@@ -12,7 +12,7 @@
     { label: 'index.ts', path: './src/demoIndex.ts' },
   ]);
 
-  let { guestbook } = $props<{ guestbook: GuestbookEntry[] }>();
+  let { guestbook }: { guestbook: GuestbookEntry[] } = $props();
 </script>
 
 <DemoPage

--- a/packages/site/src/demos/your-first-mochi-app/Hello.svelte
+++ b/packages/site/src/demos/your-first-mochi-app/Hello.svelte
@@ -3,7 +3,7 @@
   import LikeButton from './LikeButton.svelte';
   import Visitor from './Visitor.svelte';
 
-  let { siteName, renderedAt } = $props<{ siteName: string; renderedAt: string }>();
+  let { siteName, renderedAt }: { siteName: string; renderedAt: string } = $props();
 
   const { url } = getRequestContext();
   const visitorName = url.searchParams.get('name') ?? 'friend';

--- a/packages/site/src/demos/your-first-mochi-app/LikeButton.svelte
+++ b/packages/site/src/demos/your-first-mochi-app/LikeButton.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  const props = $props<{ initialLikes: number }>();
+  const props: { initialLikes: number } = $props();
   let likes = $state(props.initialLikes);
 </script>
 

--- a/packages/site/src/demos/your-first-mochi-app/LikeButton.svelte
+++ b/packages/site/src/demos/your-first-mochi-app/LikeButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-  const props: { initialLikes: number } = $props();
-  let likes = $state(props.initialLikes);
+  let { initialLikes }: { initialLikes: number } = $props();
+  let likes = $state(initialLikes);
 </script>
 
 <button onclick={() => likes++}>♥ {likes}</button>


### PR DESCRIPTION
## Summary

- Converts all `$props<T>()` generic calls to the Svelte 5 recommended form: `let { … }: T = $props()`
- Inline annotation for simple props; `interface Props` for multi-prop layouts (`AdminLayout`, `HNLayout`)
- `children: () => unknown` → `children: Snippet` in layout components
- Updates all matching examples in docs and `CLAUDE.md`
- Adds a new **Typing props** subsection to `71-island-props.md` covering inline types, `Props` interface, `Snippet`, and `svelte/elements`