### PR TITLE
feat: replace chokidar with native fs.watch shim

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,6 @@
         "mochi-framework": "src/cli.js",
       },
       "dependencies": {
-        "chokidar": "^4.0.3",
         "deepmerge": "^4.3.1",
         "devalue": "^5.8.1",
         "js-cookie": "^3.0.7",

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -83,7 +83,6 @@
     }
   },
   "dependencies": {
-    "chokidar": "^4.0.3",
     "deepmerge": "^4.3.1",
     "devalue": "^5.8.1",
     "js-cookie": "^3.0.7",

--- a/packages/mochi/src/devWatcher.ts
+++ b/packages/mochi/src/devWatcher.ts
@@ -1,7 +1,7 @@
 import type { Server, ServerWebSocket } from 'bun';
 import { existsSync } from 'fs';
 import path from 'node:path';
-import chokidar from 'chokidar';
+import { createWatcher } from './lib/fileWatcher';
 import debounce from './vendor/debounce/index';
 import type { ComponentRegistry } from './ComponentRegistry';
 import { mochiEvents } from './events';
@@ -31,8 +31,8 @@ import {
 
 const FILE_CHANGE_EVENTS = new Set<string>(['add', 'change', 'unlink', 'addDir', 'unlinkDir']);
 
-// Chokidar reports a rename as unlink-old + add-new, so logging the verb per
-// event surfaces both the old and new filename instead of just "changed".
+// A rename surfaces as unlink-old + add-new, so logging the verb per event
+// surfaces both the old and new filename instead of just "changed".
 function publicChangeVerb(event: string): string {
   if (event === 'add' || event === 'addDir') {
     return 'added';
@@ -68,8 +68,8 @@ export interface DevWatcherDeps {
 }
 
 /**
- * Wire up the dev-mode file watcher: chokidar over the source tree, public
- * dir, and `svelte.config.js`. Saves are debounced (100 ms) and serialized
+ * Wire up the dev-mode file watcher over the source tree, public dir, and
+ * `svelte.config.js`. Saves are debounced (100 ms) and serialized
  * through a Promise chain so the live-reload signal only fires after client
  * chunks are ready. CSS edits take a fast-path that re-bundles imported CSS
  * without an SSR recompile; public-dir edits rescan and reload the route map.
@@ -511,16 +511,15 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
     const abs = path.resolve(filePath);
     return abs === outDirAbs || abs.startsWith(outDirAbs + path.sep);
   };
-  const watcher = chokidar.watch(finalWatchPaths, {
-    ignoreInitial: true,
+  const watcher = createWatcher(finalWatchPaths, {
     ignored: [/(^|[/\\])node_modules([/\\]|$)/, isInsideOutDir],
     cwd: process.cwd(),
   });
 
   const watcherReady =
     finalWatchPaths.length === 0
-      ? // chokidar never emits 'ready' for an empty watch set, so don't wait on
-        // it — there's nothing being watched, hence no startup race to guard.
+      ? // The watcher never emits 'ready' for an empty watch set, so don't wait
+        // on it — there's nothing being watched, hence no startup race to guard.
         Promise.resolve()
       : new Promise<void>((resolve) => {
           let settled = false;
@@ -534,7 +533,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
           watcher.once('ready', done);
           // Safety net so serve() can't hang indefinitely if 'ready' never
           // arrives. unref so it can't keep the process alive. Reaching this
-          // means chokidar never signalled ready for a non-empty watch set
+          // means the watcher never signalled ready for a non-empty watch set
           setTimeout(() => {
             if (settled) {
               return;
@@ -622,7 +621,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       notifyClients();
     });
   }, 100);
-  const svelteConfigWatcher = chokidar.watch(svelteConfigPath, { ignoreInitial: true });
+  const svelteConfigWatcher = createWatcher([svelteConfigPath]);
   svelteConfigWatcher
     .on('add', reloadSvelteConfig)
     .on('change', reloadSvelteConfig)

--- a/packages/mochi/src/events.ts
+++ b/packages/mochi/src/events.ts
@@ -59,7 +59,7 @@ export type MochiFileChangeType = 'add' | 'change' | 'unlink' | 'addDir' | 'unli
 export interface MochiFileChangeEvent {
   /** Absolute path of the changed file, as reported by the dev watcher. */
   path: string;
-  /** Kind of change, mirroring chokidar event names. */
+  /** Kind of change: add | change | unlink | addDir | unlinkDir. */
   type: MochiFileChangeType;
 }
 

--- a/packages/mochi/src/lib/fileWatcher.test.ts
+++ b/packages/mochi/src/lib/fileWatcher.test.ts
@@ -76,15 +76,19 @@ test("classifies a modification of an existing file as 'change'", async () => {
 
 test("classifies a deletion as 'unlink'", async () => {
   const target = path.join(dir, 'c.txt');
-  writeFileSync(target, 'one');
   watcher = createWatcher([dir], { cwd: dir });
-  // Touch first so the file becomes 'seen', then delete.
-  await new Promise((r) => setTimeout(r, 50));
-  writeFileSync(target, 'two');
-  await nextEvent(watcher, (kind, rel) => rel === 'c.txt');
-  const p = nextEvent(watcher, (kind, rel) => rel === 'c.txt' && kind === 'unlink');
+  await settle();
+  // Create under the watcher and wait for 'add' — this seeds the seen-map so the
+  // delete can be classified. Then settle again before deleting: a delete fired
+  // immediately after a preceding write to the same path gets coalesced away by
+  // the OS watch layer (observed on Linux inotify), dropping the 'unlink'.
+  const added = nextEvent(watcher, (kind, rel) => rel === 'c.txt' && kind === 'add');
+  writeFileSync(target, 'one');
+  await added;
+  await settle();
+  const removed = nextEvent(watcher, (kind, rel) => rel === 'c.txt' && kind === 'unlink');
   rmSync(target);
-  await p;
+  await removed;
 });
 
 test('detects a file added in a nested subdirectory', async () => {

--- a/packages/mochi/src/lib/fileWatcher.test.ts
+++ b/packages/mochi/src/lib/fileWatcher.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, expect, test } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createWatcher, type FileChangeKind, type FileWatcher } from './fileWatcher';
+
+let dir: string;
+let watcher: FileWatcher | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(path.join(tmpdir(), 'mochi-watch-'));
+});
+
+afterEach(() => {
+  watcher?.close();
+  watcher = undefined;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+// The OS needs a beat to register a freshly-attached fs.watch before mutations
+// are reliably reported — more so when the full suite runs many watch tests in
+// parallel processes. Settle before the first write that an assertion depends on.
+function settle(): Promise<void> {
+  return new Promise((r) => setTimeout(r, 80));
+}
+
+// fs.watch latency varies by platform, so wait for a matching event rather than
+// asserting synchronously after the filesystem mutation.
+function nextEvent(w: FileWatcher, predicate: (kind: FileChangeKind, rel: string) => boolean, timeoutMs = 8000): Promise<{ kind: FileChangeKind; rel: string }> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      w.off('all', onAll);
+      reject(new Error('timed out waiting for event'));
+    }, timeoutMs);
+    function onAll(kind: FileChangeKind, rel: string) {
+      if (predicate(kind, rel)) {
+        clearTimeout(timer);
+        w.off('all', onAll);
+        resolve({ kind, rel });
+      }
+    }
+    w.on('all', onAll);
+  });
+}
+
+test("emits 'ready' once", async () => {
+  watcher = createWatcher([dir]);
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('no ready')), 2000);
+    watcher!.once('ready', () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+});
+
+test("classifies a new file as 'add'", async () => {
+  watcher = createWatcher([dir], { cwd: dir });
+  const target = path.join(dir, 'a.txt');
+  await settle();
+  const p = nextEvent(watcher, (kind, rel) => rel === 'a.txt' && kind === 'add');
+  writeFileSync(target, 'one');
+  await p;
+});
+
+test("classifies a modification of an existing file as 'change'", async () => {
+  const target = path.join(dir, 'b.txt');
+  writeFileSync(target, 'one');
+  watcher = createWatcher([dir], { cwd: dir });
+  const p = nextEvent(watcher, (kind, rel) => rel === 'b.txt' && kind === 'change');
+  // Give the watcher a beat to attach before mutating.
+  await new Promise((r) => setTimeout(r, 50));
+  writeFileSync(target, 'two');
+  await p;
+});
+
+test("classifies a deletion as 'unlink'", async () => {
+  const target = path.join(dir, 'c.txt');
+  writeFileSync(target, 'one');
+  watcher = createWatcher([dir], { cwd: dir });
+  // Touch first so the file becomes 'seen', then delete.
+  await new Promise((r) => setTimeout(r, 50));
+  writeFileSync(target, 'two');
+  await nextEvent(watcher, (kind, rel) => rel === 'c.txt');
+  const p = nextEvent(watcher, (kind, rel) => rel === 'c.txt' && kind === 'unlink');
+  rmSync(target);
+  await p;
+});
+
+test('detects a file added in a nested subdirectory', async () => {
+  const sub = path.join(dir, 'nested');
+  mkdirSync(sub);
+  watcher = createWatcher([dir], { cwd: dir });
+  await new Promise((r) => setTimeout(r, 50));
+  const p = nextEvent(watcher, (kind, rel) => rel === path.join('nested', 'deep.txt') && kind === 'add');
+  writeFileSync(path.join(sub, 'deep.txt'), 'x');
+  await p;
+});
+
+test('emits cwd-relative paths', async () => {
+  watcher = createWatcher([dir], { cwd: dir });
+  await settle();
+  const p = nextEvent(watcher, (_kind, rel) => rel === 'rel.txt');
+  writeFileSync(path.join(dir, 'rel.txt'), 'x');
+  const { rel } = await p;
+  expect(path.isAbsolute(rel)).toBe(false);
+});
+
+test('honors RegExp and predicate ignore matchers', async () => {
+  mkdirSync(path.join(dir, 'node_modules'));
+  watcher = createWatcher([dir], {
+    cwd: dir,
+    ignored: [/(^|[/\\])node_modules([/\\]|$)/, (p) => p.endsWith('.skip')],
+  });
+  let leaked = false;
+  watcher.on('all', (_kind, rel) => {
+    if (rel.includes('node_modules') || rel.endsWith('.skip')) {
+      leaked = true;
+    }
+  });
+  await new Promise((r) => setTimeout(r, 50));
+  // Space the writes out: bursts get coalesced/dropped by the OS watch layer,
+  // which would mask (not falsify) the ignore assertion.
+  writeFileSync(path.join(dir, 'node_modules', 'pkg.js'), 'x');
+  await new Promise((r) => setTimeout(r, 120));
+  writeFileSync(path.join(dir, 'ignored.skip'), 'x');
+  await new Promise((r) => setTimeout(r, 120));
+  // A non-ignored write proves the watcher is live and flushes the queue.
+  const p = nextEvent(watcher, (_kind, rel) => rel === 'kept.txt');
+  writeFileSync(path.join(dir, 'kept.txt'), 'x');
+  await p;
+  expect(leaked).toBe(false);
+});
+
+test('watches a single file target via its parent directory', async () => {
+  const target = path.join(dir, 'config.js');
+  watcher = createWatcher([target], { cwd: dir });
+  await settle();
+  const created = nextEvent(watcher, (kind, rel) => rel === 'config.js' && kind === 'add');
+  writeFileSync(target, 'export default {}');
+  await created;
+  const changed = nextEvent(watcher, (kind, rel) => rel === 'config.js' && kind === 'change');
+  await new Promise((r) => setTimeout(r, 50));
+  writeFileSync(target, 'export default { x: 1 }');
+  await changed;
+});
+
+test('a sibling change does not leak into a single-file watch', async () => {
+  const target = path.join(dir, 'watched.js');
+  writeFileSync(target, 'a');
+  watcher = createWatcher([target], { cwd: dir });
+  let leaked = false;
+  watcher.on('all', (_kind, rel) => {
+    if (rel === 'sibling.js') {
+      leaked = true;
+    }
+  });
+  await new Promise((r) => setTimeout(r, 50));
+  writeFileSync(path.join(dir, 'sibling.js'), 'b');
+  await new Promise((r) => setTimeout(r, 120));
+  // Drive a real event on the watched file to flush the queue.
+  const p = nextEvent(watcher, (_kind, rel) => rel === 'watched.js');
+  writeFileSync(target, 'c');
+  await p;
+  expect(leaked).toBe(false);
+});
+
+test('close stops further events', async () => {
+  watcher = createWatcher([dir], { cwd: dir });
+  await new Promise((r) => setTimeout(r, 50));
+  let count = 0;
+  watcher.on('all', () => {
+    count += 1;
+  });
+  watcher.close();
+  writeFileSync(path.join(dir, 'after-close.txt'), 'x');
+  await new Promise((r) => setTimeout(r, 200));
+  expect(count).toBe(0);
+});

