### PR TITLE
feat: add MCP server at /mcp (tmcp, get_documentation_sections, get_section)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -6,7 +6,7 @@
     },
     "mochi-mcp": {
       "type": "http",
-      "url": "http://localhost:3333/mcp"
+      "url": "https://mochi.fast/mcp"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "svelte": {
       "type": "http",
       "url": "https://mcp.svelte.dev/mcp"
+    },
+    "yt-subsor-mcp": {
+      "type": "http",
+      "url": "http://localhost:3333/mcp"
     }
   }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://mcp.svelte.dev/mcp"
     },
-    "yt-subsor-mcp": {
+    "mochi-mcp": {
       "type": "http",
       "url": "http://localhost:3333/mcp"
     }

--- a/bun.lock
+++ b/bun.lock
@@ -120,6 +120,8 @@
         "@fontsource/public-sans": "^5.2.7",
         "@lucide/svelte": "^1.18.0",
         "@mdi/js": "7.4.47",
+        "@tmcp/adapter-valibot": "0.1.6",
+        "@tmcp/transport-http": "0.8.6",
         "mdsvex": "^0.12.7",
         "mochi-framework": "workspace:*",
         "rehype-slug": "^6.0.0",
@@ -128,6 +130,8 @@
         "svelte": "^5.56.3",
         "svelte-french-toast": "2.0.0-alpha.0",
         "svelte-meta-tags": "^5.0.0",
+        "tmcp": "1.19.4",
+        "valibot": "1.4.1",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -258,6 +262,8 @@
 
     "@shuding/opentype.js": ["@shuding/opentype.js@1.4.0-beta.0", "", { "dependencies": { "fflate": "^0.7.3", "string.prototype.codepointat": "^0.2.1" }, "bin": { "ot": "bin/ot" } }, "sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 
     "@sveltejs/load-config": ["@sveltejs/load-config@0.1.1", "", {}, "sha512-BXXm+VOH/9X4N7Dd1iZ2MqA1h7M+9i2noI8QYuLDY8QcN2WHYn7D/VK/+IJNfcAmRw7ACNJ538UT9GXIhnBTiA=="],
@@ -289,6 +295,12 @@
     "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg=="],
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.1", "", { "os": "win32", "cpu": "x64" }, "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA=="],
+
+    "@tmcp/adapter-valibot": ["@tmcp/adapter-valibot@0.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@valibot/to-json-schema": "^1.3.0", "valibot": "^1.1.0" }, "peerDependencies": { "tmcp": "^1.17.0" } }, "sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA=="],
+
+    "@tmcp/session-manager": ["@tmcp/session-manager@0.2.2", "", { "peerDependencies": { "tmcp": "^1.16.3" } }, "sha512-UrCRpTsxh5XnMbplspvftEYboiZWgAiXqqAUbyFTHoHMJ0LoNDy8bQd0+7qtxtT4S5Qsnv650gvs/Nbec5NTCQ=="],
+
+    "@tmcp/transport-http": ["@tmcp/transport-http@0.8.6", "", { "dependencies": { "@tmcp/session-manager": "^0.2.2", "esm-env": "^1.2.2" }, "peerDependencies": { "@tmcp/auth": "^0.3.3 || ^0.4.0", "tmcp": "^1.18.0" }, "optionalPeers": ["@tmcp/auth"] }, "sha512-iLcxu+tEMbkVHbhFfyXQhxfPDDTfm+F0kEw8Xg/a1rm29s4cBg1vwcpbtk02XTxsdDh8RJ1AZkQwF9WDGeb/IA=="],
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
@@ -335,6 +347,8 @@
     "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.61.0", "", { "dependencies": { "@typescript-eslint/types": "8.61.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.1", "", {}, "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ=="],
+
+    "@valibot/to-json-schema": ["@valibot/to-json-schema@1.7.1", "", { "peerDependencies": { "valibot": "^1.4.0" } }, "sha512-3qkmU6KXWh8GIThEAW3kuRHPQBMjWkKy+Ppz3WkUucx53DTpOa6siMn4xDGSOhlVyMrDaJTCTMLYPZVAIk1P0A=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -511,6 +525,8 @@
     "js-cookie": ["js-cookie@3.0.8", "", {}, "sha512-yeJd4aNAdYZQjaon2bpD/Gb0B/omw7HQOsynXXcOiWVCacbBcPlgn8S/d1X6blFSaHao7ozqtW7NZW19xpCtIw=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-rpc-2.0": ["json-rpc-2.0@1.7.1", "", {}, "sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -692,6 +708,8 @@
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
+    "sqids": ["sqids@0.3.0", "", {}, "sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw=="],
+
     "string.prototype.codepointat": ["string.prototype.codepointat@0.2.1", "", {}, "sha512-2cBVCj6I4IOvEnjgO/hWqXjqBGsY+zwPmHl12Srk9IXSZ56Jwwmy+66XO5Iut/oQVR7t5ihYdLB0GMa4alEUcg=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
@@ -738,6 +756,8 @@
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "tmcp": ["tmcp@1.19.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "json-rpc-2.0": "^1.7.1", "sqids": "^0.3.0", "uri-template-matcher": "^1.1.1", "valibot": "^1.1.0" } }, "sha512-fMoUJ3Gef9iA0yKZNeW2SQCCKTluCwghUyOz/qxPS8XxrQk6Jlw4lgql3S+s6L//FteLeSJ7erKxMWl727mZoQ=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
@@ -764,7 +784,11 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "uri-template-matcher": ["uri-template-matcher@1.1.2", "", {}, "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "update": "bun update --interactive --recursive",
     "deps": "bun packages/mochi/scripts/dep-report.ts",
     "e18e": "bash scripts/e18e.sh",
-    "mochi:animate": "bun --cwd=packages/video-animations run animate"
+    "mochi:animate": "bun --cwd=packages/video-animations run animate",
+    "mcp": "DANGEROUSLY_OMIT_AUTH=true bunx @modelcontextprotocol/inspector"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/packages/docs/162-extensions.md
+++ b/packages/docs/162-extensions.md
@@ -171,6 +171,20 @@ await Mochi.serve({
 
 Do **NOT** bypass CSRF on a state-mutating endpoint; instead, prefer the narrower `csrf:trustedOrigins` filter or `csrf.checkOrigin: false` on `Mochi.serve()`.
 
+#### `trailingSlash:redirect`
+
+Override the `trailingSlash` policy for the current request. The filter receives the redirect the framework computed — a `Response` (301/308) when the path isn't canonical, or `null` when no redirect applies. Return the input unchanged to delegate, or `null` to skip the redirect and let the request reach its handler as-is. Sync. Useful for endpoints that must answer at an exact path regardless of the site-wide policy — e.g. an MCP endpoint at `/mcp` under `trailingSlash: 'always'`.
+
+```ts
+await Mochi.serve({
+  trailingSlash: 'always',
+  filters: {
+    'trailingSlash:redirect': (redirect, { url }) => (url.pathname === '/mcp' ? null : redirect),
+  },
+  routes,
+});
+```
+
 #### `cookie:defaults`
 
 Default `CookieSerializeOptions` merged into every `cookies.set()` call. Per-call options win on a per-field basis. `path` and `domain` from defaults also apply to `cookies.delete()` so the browser still matches the original `Set-Cookie`. Resolved once at startup. Sync.

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -1166,7 +1166,7 @@ export class Mochi {
     const composedFetch = async (req: Request, server: Server<undefined>): Promise<Response> => {
       const url = buildPublicUrl(req, options.proxy);
       if (trailingSlashPolicy) {
-        const redirect = trailingSlashRedirect(req.method, url, trailingSlashPolicy);
+        const redirect = applyFilter('trailingSlash:redirect', trailingSlashRedirect(req.method, url, trailingSlashPolicy), { request: req, url, policy: trailingSlashPolicy });
         if (redirect) {
           return redirect;
         }

--- a/packages/mochi/src/extensions.test.ts
+++ b/packages/mochi/src/extensions.test.ts
@@ -409,6 +409,38 @@ describe('new extension points', () => {
     expect(result).toBe(blocking);
   });
 
+  test('trailingSlash:redirect can suppress the redirect for a specific path', () => {
+    const redirect = new Response(null, { status: 308, headers: { Location: '/mcp/' } });
+    initExtensions({
+      filters: {
+        'trailingSlash:redirect': (computed, { url }) => (url.pathname === '/mcp' ? null : computed),
+      },
+    });
+    const exempt = applyFilter('trailingSlash:redirect', redirect, {
+      request: new Request('http://localhost/mcp'),
+      url: new URL('http://localhost/mcp'),
+      policy: 'always',
+    });
+    expect(exempt).toBeNull();
+    const other = applyFilter('trailingSlash:redirect', redirect, {
+      request: new Request('http://localhost/docs'),
+      url: new URL('http://localhost/docs'),
+      policy: 'always',
+    });
+    expect(other).toBe(redirect);
+  });
+
+  test('trailingSlash:redirect leaves the computed redirect untouched with no filter', () => {
+    const redirect = new Response(null, { status: 308, headers: { Location: '/foo/' } });
+    initExtensions({ filters: {} });
+    const result = applyFilter('trailingSlash:redirect', redirect, {
+      request: new Request('http://localhost/foo'),
+      url: new URL('http://localhost/foo'),
+      policy: 'always',
+    });
+    expect(result).toBe(redirect);
+  });
+
   // The runtime fires `route:matched` from inside `requestContext.run(...)`
   // for all four kinds (page, api, ws, sse). Drive the same shape here to lock
   // the contract that `getRequestContext()` works inside the hook regardless

--- a/packages/mochi/src/extensions.ts
+++ b/packages/mochi/src/extensions.ts
@@ -19,6 +19,7 @@ import type { PreprocessorGroup } from 'svelte/compiler';
 import type { CookieSerializeOptions } from './cookies';
 import type { MochiServeOptions } from './types';
 import type { MochiEventMap, MochiRequestKind } from './events';
+import type { TrailingSlashPolicy } from './trailingSlash';
 import { pinGlobal } from './globalState';
 
 /**
@@ -71,6 +72,7 @@ export interface MochiFilterValue {
   'csrf:protectedMethods': Set<string>;
   'csrf:trustedOrigins': Set<string>;
   'csrf:check': Response | null;
+  'trailingSlash:redirect': Response | null;
   'cookie:defaults': CookieSerializeOptions;
   'html:shell': string;
   'serverIsland:secretKey': Buffer;
@@ -92,6 +94,7 @@ export interface MochiFilterContext {
   'csrf:protectedMethods': { options: MochiServeOptions };
   'csrf:trustedOrigins': { options: MochiServeOptions };
   'csrf:check': { request: Request; url: URL };
+  'trailingSlash:redirect': { request: Request; url: URL; policy: TrailingSlashPolicy };
   'cookie:defaults': { options: MochiServeOptions };
   'html:shell': { options: MochiServeOptions; development: boolean };
   'serverIsland:secretKey': { options: MochiServeOptions; envKeyPresent: boolean };
@@ -159,6 +162,7 @@ const FILTER_KINDS: { [K in keyof MochiFilterValue]: MochiKind } = {
   'csrf:protectedMethods': 'sync',
   'csrf:trustedOrigins': 'sync',
   'csrf:check': 'sync',
+  'trailingSlash:redirect': 'sync',
   'cookie:defaults': 'sync',
   'html:shell': 'sync',
   'serverIsland:secretKey': 'async',

--- a/packages/mochi/src/extensions.ts
+++ b/packages/mochi/src/extensions.ts
@@ -125,6 +125,7 @@ export interface MochiFilterKindMap {
   'csrf:protectedMethods': 'sync';
   'csrf:trustedOrigins': 'sync';
   'csrf:check': 'sync';
+  'trailingSlash:redirect': 'sync';
   'cookie:defaults': 'sync';
   'html:shell': 'sync';
   'serverIsland:secretKey': 'async';

--- a/packages/mochi/src/requestSetup.ts
+++ b/packages/mochi/src/requestSetup.ts
@@ -2,6 +2,7 @@ import type { Server } from 'bun';
 import { csrfCheck, type MochiCsrfOptions } from './csrf';
 import { buildPublicUrl, getClientAddress, type MochiProxyOptions } from './proxy';
 import { extractParams } from './utils';
+import { applyFilter } from './extensions';
 import { trailingSlashRedirect, type TrailingSlashPolicy } from './trailingSlash';
 import { MochiCookieJar, type CookieSerializeOptions } from './cookies';
 import { mochiEvents } from './events';
@@ -89,7 +90,7 @@ export function makeRequestContextBuilder(cfg: RequestSetupConfig): RequestConte
     };
 
     if (policy.trailingSlash && cfg.trailingSlashPolicy) {
-      const redirect = trailingSlashRedirect(req.method, url, cfg.trailingSlashPolicy);
+      const redirect = applyFilter('trailingSlash:redirect', trailingSlashRedirect(req.method, url, cfg.trailingSlashPolicy), { request: req, url, policy: cfg.trailingSlashPolicy });
       if (redirect) {
         reportEarlyExit(redirect.status);
         return { earlyResponse: redirect };

--- a/packages/mochi/src/requestSetup.ts
+++ b/packages/mochi/src/requestSetup.ts
@@ -90,7 +90,11 @@ export function makeRequestContextBuilder(cfg: RequestSetupConfig): RequestConte
     };
 
     if (policy.trailingSlash && cfg.trailingSlashPolicy) {
-      const redirect = applyFilter('trailingSlash:redirect', trailingSlashRedirect(req.method, url, cfg.trailingSlashPolicy), { request: req, url, policy: cfg.trailingSlashPolicy });
+      const redirect = applyFilter('trailingSlash:redirect', trailingSlashRedirect(req.method, url, cfg.trailingSlashPolicy), {
+        request: req,
+        url,
+        policy: cfg.trailingSlashPolicy,
+      });
       if (redirect) {
         reportEarlyExit(redirect.status);
         return { earlyResponse: redirect };

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -20,6 +20,8 @@
     "@fontsource/public-sans": "^5.2.7",
     "@lucide/svelte": "^1.18.0",
     "@mdi/js": "7.4.47",
+    "@tmcp/adapter-valibot": "0.1.6",
+    "@tmcp/transport-http": "0.8.6",
     "mdsvex": "^0.12.7",
     "mochi-framework": "workspace:*",
     "rehype-slug": "^6.0.0",
@@ -27,7 +29,9 @@
     "slugify": "^1.6.9",
     "svelte": "^5.56.3",
     "svelte-french-toast": "2.0.0-alpha.0",
-    "svelte-meta-tags": "^5.0.0"
+    "svelte-meta-tags": "^5.0.0",
+    "tmcp": "1.19.4",
+    "valibot": "1.4.1"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -145,6 +145,9 @@ await Mochi.serve({
   },
   filters: {
     'consoleLogger:line': silenceInternalRoutes,
+    // The MCP endpoint must answer at exactly /mcp; the site-wide trailingSlash: 'always'
+    // policy would otherwise 308 it to /mcp/ and some MCP clients don't follow the redirect.
+    'trailingSlash:redirect': (redirect, { url }) => (url.pathname === '/mcp' ? null : redirect),
   },
   routes,
 });

--- a/packages/site/src/lib/docs.ts
+++ b/packages/site/src/lib/docs.ts
@@ -316,9 +316,6 @@ export interface SectionIndexEntry {
   description: string;
 }
 
-// Flat, type-qualified catalog of every doc and demo — the same data behind /llms.json, but keyed by
-// {type, slug} instead of URLs so the MCP server can hand an agent a stable id to fetch with get_section.
-// The type qualifier disambiguates the slugs (e.g. view-transitions) that exist as both a doc and a demo.
 export async function buildSectionIndex(): Promise<SectionIndexEntry[]> {
   const docList = await loadDocs();
   const docs: SectionIndexEntry[] = docList.map((d) => ({

--- a/packages/site/src/lib/docs.ts
+++ b/packages/site/src/lib/docs.ts
@@ -324,7 +324,7 @@ export async function buildSectionIndex(): Promise<SectionIndexEntry[]> {
     title: d.title,
     description: d.description ?? '',
   }));
-  const demoEntries: SectionIndexEntry[] = internalDemos().map((d) => ({ type: 'demo', slug: d.slug!, title: d.title, description: d.hook }));
+  const demoEntries: SectionIndexEntry[] = internalDemos().map((d) => ({ type: 'demo', slug: d.slug, title: d.title, description: d.hook }));
   return [...docs, ...demoEntries];
 }
 

--- a/packages/site/src/lib/docs.ts
+++ b/packages/site/src/lib/docs.ts
@@ -309,6 +309,28 @@ export function internalDemoLlmsRoutes(): DemoLlmsRoute[] {
   return internalDemos().map((d) => ({ path: demoLlmsPath(d.href), slug: d.slug }));
 }
 
+export interface SectionIndexEntry {
+  type: 'doc' | 'demo';
+  slug: string;
+  title: string;
+  description: string;
+}
+
+// Flat, type-qualified catalog of every doc and demo — the same data behind /llms.json, but keyed by
+// {type, slug} instead of URLs so the MCP server can hand an agent a stable id to fetch with get_section.
+// The type qualifier disambiguates the slugs (e.g. view-transitions) that exist as both a doc and a demo.
+export async function buildSectionIndex(): Promise<SectionIndexEntry[]> {
+  const docList = await loadDocs();
+  const docs: SectionIndexEntry[] = docList.map((d) => ({
+    type: 'doc',
+    slug: d.slug,
+    title: d.title,
+    description: d.description ?? '',
+  }));
+  const demoEntries: SectionIndexEntry[] = internalDemos().map((d) => ({ type: 'demo', slug: d.slug!, title: d.title, description: d.hook }));
+  return [...docs, ...demoEntries];
+}
+
 export async function buildLlmsJson(origin: string): Promise<{ docs: LlmsIndexEntry[]; demos: LlmsIndexEntry[] }> {
   const docList = await loadDocs();
   const docs: LlmsIndexEntry[] = docList.map((d) => ({

--- a/packages/site/src/lib/mcp.test.ts
+++ b/packages/site/src/lib/mcp.test.ts
@@ -1,8 +1,6 @@
 import { beforeAll, describe, expect, test } from 'bun:test';
 import { mcpServer } from './mcp';
 
-// Drive the MCP server through receive() directly — no HTTP transport needed — to prove the two tools
-// list, return the right content, and disambiguate the slugs that exist as both a doc and a demo.
 type JsonRpcResult = { result?: { content?: { text: string }[]; isError?: boolean; tools?: { name: string }[]; serverInfo?: { name: string } } };
 
 async function call(method: string, params?: unknown, id = 1): Promise<JsonRpcResult> {

--- a/packages/site/src/lib/mcp.test.ts
+++ b/packages/site/src/lib/mcp.test.ts
@@ -62,7 +62,12 @@ describe('mcp docs server', () => {
     // `hydratable` exists as both a doc page and a demo; only the type tells them apart.
     const res = await call('tools/call', {
       name: 'get_section',
-      arguments: { sections: [{ type: 'doc', slug: 'hydratable' }, { type: 'demo', slug: 'hydratable' }] },
+      arguments: {
+        sections: [
+          { type: 'doc', slug: 'hydratable' },
+          { type: 'demo', slug: 'hydratable' },
+        ],
+      },
     });
     const text = toolText(res);
     expect(text).toContain('==== doc:hydratable ====');
@@ -75,7 +80,12 @@ describe('mcp docs server', () => {
   test('multiple sections are returned in the requested order', async () => {
     const res = await call('tools/call', {
       name: 'get_section',
-      arguments: { sections: [{ type: 'doc', slug: 'intro' }, { type: 'demo', slug: 'hello-world' }] },
+      arguments: {
+        sections: [
+          { type: 'doc', slug: 'intro' },
+          { type: 'demo', slug: 'hello-world' },
+        ],
+      },
     });
     const text = toolText(res);
     expect(text.indexOf('==== doc:intro ====')).toBeLessThan(text.indexOf('==== demo:hello-world ===='));
@@ -84,7 +94,12 @@ describe('mcp docs server', () => {
   test('missing slugs appear inline as (not found) but found sections still return as text', async () => {
     const res = await call('tools/call', {
       name: 'get_section',
-      arguments: { sections: [{ type: 'doc', slug: 'intro' }, { type: 'doc', slug: 'no-such-slug' }] },
+      arguments: {
+        sections: [
+          { type: 'doc', slug: 'intro' },
+          { type: 'doc', slug: 'no-such-slug' },
+        ],
+      },
     });
     expect(res.result?.isError).toBeUndefined();
     const text = toolText(res);
@@ -96,7 +111,12 @@ describe('mcp docs server', () => {
   test('returns a tool error only when every requested slug is missing', async () => {
     const res = await call('tools/call', {
       name: 'get_section',
-      arguments: { sections: [{ type: 'doc', slug: 'nope-1' }, { type: 'demo', slug: 'nope-2' }] },
+      arguments: {
+        sections: [
+          { type: 'doc', slug: 'nope-1' },
+          { type: 'demo', slug: 'nope-2' },
+        ],
+      },
     });
     expect(res.result?.isError).toBe(true);
   });

--- a/packages/site/src/lib/mcp.test.ts
+++ b/packages/site/src/lib/mcp.test.ts
@@ -45,29 +45,59 @@ describe('mcp docs server', () => {
   });
 
   test('get_section returns the raw markdown for a doc', async () => {
-    const res = await call('tools/call', { name: 'get_section', arguments: { type: 'doc', slug: 'intro' } });
-    expect(toolText(res)).toContain('slug: intro');
+    const res = await call('tools/call', { name: 'get_section', arguments: { sections: [{ type: 'doc', slug: 'intro' }] } });
+    const text = toolText(res);
+    expect(text).toContain('==== doc:intro ====');
+    expect(text).toContain('slug: intro');
   });
 
   test('get_section returns the source bundle for a demo', async () => {
-    const res = await call('tools/call', { name: 'get_section', arguments: { type: 'demo', slug: 'hello-world' } });
-    expect(toolText(res)).toContain('## Demo: hello-world');
+    const res = await call('tools/call', { name: 'get_section', arguments: { sections: [{ type: 'demo', slug: 'hello-world' }] } });
+    const text = toolText(res);
+    expect(text).toContain('==== demo:hello-world ====');
+    expect(text).toContain('## Demo: hello-world');
   });
 
   test('the type qualifier disambiguates a slug that is both a doc and a demo', async () => {
     // `hydratable` exists as both a doc page and a demo; only the type tells them apart.
-    const doc = await call('tools/call', { name: 'get_section', arguments: { type: 'doc', slug: 'hydratable' } });
-    const demo = await call('tools/call', { name: 'get_section', arguments: { type: 'demo', slug: 'hydratable' } });
-    const docText = toolText(doc);
-    const demoText = toolText(demo);
-    expect(docText).not.toBe(demoText);
-    expect(demoText).toContain('## Demo: hydratable');
-    expect(docText).not.toContain('## Demo: hydratable');
+    const res = await call('tools/call', {
+      name: 'get_section',
+      arguments: { sections: [{ type: 'doc', slug: 'hydratable' }, { type: 'demo', slug: 'hydratable' }] },
+    });
+    const text = toolText(res);
+    expect(text).toContain('==== doc:hydratable ====');
+    expect(text).toContain('==== demo:hydratable ====');
+    // doc comes before demo (requested order preserved)
+    expect(text.indexOf('==== doc:hydratable ====')).toBeLessThan(text.indexOf('==== demo:hydratable ===='));
+    expect(text).toContain('## Demo: hydratable');
   });
 
-  test('an unknown slug returns a tool error, not a crash', async () => {
-    const res = await call('tools/call', { name: 'get_section', arguments: { type: 'doc', slug: 'does-not-exist' } });
+  test('multiple sections are returned in the requested order', async () => {
+    const res = await call('tools/call', {
+      name: 'get_section',
+      arguments: { sections: [{ type: 'doc', slug: 'intro' }, { type: 'demo', slug: 'hello-world' }] },
+    });
+    const text = toolText(res);
+    expect(text.indexOf('==== doc:intro ====')).toBeLessThan(text.indexOf('==== demo:hello-world ===='));
+  });
+
+  test('missing slugs appear inline as (not found) but found sections still return as text', async () => {
+    const res = await call('tools/call', {
+      name: 'get_section',
+      arguments: { sections: [{ type: 'doc', slug: 'intro' }, { type: 'doc', slug: 'no-such-slug' }] },
+    });
+    expect(res.result?.isError).toBeUndefined();
+    const text = toolText(res);
+    expect(text).toContain('==== doc:intro ====');
+    expect(text).toContain('==== doc:no-such-slug ====');
+    expect(text).toContain('(not found)');
+  });
+
+  test('returns a tool error only when every requested slug is missing', async () => {
+    const res = await call('tools/call', {
+      name: 'get_section',
+      arguments: { sections: [{ type: 'doc', slug: 'nope-1' }, { type: 'demo', slug: 'nope-2' }] },
+    });
     expect(res.result?.isError).toBe(true);
-    expect(toolText(res)).toContain('does-not-exist');
   });
 });

--- a/packages/site/src/lib/mcp.test.ts
+++ b/packages/site/src/lib/mcp.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, describe, expect, test } from 'bun:test';
+import { mcpServer } from './mcp';
+
+// Drive the MCP server through receive() directly — no HTTP transport needed — to prove the two tools
+// list, return the right content, and disambiguate the slugs that exist as both a doc and a demo.
+type JsonRpcResult = { result?: { content?: { text: string }[]; isError?: boolean; tools?: { name: string }[]; serverInfo?: { name: string } } };
+
+async function call(method: string, params?: unknown, id = 1): Promise<JsonRpcResult> {
+  return (await mcpServer.receive({ jsonrpc: '2.0', id, method, params } as never)) as JsonRpcResult;
+}
+
+function toolText(res: JsonRpcResult): string {
+  return res.result?.content?.map((c) => c.text).join('') ?? '';
+}
+
+describe('mcp docs server', () => {
+  beforeAll(async () => {
+    await call('initialize', { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '1.0.0' } });
+    await mcpServer.receive({ jsonrpc: '2.0', method: 'notifications/initialized' } as never);
+  });
+
+  test('initialize reports the server identity', async () => {
+    const res = await call('initialize', { protocolVersion: '2025-06-18', capabilities: {}, clientInfo: { name: 'test', version: '1.0.0' } });
+    expect(res.result?.serverInfo?.name).toBe('mochi-docs');
+  });
+
+  test('tools/list exposes exactly the two documentation tools', async () => {
+    const res = await call('tools/list', {});
+    const names = res.result?.tools?.map((t) => t.name) ?? [];
+    expect(names).toContain('get_documentation_sections');
+    expect(names).toContain('get_section');
+  });
+
+  test('get_documentation_sections lists known docs and demos with their type', async () => {
+    const res = await call('tools/call', { name: 'get_documentation_sections', arguments: {} });
+    const sections = JSON.parse(toolText(res)) as { type: string; slug: string; title: string; description: string }[];
+    expect(sections.some((s) => s.type === 'doc' && s.slug === 'intro')).toBe(true);
+    expect(sections.some((s) => s.type === 'demo' && s.slug === 'hello-world')).toBe(true);
+    // Every entry carries the fields an agent needs to pick and fetch a section.
+    for (const s of sections) {
+      expect(s.type === 'doc' || s.type === 'demo').toBe(true);
+      expect(s.slug).toBeTruthy();
+      expect(s.title).toBeTruthy();
+    }
+  });
+
+  test('get_section returns the raw markdown for a doc', async () => {
+    const res = await call('tools/call', { name: 'get_section', arguments: { type: 'doc', slug: 'intro' } });
+    expect(toolText(res)).toContain('slug: intro');
+  });
+
+  test('get_section returns the source bundle for a demo', async () => {
+    const res = await call('tools/call', { name: 'get_section', arguments: { type: 'demo', slug: 'hello-world' } });
+    expect(toolText(res)).toContain('## Demo: hello-world');
+  });
+
+  test('the type qualifier disambiguates a slug that is both a doc and a demo', async () => {
+    // `hydratable` exists as both a doc page and a demo; only the type tells them apart.
+    const doc = await call('tools/call', { name: 'get_section', arguments: { type: 'doc', slug: 'hydratable' } });
+    const demo = await call('tools/call', { name: 'get_section', arguments: { type: 'demo', slug: 'hydratable' } });
+    const docText = toolText(doc);
+    const demoText = toolText(demo);
+    expect(docText).not.toBe(demoText);
+    expect(demoText).toContain('## Demo: hydratable');
+    expect(docText).not.toContain('## Demo: hydratable');
+  });
+
+  test('an unknown slug returns a tool error, not a crash', async () => {
+    const res = await call('tools/call', { name: 'get_section', arguments: { type: 'doc', slug: 'does-not-exist' } });
+    expect(res.result?.isError).toBe(true);
+    expect(toolText(res)).toContain('does-not-exist');
+  });
+});

--- a/packages/site/src/lib/mcp.ts
+++ b/packages/site/src/lib/mcp.ts
@@ -44,21 +44,34 @@ mcpServer.tool(
 mcpServer.tool(
   {
     name: 'get_section',
-    description: 'Fetch the full text of one documentation section (a doc page or a demo) by its type and slug, as returned by get_documentation_sections.',
+    description:
+      'Fetch the full text of one or more documentation sections (doc pages or demos). Pass an array of { type, slug } objects as returned by get_documentation_sections. Sections are returned in the requested order, each preceded by an ==== type:slug ==== marker.',
     annotations: readOnlyHints,
     schema: v.object({
-      type: v.picklist(['doc', 'demo']),
-      slug: v.string(),
+      sections: v.array(v.object({ type: v.picklist(['doc', 'demo']), slug: v.string() })),
     }),
   },
-  async ({ type, slug }) => {
-    const content = type === 'doc' ? await getDocLlmsTxt(slug) : await getDemoLlmsTxt(slug);
-    if (content === null) {
-      logger.warn(`[mcp] get_section ${type}:${slug} → not found`);
-      return tool.error(`No ${type} found with slug '${slug}'. Call get_documentation_sections to list valid slugs.`);
+  async ({ sections }) => {
+    const results = await Promise.all(
+      sections.map(async ({ type, slug }) => {
+        const content = type === 'doc' ? await getDocLlmsTxt(slug) : await getDemoLlmsTxt(slug);
+        return { type, slug, content };
+      }),
+    );
+
+    const parts: string[] = [];
+    const found: string[] = [];
+    const missing: string[] = [];
+    for (const { type, slug, content } of results) {
+      const id = `${type}:${slug}`;
+      parts.push(`==== ${id} ====\n\n${content !== null ? content.trimEnd() : '(not found)'}`);
+      if (content !== null) found.push(id);
+      else missing.push(id);
     }
-    logger.log(`[mcp] get_section ${type}:${slug} → ${content.length} chars`);
-    return tool.text(content);
+    if (found.length) logger.log(`[mcp] get_section [${found.join(', ')}] → ${found.length} found`);
+    if (missing.length) logger.warn(`[mcp] get_section not found: ${missing.join(', ')}`);
+    if (!found.length) return tool.error(`None of the requested sections were found. Call get_documentation_sections to list valid slugs.`);
+    return tool.text(parts.join('\n\n'));
   },
 );
 

--- a/packages/site/src/lib/mcp.ts
+++ b/packages/site/src/lib/mcp.ts
@@ -1,6 +1,7 @@
 import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
 import { HttpTransport } from '@tmcp/transport-http';
 import mochiPkg from 'mochi-framework/package.json' with { type: 'json' };
+import { logger } from 'mochi-framework';
 import { McpServer } from 'tmcp';
 import { tool } from 'tmcp/utils';
 import * as v from 'valibot';
@@ -33,7 +34,11 @@ mcpServer.tool(
       'List every Mochi documentation section and demo. Returns a JSON array of { type, slug, title, description }. Call this first, then pass a { type, slug } to get_section to read one.',
     annotations: readOnlyHints,
   },
-  async () => tool.text(JSON.stringify(await buildSectionIndex())),
+  async () => {
+    const sections = await buildSectionIndex();
+    logger.log('[mcp] get_documentation_sections →', sections.length, 'sections');
+    return tool.text(JSON.stringify(sections));
+  },
 );
 
 mcpServer.tool(
@@ -49,8 +54,10 @@ mcpServer.tool(
   async ({ type, slug }) => {
     const content = type === 'doc' ? await getDocLlmsTxt(slug) : await getDemoLlmsTxt(slug);
     if (content === null) {
+      logger.warn(`[mcp] get_section ${type}:${slug} → not found`);
       return tool.error(`No ${type} found with slug '${slug}'. Call get_documentation_sections to list valid slugs.`);
     }
+    logger.log(`[mcp] get_section ${type}:${slug} → ${content.length} chars`);
     return tool.text(content);
   },
 );

--- a/packages/site/src/lib/mcp.ts
+++ b/packages/site/src/lib/mcp.ts
@@ -1,0 +1,67 @@
+import { ValibotJsonSchemaAdapter } from '@tmcp/adapter-valibot';
+import { HttpTransport } from '@tmcp/transport-http';
+import mochiPkg from 'mochi-framework/package.json' with { type: 'json' };
+import { McpServer } from 'tmcp';
+import { tool } from 'tmcp/utils';
+import * as v from 'valibot';
+import { buildSectionIndex, getDemoLlmsTxt, getDocLlmsTxt } from './docs';
+
+const adapter = new ValibotJsonSchemaAdapter();
+
+export const mcpServer = new McpServer(
+  {
+    name: 'mochi-docs',
+    version: `${mochiPkg.version}`,
+    description:
+      'Official documentation and demos for the Mochi framework (SSR-first Svelte 5 on Bun with islands-based hydration). ALWAYS consult this server before writing or changing code in an application built on Mochi: call get_documentation_sections to see what exists, then get_section to read the relevant docs and demos. The framework has its own APIs and conventions, so do not rely on prior assumptions — verify against these docs first.',
+  },
+  {
+    adapter,
+    capabilities: { tools: { listChanged: false } },
+  },
+);
+
+// Both tools only read documentation — never mutate state and always return the same result for the
+// same input — so spell out the hints rather than letting clients fall back to the conservative
+// defaults (destructive, non-idempotent, open-world).
+const readOnlyHints = { readOnlyHint: true, destructiveHint: false, idempotentHint: true, openWorldHint: false } as const;
+
+mcpServer.tool(
+  {
+    name: 'get_documentation_sections',
+    description:
+      'List every Mochi documentation section and demo. Returns a JSON array of { type, slug, title, description }. Call this first, then pass a { type, slug } to get_section to read one.',
+    annotations: readOnlyHints,
+  },
+  async () => tool.text(JSON.stringify(await buildSectionIndex())),
+);
+
+mcpServer.tool(
+  {
+    name: 'get_section',
+    description: 'Fetch the full text of one documentation section (a doc page or a demo) by its type and slug, as returned by get_documentation_sections.',
+    annotations: readOnlyHints,
+    schema: v.object({
+      type: v.picklist(['doc', 'demo']),
+      slug: v.string(),
+    }),
+  },
+  async ({ type, slug }) => {
+    const content = type === 'doc' ? await getDocLlmsTxt(slug) : await getDemoLlmsTxt(slug);
+    if (content === null) {
+      return tool.error(`No ${type} found with slug '${slug}'. Call get_documentation_sections to list valid slugs.`);
+    }
+    return tool.text(content);
+  },
+);
+
+// A `trailingSlash:redirect` filter in index.ts exempts /mcp from the site's `trailingSlash: 'always'`
+// policy so the endpoint answers at /mcp directly. The Mochi route already scopes this transport to
+// that path, so let it respond regardless of pathname (`path: null`) — that also keeps the /mcp/ form
+// working for clients that still send it. This server only answers request/response tool calls and
+// pushes nothing back, so the long-lived SSE stream is disabled (GET returns 405).
+const transport = new HttpTransport(mcpServer, { path: null, disableSse: true });
+
+export async function respondMcp(request: Request): Promise<Response> {
+  return (await transport.respond(request)) ?? new Response('Not Found', { status: 404 });
+}

--- a/packages/site/src/lib/mcp.ts
+++ b/packages/site/src/lib/mcp.ts
@@ -85,10 +85,7 @@ mcpServer.tool(
 );
 
 // A `trailingSlash:redirect` filter in index.ts exempts /mcp from the site's `trailingSlash: 'always'`
-// policy so the endpoint answers at /mcp directly. The Mochi route already scopes this transport to
-// that path, so let it respond regardless of pathname (`path: null`) — that also keeps the /mcp/ form
-// working for clients that still send it. This server only answers request/response tool calls and
-// pushes nothing back, so the long-lived SSE stream is disabled (GET returns 405).
+// policy so the endpoint answers at /mcp directly.
 const transport = new HttpTransport(mcpServer, { path: null, disableSse: true });
 
 export async function respondMcp(request: Request): Promise<Response> {

--- a/packages/site/src/lib/mcp.ts
+++ b/packages/site/src/lib/mcp.ts
@@ -65,12 +65,21 @@ mcpServer.tool(
     for (const { type, slug, content } of results) {
       const id = `${type}:${slug}`;
       parts.push(`==== ${id} ====\n\n${content !== null ? content.trimEnd() : '(not found)'}`);
-      if (content !== null) found.push(id);
-      else missing.push(id);
+      if (content !== null) {
+        found.push(id);
+      } else {
+        missing.push(id);
+      }
     }
-    if (found.length) logger.log(`[mcp] get_section [${found.join(', ')}] → ${found.length} found`);
-    if (missing.length) logger.warn(`[mcp] get_section not found: ${missing.join(', ')}`);
-    if (!found.length) return tool.error(`None of the requested sections were found. Call get_documentation_sections to list valid slugs.`);
+    if (found.length) {
+      logger.log(`[mcp] get_section [${found.join(', ')}] → ${found.length} found`);
+    }
+    if (missing.length) {
+      logger.warn(`[mcp] get_section not found: ${missing.join(', ')}`);
+    }
+    if (!found.length) {
+      return tool.error(`None of the requested sections were found. Call get_documentation_sections to list valid slugs.`);
+    }
     return tool.text(parts.join('\n\n'));
   },
 );

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -14,6 +14,7 @@ import {
   internalDemoLlmsRoutes,
   loadDocs,
 } from './lib/docs';
+import { respondMcp } from './lib/mcp';
 import { profilerEnabled, startProfiler, stopProfiler } from './lib/profiler';
 import { routes as apiRoutes } from './demos/api/routes';
 import { routes as cacheEventsRoutes } from './demos/cache-events/routes';
@@ -160,6 +161,7 @@ export const routes: Record<string, MochiRouteValue> = {
     return Response.json(await buildLlmsJson(url.origin));
   }),
   '/SKILL.md': Mochi.file('./src/SKILL.md'),
+  '/mcp': Mochi.api(({ request }) => respondMcp(request)),
   ...demoLlmsRoutes,
   ...apiRoutes,
   ...cacheEventsRoutes,


### PR DESCRIPTION
## Summary

- Adds an HTTP MCP server at `/mcp` powered by `tmcp` + `@tmcp/transport-http` + Valibot
- Two tools: `get_documentation_sections` (full catalog of docs + demos) and `get_section({ type, slug })` (fetch one doc or demo by its qualified id)
- Both tools carry correct read-only annotations (`readOnlyHint`, `destructiveHint: false`, `idempotentHint`, `openWorldHint: false`)
- Server description instructs agents to always consult these docs before working on Mochi apps
- Adds `trailingSlash:redirect` filter to the framework extension API so `/mcp` can be exempted from the site's `trailingSlash: 'always'` policy — clients POST to `/mcp` directly without a 308 redirect
- SSE stream disabled (`disableSse: true`) — this server is request/response only with no server-push notifications
- Server version tracks `mochi-framework` package version

## Test plan

- [ ] `bun test packages/site/src/lib/mcp.test.ts` — 7 tests covering tools/list, both tools, colliding slug disambiguation (`hydratable` as both doc and demo), and unknown-slug error path
- [ ] `bun test packages/mochi/src/extensions.test.ts` — 2 new tests for `trailingSlash:redirect` filter (suppress for `/mcp`, pass-through for other paths)
- [ ] Live: `POST http://localhost:3333/mcp` with `initialize` → `tools/list` → `tools/call` using an MCP client