### PR TITLE
fix(cli): reference both svelte-check patch versions in scaffolded projects

### DIFF
--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -79,6 +79,7 @@ describe('transformPackageJson', () => {
     const input = JSON.stringify({ name: 'mochi-minimal' });
     const out = JSON.parse(transformPackageJson(input, { name: 'my-app', mochiVersion: '^0.1.0' }));
     expect(out.patchedDependencies).toEqual({
+      'svelte-check@4.4.7': 'patches/svelte-check@4.4.7.patch',
       'svelte-check@4.6.0': 'patches/svelte-check@4.6.0.patch',
     });
   });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -96,7 +96,13 @@ export function transformPackageJson(contents: string, opts: PackageJsonTransfor
   // path against the repo root, which breaks for a workspace-relative path.
   // Templates ship the patch *file* under `patches/`; we wire it up here so the
   // scaffolded standalone project picks it up on first `bun install`.
+  //
+  // We reference both the current and the previous svelte-check versions so the
+  // generated project survives drift between a published CLI and the live-served
+  // template (they bump independently). Bun applies only the entry whose version
+  // actually resolves and ignores the other, as long as both patch files exist.
   pkg.patchedDependencies = {
+    'svelte-check@4.4.7': 'patches/svelte-check@4.4.7.patch',
     'svelte-check@4.6.0': 'patches/svelte-check@4.6.0.patch',
   };
 

--- a/packages/demos/patches/svelte-check@4.4.7.patch
+++ b/packages/demos/patches/svelte-check@4.4.7.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/src/index.js b/dist/src/index.js
+--- a/dist/src/index.js
++++ b/dist/src/index.js
+@@ -96867,6 +96867,13 @@
+                 }
+                 value.push('})');
+             }
++            else if (attr.name.startsWith('mochi:')) {
++                name.unshift('...__sveltets_2_empty({');
++                if (!value) {
++                    value = ['__sveltets_2_any()'];
++                }
++                value.push('})');
++            }
+             element.addProp(name, value);
+         };
+     const transformAttributeCase = (name) => {

--- a/packages/minimal/patches/svelte-check@4.4.7.patch
+++ b/packages/minimal/patches/svelte-check@4.4.7.patch
@@ -1,0 +1,17 @@
+diff --git a/dist/src/index.js b/dist/src/index.js
+--- a/dist/src/index.js
++++ b/dist/src/index.js
+@@ -96867,6 +96867,13 @@
+                 }
+                 value.push('})');
+             }
++            else if (attr.name.startsWith('mochi:')) {
++                name.unshift('...__sveltets_2_empty({');
++                if (!value) {
++                    value = ['__sveltets_2_any()'];
++                }
++                value.push('})');
++            }
+             element.addProp(name, value);
+         };
+     const transformAttributeCase = (name) => {


### PR DESCRIPTION
## Problem

`bun create mochi@latest` (minimal template) fails on the first `bun install`:

```
error: Couldn't find patch file: 'patches/svelte-check@4.4.7.patch'
```

### Root cause

The injected `patchedDependencies` version is **hardcoded in the published CLI** (`transformPackageJson`), while the template is **served live from `main`** and bumps independently. They drifted:

- Published `create-mochi@0.2.4` injects `svelte-check@4.4.7` → `patches/svelte-check@4.4.7.patch`.
- The live template was bumped to `svelte-check@4.6.0` and now only ships `4.6.0.patch`.

So the generated `package.json` references a patch file the template no longer contains. The `4.4.7 → 4.6.0` bump landed in a `chore:` commit (#98), which release-please does not publish — so npm still serves the stale CLI.

## Fix

- Inject **both** `svelte-check@4.4.7` and `svelte-check@4.6.0` patch entries (oldest → newest). Bun applies only the entry whose version actually resolves and ignores the other, provided both patch files exist (verified).
- Restore `svelte-check@4.4.7.patch` to **both** the `minimal` and `demos` templates (the CLI injects into whichever template is scaffolded).

This immediately unblocks the currently-published CLI (template served live from `main`) and, as a `fix(cli):`, triggers a `create-mochi` patch release so future scaffolds match too.