--- a/packages/mochi/src/lib/fileWatcher.ts
+++ b/packages/mochi/src/lib/fileWatcher.ts
@@ -25,6 +25,12 @@ export interface CreateWatcherOptions {
  * recovered by `statSync` + a seen-path map. Directory targets are watched
  * recursively; file targets are watched via their parent directory so atomic
  * saves (rename-over) and create-when-absent are still caught.
+ *
+ * Like chokidar, this inherits `fs.watch`'s OS-level event coalescing: events
+ * fired in very rapid succession on the same path can be collapsed (e.g. on
+ * Linux inotify, a delete landing within milliseconds of a preceding write may
+ * be dropped). Harmless for a dev watcher — human-paced saves are spaced out,
+ * and a missed `unlink` only leaves a stale cache entry corrected on next edit.
  */
 class FileWatcher extends EventEmitter {
   private watchers: FSWatcher[] = [];

--- a/packages/mochi/src/lib/fileWatcher.ts
+++ b/packages/mochi/src/lib/fileWatcher.ts
@@ -1,0 +1,188 @@
+import { EventEmitter } from 'node:events';
+import { existsSync, statSync, watch, type FSWatcher } from 'node:fs';
+import path from 'node:path';
+
+export type FileChangeKind = 'add' | 'change' | 'unlink' | 'addDir' | 'unlinkDir';
+
+/** A path is ignored if any RegExp matches it or any predicate returns true. */
+export type IgnoreMatcher = RegExp | ((path: string) => boolean);
+
+export interface CreateWatcherOptions {
+  ignored?: IgnoreMatcher[];
+  cwd?: string;
+}
+
+/**
+ * The slice of chokidar that Mochi's dev watcher actually uses, rebuilt on Bun's
+ * native recursive `fs.watch` so the framework ships no watch dependency.
+ *
+ * Emits chokidar-shaped events: a generic `'all'` (kind, cwd-relative path) plus
+ * a per-kind event, then `'ready'` once and `'error'` per failure. Paths are
+ * emitted relative to `cwd` to match chokidar's `cwd` option, which the call
+ * site relies on for `startsWith(publicDirRel + sep)` routing.
+ *
+ * `fs.watch` only distinguishes `'rename'` from `'change'`, so add/unlink are
+ * recovered by `statSync` + a seen-path map. Directory targets are watched
+ * recursively; file targets are watched via their parent directory so atomic
+ * saves (rename-over) and create-when-absent are still caught.
+ */
+class FileWatcher extends EventEmitter {
+  private watchers: FSWatcher[] = [];
+  private readonly cwd: string;
+  private readonly ignored: IgnoreMatcher[];
+  private readonly seen = new Map<string, 'file' | 'dir'>();
+  private readonly recent = new Map<string, ReturnType<typeof setTimeout>>();
+  private closed = false;
+
+  constructor(paths: string[], opts: CreateWatcherOptions) {
+    super();
+    this.cwd = opts.cwd ?? process.cwd();
+    this.ignored = opts.ignored ?? [];
+
+    for (const target of paths) {
+      this.watchTarget(target);
+    }
+
+    // fs.watch is active synchronously; defer 'ready' so the caller's
+    // `.once('ready', …)` (attached synchronously after construction) is wired
+    // before it fires.
+    queueMicrotask(() => {
+      if (!this.closed) {
+        this.emit('ready');
+      }
+    });
+  }
+
+  private watchTarget(target: string): void {
+    let isDir = false;
+    try {
+      isDir = statSync(target).isDirectory();
+    } catch {
+      // Target doesn't exist yet (e.g. svelte.config.js): fall through to
+      // parent-directory watching so we still catch its creation.
+    }
+
+    if (isDir) {
+      this.attach(target, true);
+      return;
+    }
+
+    // File (or not-yet-created) target: watch its parent so renames and atomic
+    // saves — which swap the inode and would silently kill a direct file watch —
+    // are still observed. Filter the parent's events down to this basename.
+    const parent = path.dirname(target);
+    if (!existsSync(parent)) {
+      return;
+    }
+    this.attach(parent, false, path.basename(target));
+  }
+
+  private attach(watchRoot: string, recursive: boolean, onlyBase?: string): void {
+    let w: FSWatcher;
+    try {
+      w = watch(watchRoot, { recursive });
+    } catch (err) {
+      this.emit('error', err);
+      return;
+    }
+    w.on('change', (rawEvent, filename) => {
+      if (filename == null) {
+        return;
+      }
+      const abs = path.resolve(watchRoot, filename.toString());
+      if (onlyBase != null && path.basename(abs) !== onlyBase) {
+        return;
+      }
+      this.handle(rawEvent, abs);
+    });
+    w.on('error', (err) => this.emit('error', err));
+    this.watchers.push(w);
+  }
+
+  private handle(rawEvent: string, abs: string): void {
+    const rel = path.relative(this.cwd, abs);
+    if (this.isIgnored(abs, rel)) {
+      return;
+    }
+    const kind = this.classify(rawEvent, abs);
+    if (kind == null) {
+      return;
+    }
+    const key = `${kind}:${rel}`;
+    if (this.recent.has(key)) {
+      return;
+    }
+    const timer = setTimeout(() => this.recent.delete(key), 20);
+    timer.unref?.();
+    this.recent.set(key, timer);
+
+    this.emit('all', kind, rel);
+    this.emit(kind, rel);
+  }
+
+  private classify(rawEvent: string, abs: string): FileChangeKind | null {
+    let isDirectory: boolean | null;
+    try {
+      isDirectory = statSync(abs).isDirectory();
+    } catch {
+      isDirectory = null; // path is gone
+    }
+
+    if (isDirectory === null) {
+      const known = this.seen.get(abs);
+      if (!known) {
+        return null;
+      }
+      this.seen.delete(abs);
+      return known === 'dir' ? 'unlinkDir' : 'unlink';
+    }
+
+    if (isDirectory) {
+      if (this.seen.get(abs) === 'dir') {
+        return null; // directory touch, not a creation
+      }
+      this.seen.set(abs, 'dir');
+      return 'addDir';
+    }
+
+    const known = this.seen.get(abs);
+    this.seen.set(abs, 'file');
+    // A raw 'change' is always a modification; a 'rename' on a file we've never
+    // seen is a creation, otherwise it's an atomic save over an existing file.
+    if (rawEvent === 'change') {
+      return 'change';
+    }
+    return known === 'file' ? 'change' : 'add';
+  }
+
+  private isIgnored(abs: string, rel: string): boolean {
+    for (const matcher of this.ignored) {
+      if (matcher instanceof RegExp) {
+        if (matcher.test(rel)) {
+          return true;
+        }
+      } else if (matcher(abs)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const w of this.watchers) {
+      w.close();
+    }
+    this.watchers = [];
+    for (const timer of this.recent.values()) {
+      clearTimeout(timer);
+    }
+    this.recent.clear();
+  }
+}
+
+export function createWatcher(paths: string[], opts: CreateWatcherOptions = {}): FileWatcher {
+  return new FileWatcher(paths, opts);
+}
+
+export type { FileWatcher };

--- a/packages/mochi/src/publicDirSpaces.test.ts
+++ b/packages/mochi/src/publicDirSpaces.test.ts
@@ -5,7 +5,7 @@ import type { Server } from 'bun';
 import { Mochi } from './Mochi';
 
 // Poll a URL until it returns the expected status or the deadline passes. The
-// dev watcher debounces public-dir changes (~100ms) and chokidar's event
+// dev watcher debounces public-dir changes (~100ms) and fs.watch event
 // latency varies by platform, so the live-add assertion can't fetch immediately.
 async function fetchUntil(url: string, status: number, timeoutMs = 8000): Promise<Response> {
   const deadline = performance.now() + timeoutMs;


### PR DESCRIPTION
## Summary

- Drop `chokidar` + `readdirp` from `mochi-framework` dependencies (2 fewer packages shipped to npm consumers)
- Add `packages/mochi/src/lib/fileWatcher.ts` — a zero-dep shim over Bun's native `node:fs` recursive `watch` that reproduces the chokidar event surface (`add`/`change`/`unlink`/`addDir`/`unlinkDir`, `ready`, `error`, cwd-relative paths, ignore matchers)
- Swap both `chokidar.watch()` call sites in `devWatcher.ts`; all existing event handler code is unchanged

## Test plan

- [ ] `bun run checks` passes (lint + typecheck + 58/58 mochi tests)
- [ ] `publicDirSpaces.test.ts` live-add regression passes (native watcher drives the public-dir hot-reload path)
- [ ] Dev smoke test on macOS: `.svelte` / `.css` / public asset / `svelte.config.js` edits each trigger HMR
- [ ] **Linux (Docker)**: smoke test recursive `fs.watch` on deploy target before merging — recursive semantics differ from macOS