### PR TITLE
fix: stop demo source paths show up in island props + better demo links

### DIFF
--- a/packages/docs/10-intro.md
+++ b/packages/docs/10-intro.md
@@ -43,9 +43,9 @@ The header text, the main column, and the footer ship as HTML and stay that way.
 Questions, bug reports, ideas, or just want to see what others are building? Join the [Mochi Discord](/discord/).
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
-    { href: "/demos/hydration/", title: "Hydration Modes", hook: "The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island." },
-    { href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
-  ]}
+demos={[
+{ href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
+{ href: "/demos/hydration/", title: "Hydration Modes", hook: "The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island." },
+{ href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
+]}
 />

--- a/packages/docs/10-intro.md
+++ b/packages/docs/10-intro.md
@@ -7,6 +7,7 @@ description: 'A lightweight, server-first Svelte 5 framework running on Bun that
 <script>
   import Callout from './_components/Callout.svelte';
   import IslandsDemo from './_components/IslandsDemo.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 # mochi
@@ -40,3 +41,11 @@ The header text, the main column, and the footer ship as HTML and stay that way.
 ## Community
 
 Questions, bug reports, ideas, or just want to see what others are building? Join the [Mochi Discord](/discord/).
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
+    { href: "/demos/hydration/", title: "Hydration Modes", hook: "The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island." },
+    { href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
+  ]}
+/>

--- a/packages/docs/100-websocket-routes.md
+++ b/packages/docs/100-websocket-routes.md
@@ -6,6 +6,7 @@ description: 'Register WebSocket endpoints with Mochi.ws() and handle upgrade, o
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## WebSocket routes
@@ -150,3 +151,10 @@ message(ws, msg) {
 ### Lifecycle events
 
 Every WebSocket emits `ws:open`, `ws:message`, and `ws:close` on `mochiEvents`. `logger()` already prints them. See `Events` for the full payload shape and how to add custom subscribers.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/chat/", title: "Real-time Chat", hook: "A hydrated island over a Mochi.ws() route, with pub/sub broadcast and in-memory history." },
+    { href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." },
+  ]}
+/>

--- a/packages/docs/100-websocket-routes.md
+++ b/packages/docs/100-websocket-routes.md
@@ -153,8 +153,8 @@ message(ws, msg) {
 Every WebSocket emits `ws:open`, `ws:message`, and `ws:close` on `mochiEvents`. `logger()` already prints them. See `Events` for the full payload shape and how to add custom subscribers.
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/chat/", title: "Real-time Chat", hook: "A hydrated island over a Mochi.ws() route, with pub/sub broadcast and in-memory history." },
-    { href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." },
-  ]}
+demos={[
+{ href: "/demos/chat/", title: "Real-time Chat", hook: "A hydrated island over a Mochi.ws() route, with pub/sub broadcast and in-memory history." },
+{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." },
+]}
 />

--- a/packages/docs/11-your-first-mochi-app.md
+++ b/packages/docs/11-your-first-mochi-app.md
@@ -6,6 +6,7 @@ description: 'Build your first page with serverProps, selective hydration, and s
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Your first Mochi app
@@ -189,3 +190,10 @@ The finished app is running on this site at [**/docs/your-first-mochi-app/hello*
 - [Lazy hydration](/docs/lazy-hydration/) — `mochi:hydrate:visible` for below-the-fold islands
 - [Server islands](/docs/server-islands/) — `mochi:defer`, signed props, and `MOCHI_KEY`
 - [Passing props to islands](/docs/island-props/) — every type `devalue` can round-trip
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
+    { href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
+  ]}
+/>

--- a/packages/docs/11-your-first-mochi-app.md
+++ b/packages/docs/11-your-first-mochi-app.md
@@ -192,8 +192,8 @@ The finished app is running on this site at [**/docs/your-first-mochi-app/hello*
 - [Passing props to islands](/docs/island-props/) — every type `devalue` can round-trip
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
-    { href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
-  ]}
+demos={[
+{ href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
+{ href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
+]}
 />

--- a/packages/docs/110-server-sent-events.md
+++ b/packages/docs/110-server-sent-events.md
@@ -6,6 +6,7 @@ description: 'Push real-time updates to clients over a single HTTP connection wi
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Server-Sent Events
@@ -75,3 +76,7 @@ stream.onClose(() => sub.unsubscribe());
 ### Events
 
 `Mochi.sse` emits `sse:open`, `sse:message`, and `sse:close` on `mochiEvents`. `logger()` prints them by default.
+
+<SeeItInAction
+  demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
+/>

--- a/packages/docs/110-server-sent-events.md
+++ b/packages/docs/110-server-sent-events.md
@@ -78,5 +78,5 @@ stream.onClose(() => sub.unsubscribe());
 `Mochi.sse` emits `sse:open`, `sse:message`, and `sse:close` on `mochiEvents`. `logger()` prints them by default.
 
 <SeeItInAction
-  demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
+demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
 />

--- a/packages/docs/120-middleware.md
+++ b/packages/docs/120-middleware.md
@@ -160,5 +160,5 @@ await Mochi.serve({
 `asset`, `fallback`, and `error` events pass through unchanged — framework bundles already get long-lived immutable caching in production. WebSocket upgrades and SSE streams never reach the middleware.
 
 <SeeItInAction
-  demos={[{ href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." }]}
+demos={[{ href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." }]}
 />

--- a/packages/docs/120-middleware.md
+++ b/packages/docs/120-middleware.md
@@ -6,6 +6,7 @@ description: 'Intercept and transform requests and responses using SvelteKit-sty
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Middleware (hooks)
@@ -157,3 +158,7 @@ await Mochi.serve({
 ```
 
 `asset`, `fallback`, and `error` events pass through unchanged — framework bundles already get long-lived immutable caching in production. WebSocket upgrades and SSE streams never reach the middleware.
+
+<SeeItInAction
+  demos={[{ href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." }]}
+/>

--- a/packages/docs/130-error-handling.md
+++ b/packages/docs/130-error-handling.md
@@ -139,5 +139,5 @@ Uncaught throws inside a `Mochi.api` handler are coerced to `500 Internal Server
 If the user's `errorPage` itself throws during render, Mochi returns a plain-text response that mentions both the original error and the secondary render failure — the error page cannot crash the server.
 
 <SeeItInAction
-  demos={[{ href: "/demos/error/", title: "Error Handling", hook: "Catch render errors and unmatched routes via Mochi.serve()'s errorPage option and the handleError hook." }]}
+demos={[{ href: "/demos/error/", title: "Error Handling", hook: "Catch render errors and unmatched routes via Mochi.serve()'s errorPage option and the handleError hook." }]}
 />

--- a/packages/docs/130-error-handling.md
+++ b/packages/docs/130-error-handling.md
@@ -6,6 +6,7 @@ description: 'Configure a custom error page and control how uncaught errors are 
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Error handling
@@ -136,3 +137,7 @@ Uncaught throws inside a `Mochi.api` handler are coerced to `500 Internal Server
 ### Fallback behaviour
 
 If the user's `errorPage` itself throws during render, Mochi returns a plain-text response that mentions both the original error and the secondary render failure — the error page cannot crash the server.
+
+<SeeItInAction
+  demos={[{ href: "/demos/error/", title: "Error Handling", hook: "Catch render errors and unmatched routes via Mochi.serve()'s errorPage option and the handleError hook." }]}
+/>

--- a/packages/docs/135-error-boundaries.md
+++ b/packages/docs/135-error-boundaries.md
@@ -4,6 +4,10 @@ slug: error-boundaries
 description: 'Hydratable islands are automatically wrapped in svelte:boundary so a single island failure cannot crash the page.'
 ---
 
+<script>
+  import SeeItInAction from './_components/SeeItInAction.svelte';
+</script>
+
 ## Error boundaries
 
 Mochi auto-wraps every `mochi:hydrate` and `mochi:hydrate:visible` island in `<svelte:boundary>`. A throw inside one island no longer takes down the page render — the failed island is replaced by a `<mochi-island-failure>` stub and the rest of the page continues. No opt-in, no configuration.
@@ -74,3 +78,7 @@ The `MochiIslandErrorKind` type also reserves `'client-hydrate'`, but client-sid
 
 - [Error handling](error-handling/) — top-level page errors and the configured `errorPage`.
 - [Selective hydration](selective-hydration/), [Lazy hydration](lazy-hydration/), [Server islands](server-islands/) — the directives boundaries wrap.
+
+<SeeItInAction
+  demos={[{ href: "/demos/error-boundaries/", title: "Error Boundaries", hook: "Contain island failures with <svelte:boundary> so one broken component does not crash the page." }]}
+/>

--- a/packages/docs/135-error-boundaries.md
+++ b/packages/docs/135-error-boundaries.md
@@ -80,5 +80,5 @@ The `MochiIslandErrorKind` type also reserves `'client-hydrate'`, but client-sid
 - [Selective hydration](selective-hydration/), [Lazy hydration](lazy-hydration/), [Server islands](server-islands/) — the directives boundaries wrap.
 
 <SeeItInAction
-  demos={[{ href: "/demos/error-boundaries/", title: "Error Boundaries", hook: "Contain island failures with <svelte:boundary> so one broken component does not crash the page." }]}
+demos={[{ href: "/demos/error-boundaries/", title: "Error Boundaries", hook: "Contain island failures with <svelte:boundary> so one broken component does not crash the page." }]}
 />

--- a/packages/docs/140-utility-helpers.md
+++ b/packages/docs/140-utility-helpers.md
@@ -4,6 +4,10 @@ slug: utility-helpers
 description: 'Small helper functions for building JSON responses, error responses, and form-action results.'
 ---
 
+<script>
+  import SeeItInAction from './_components/SeeItInAction.svelte';
+</script>
+
 ## Utility helpers
 
 Small functions exported from `mochi-framework` for shaping responses and form-action results. Each helper is documented in depth where it is used; this page is a single index.
@@ -61,3 +65,7 @@ import { redirect } from 'mochi-framework';
 
 return redirect(303, '/dashboard');
 ```
+
+<SeeItInAction
+  demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
+/>

--- a/packages/docs/140-utility-helpers.md
+++ b/packages/docs/140-utility-helpers.md
@@ -67,5 +67,5 @@ return redirect(303, '/dashboard');
 ```
 
 <SeeItInAction
-  demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
+demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
 />

--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -122,9 +122,9 @@ See the [Cache Events demo](/demos/cache-events/) for a worked example that pipe
 `MochiCache` lives on the server. Importing it into a hydratable island throws — caches are shared per-process state and don't make sense in the browser. Construct cache instances in `.ts` modules or page-route scripts, never inside a `mochi:hydrate` component.
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." },
-    { href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." },
-    { href: "/cookie-vary-test/", title: "Cookie Vary Test", hook: "A page that sets Vary: Cookie on its response — useful for testing cookie-partitioned cache keys." },
-  ]}
+demos={[
+{ href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." },
+{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." },
+{ href: "/cookie-vary-test/", title: "Cookie Vary Test", hook: "A page that sets Vary: Cookie on its response — useful for testing cookie-partitioned cache keys." },
+]}
 />

--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -6,6 +6,7 @@ description: 'Cache server-side data with stale-while-revalidate semantics using
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Cache
@@ -119,3 +120,11 @@ See the [Cache Events demo](/demos/cache-events/) for a worked example that pipe
 ### Server-only
 
 `MochiCache` lives on the server. Importing it into a hydratable island throws — caches are shared per-process state and don't make sense in the browser. Construct cache instances in `.ts` modules or page-route scripts, never inside a `mochi:hydrate` component.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." },
+    { href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." },
+    { href: "/cookie-vary-test/", title: "Cookie Vary Test", hook: "A page that sets Vary: Cookie on its response — useful for testing cookie-partitioned cache keys." },
+  ]}
+/>

--- a/packages/docs/146-logging.md
+++ b/packages/docs/146-logging.md
@@ -6,6 +6,7 @@ description: 'An isomorphic, level-gated logger that works in server, SSR, and c
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Logging
@@ -99,3 +100,7 @@ getLogLevel(); // 'error'
 ### Relationship to `mochiEvents`
 
 The event bus (`mochiEvents`) is a separate concern: it carries structured payloads to any subscriber you wire up, regardless of console output. The built-in `consoleLogger()` — the thing that prints request lines like `GET /foo 200 12ms` — is just one consumer subscribing to those events and calling `logger.info` / `logger.warn` per event. Plug Sentry, OpenTelemetry, or your own pipeline directly into `mochiEvents`; use `logger` for ad-hoc messages.
+
+<SeeItInAction
+  demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
+/>

--- a/packages/docs/146-logging.md
+++ b/packages/docs/146-logging.md
@@ -102,5 +102,5 @@ getLogLevel(); // 'error'
 The event bus (`mochiEvents`) is a separate concern: it carries structured payloads to any subscriber you wire up, regardless of console output. The built-in `consoleLogger()` — the thing that prints request lines like `GET /foo 200 12ms` — is just one consumer subscribing to those events and calling `logger.info` / `logger.warn` per event. Plug Sentry, OpenTelemetry, or your own pipeline directly into `mochiEvents`; use `logger` for ad-hoc messages.
 
 <SeeItInAction
-  demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
+demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
 />

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -366,5 +366,5 @@ Emitted by `MochiCache` — see [Subscribing to cache events](/docs/cache#subscr
 `logger()` (see `logger`) already prints `request`, `ws:*`, `sse:*`, `server:*`, `error`, and `cache:revalidate` lines. Pass `{ cache: 'verbose' }` to also print every `cache:read`, or `{ cache: false }` to silence cache logging entirely.
 
 <SeeItInAction
-  demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
+demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
 />

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -6,6 +6,7 @@ description: 'Subscribe to framework lifecycle events like requests, WebSocket a
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Events
@@ -363,3 +364,7 @@ Emitted by `MochiCache` — see [Subscribing to cache events](/docs/cache#subscr
 ### Built-in subscribers
 
 `logger()` (see `logger`) already prints `request`, `ws:*`, `sse:*`, `server:*`, `error`, and `cache:revalidate` lines. Pass `{ cache: 'verbose' }` to also print every `cache:read`, or `{ cache: false }` to silence cache logging entirely.
+
+<SeeItInAction
+  demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
+/>

--- a/packages/docs/148-view-transitions.md
+++ b/packages/docs/148-view-transitions.md
@@ -133,8 +133,8 @@ If you'd rather wire it by hand — or need finer control — give the element a
 ```
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/view-transitions/", title: "View Transitions", hook: "Drop <ViewTransitions /> into a shared layout to animate full-page navigations with zero JavaScript." },
-    { href: "/demos/custom-transitions/", title: "Custom Transitions", hook: "Bring your own @keyframes to <ViewTransitions /> via custom={{ in, out }} — here, a funky 3D spin." },
-  ]}
+demos={[
+{ href: "/demos/view-transitions/", title: "View Transitions", hook: "Drop <ViewTransitions /> into a shared layout to animate full-page navigations with zero JavaScript." },
+{ href: "/demos/custom-transitions/", title: "Custom Transitions", hook: "Bring your own @keyframes to <ViewTransitions /> via custom={{ in, out }} — here, a funky 3D spin." },
+]}
 />

--- a/packages/docs/148-view-transitions.md
+++ b/packages/docs/148-view-transitions.md
@@ -6,6 +6,7 @@ description: 'Animate full-page navigations with the browser cross-document View
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## View Transitions
@@ -130,3 +131,10 @@ If you'd rather wire it by hand — or need finer control — give the element a
   animation: none;
 }
 ```
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/view-transitions/", title: "View Transitions", hook: "Drop <ViewTransitions /> into a shared layout to animate full-page navigations with zero JavaScript." },
+    { href: "/demos/custom-transitions/", title: "Custom Transitions", hook: "Bring your own @keyframes to <ViewTransitions /> via custom={{ in, out }} — here, a funky 3D spin." },
+  ]}
+/>

--- a/packages/docs/15-coming-from-sveltekit.md
+++ b/packages/docs/15-coming-from-sveltekit.md
@@ -6,6 +6,7 @@ description: 'A mapping of SvelteKit concepts to their Mochi equivalents for dev
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Coming from SvelteKit
@@ -925,3 +926,11 @@ await Mochi.serve({
 - [Events](/docs/events/) — `mochiEvents` lifecycle bus for observability and logging.
 - [Cache](/docs/cache/) — `MochiCache` SWR caching for arbitrary computations.
 - [Trailing slash](/docs/trailing-slash/) — global `trailingSlash` policy on `Mochi.serve()`.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
+    { href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
+    { href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
+  ]}
+/>

--- a/packages/docs/15-coming-from-sveltekit.md
+++ b/packages/docs/15-coming-from-sveltekit.md
@@ -928,9 +928,9 @@ await Mochi.serve({
 - [Trailing slash](/docs/trailing-slash/) — global `trailingSlash` policy on `Mochi.serve()`.
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
-    { href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
-    { href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
-  ]}
+demos={[
+{ href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
+{ href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
+{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
+]}
 />

--- a/packages/docs/155-css-imports.md
+++ b/packages/docs/155-css-imports.md
@@ -62,8 +62,8 @@ Bun's CSS bundler unquotes `format('woff2-variations')` to `format(woff2-variati
 A `.css` edit triggers a fast rebundle and a page reload — no SSR recompile. Edits to `.svelte` or `.ts` files go through the full compile path.
 
 <SeeItInAction
-  demos={[
-    { href: "https://demos.mochi.fast/todo/", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." },
-    { href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
-  ]}
+demos={[
+{ href: "https://demos.mochi.fast/todo/", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." },
+{ href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+]}
 />

--- a/packages/docs/155-css-imports.md
+++ b/packages/docs/155-css-imports.md
@@ -6,6 +6,7 @@ description: 'Import CSS from Svelte, TypeScript, or JavaScript files and have i
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## CSS imports
@@ -59,3 +60,10 @@ Bun's CSS bundler unquotes `format('woff2-variations')` to `format(woff2-variati
 ### Dev mode
 
 A `.css` edit triggers a fast rebundle and a page reload — no SSR recompile. Edits to `.svelte` or `.ts` files go through the full compile path.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/tailwind/", title: "Tailwind", hook: "Tailwind utility classes scoped to a single Mochi route, with Preflight skipped." },
+    { href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+  ]}
+/>

--- a/packages/docs/155-css-imports.md
+++ b/packages/docs/155-css-imports.md
@@ -63,7 +63,7 @@ A `.css` edit triggers a fast rebundle and a page reload — no SSR recompile. E
 
 <SeeItInAction
   demos={[
-    { href: "/demos/tailwind/", title: "Tailwind", hook: "Tailwind utility classes scoped to a single Mochi route, with Preflight skipped." },
+    { href: "https://demos.mochi.fast/todo/", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." },
     { href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
   ]}
 />

--- a/packages/docs/158-mdsvex.md
+++ b/packages/docs/158-mdsvex.md
@@ -6,6 +6,7 @@ description: 'Enable Markdown support in Mochi pages with mdsvex and rehype/rema
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## MdSvex
@@ -137,3 +138,7 @@ importing one then surfaces as a "no loader" error from Bun's bundler. Your
 `svelte.config.js` `compilerOptions` still apply to compiled markdown. See
 [Svelte config](/docs/svelte-config/).
 </Callout>
+
+<SeeItInAction
+  demos={[{ href: "/demos/mdsvex/", title: "MdSvex", hook: "A .md file compiled through mdsvex and rendered as a Svelte component, with an embedded <script> block." }]}
+/>

--- a/packages/docs/158-mdsvex.md
+++ b/packages/docs/158-mdsvex.md
@@ -140,5 +140,5 @@ importing one then surfaces as a "no loader" error from Bun's bundler. Your
 </Callout>
 
 <SeeItInAction
-  demos={[{ href: "/demos/mdsvex/", title: "MdSvex", hook: "A .md file compiled through mdsvex and rendered as a Svelte component, with an embedded <script> block." }]}
+demos={[{ href: "/demos/mdsvex/", title: "MdSvex", hook: "A .md file compiled through mdsvex and rendered as a Svelte component, with an embedded <script> block." }]}
 />

--- a/packages/docs/175-tailwind.md
+++ b/packages/docs/175-tailwind.md
@@ -162,8 +162,5 @@ Preflight resets every element on every page that imports the stylesheet. On a m
 </Callout>
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/tailwind/", title: "Tailwind", hook: "Tailwind utility classes scoped to a single Mochi route, with Preflight skipped." },
-    { href: "https://demos.mochi.fast/todo", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." },
-  ]}
+  demos={[{ href: "https://demos.mochi.fast/todo/", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." }]}
 />

--- a/packages/docs/175-tailwind.md
+++ b/packages/docs/175-tailwind.md
@@ -6,6 +6,7 @@ description: 'Integrate Tailwind CSS v4 into a Mochi app using the setupTailwind
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Tailwind
@@ -159,3 +160,10 @@ To opt back in, `@import 'tailwindcss/preflight.css' layer(base);`.
 Preflight resets every element on every page that imports the stylesheet. On a multi-page site, scope your Tailwind CSS to a single page (only that `.svelte` imports it) or accept that preflight will reset shared chrome too.
 
 </Callout>
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/tailwind/", title: "Tailwind", hook: "Tailwind utility classes scoped to a single Mochi route, with Preflight skipped." },
+    { href: "https://demos.mochi.fast/todo", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." },
+  ]}
+/>

--- a/packages/docs/175-tailwind.md
+++ b/packages/docs/175-tailwind.md
@@ -162,5 +162,5 @@ Preflight resets every element on every page that imports the stylesheet. On a m
 </Callout>
 
 <SeeItInAction
-  demos={[{ href: "https://demos.mochi.fast/todo/", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." }]}
+demos={[{ href: "https://demos.mochi.fast/todo/", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." }]}
 />

--- a/packages/docs/40-defining-routes.md
+++ b/packages/docs/40-defining-routes.md
@@ -6,6 +6,7 @@ description: 'Register pages, APIs, WebSockets, SSE endpoints, and file routes u
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Defining routes
@@ -226,3 +227,11 @@ Every `Mochi.page` and `Mochi.api` route answers `HEAD` automatically by running
 ### Static files
 
 Files under `./public` are served automatically; no route entry is needed. A user-defined route always wins over a same-path public file. See `Serve options` for `publicDir`.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
+    { href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
+    { href: "/demos/file/", title: "File Routes", hook: "Serve a file from disk with Mochi.file() — static path or a per-request resolver." },
+  ]}
+/>

--- a/packages/docs/40-defining-routes.md
+++ b/packages/docs/40-defining-routes.md
@@ -229,9 +229,9 @@ Every `Mochi.page` and `Mochi.api` route answers `HEAD` automatically by running
 Files under `./public` are served automatically; no route entry is needed. A user-defined route always wins over a same-path public file. See `Serve options` for `publicDir`.
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
-    { href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
-    { href: "/demos/file/", title: "File Routes", hook: "Serve a file from disk with Mochi.file() — static path or a per-request resolver." },
-  ]}
+demos={[
+{ href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
+{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
+{ href: "/demos/file/", title: "File Routes", hook: "Serve a file from disk with Mochi.file() — static path or a per-request resolver." },
+]}
 />

--- a/packages/docs/50-selective-hydration.md
+++ b/packages/docs/50-selective-hydration.md
@@ -97,9 +97,9 @@ Use `mochi:defer` to render the component on a separate request after the page s
 ```
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/hydration/", title: "Hydration Modes", hook: "The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island." },
-    { href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
-    { href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
-  ]}
+demos={[
+{ href: "/demos/hydration/", title: "Hydration Modes", hook: "The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island." },
+{ href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+{ href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
+]}
 />

--- a/packages/docs/50-selective-hydration.md
+++ b/packages/docs/50-selective-hydration.md
@@ -6,6 +6,7 @@ description: 'Mark components with mochi:hydrate to ship client-side JavaScript 
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Selective hydration with `mochi:hydrate`
@@ -94,3 +95,11 @@ Use `mochi:defer` to render the component on a separate request after the page s
 <!-- Server-rendered after page load, then hydrated -->
 <ShoppingCart mochi:defer mochi:hydrate items={initialItems} />
 ```
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/hydration/", title: "Hydration Modes", hook: "The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island." },
+    { href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+    { href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
+  ]}
+/>

--- a/packages/docs/60-lazy-hydration.md
+++ b/packages/docs/60-lazy-hydration.md
@@ -6,6 +6,7 @@ description: 'Defer island hydration until the component scrolls into view with 
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Lazy hydration with `mochi:hydrate:visible`
@@ -40,3 +41,10 @@ Stack `mochi:defer mochi:hydrate:visible` to defer both rendering and hydration:
 ```
 
 See `Selective hydration` for the eager `mochi:hydrate` directive and `Server islands` for `mochi:defer` on its own.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+    { href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
+  ]}
+/>

--- a/packages/docs/60-lazy-hydration.md
+++ b/packages/docs/60-lazy-hydration.md
@@ -43,8 +43,8 @@ Stack `mochi:defer mochi:hydrate:visible` to defer both rendering and hydration:
 See `Selective hydration` for the eager `mochi:hydrate` directive and `Server islands` for `mochi:defer` on its own.
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
-    { href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
-  ]}
+demos={[
+{ href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+{ href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
+]}
 />

--- a/packages/docs/70-server-islands.md
+++ b/packages/docs/70-server-islands.md
@@ -6,6 +6,7 @@ description: 'Render components after initial page load by fetching their HTML f
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Server islands with `mochi:defer`
@@ -108,3 +109,10 @@ bunx mochi-framework generate-key
 **Never commit `MOCHI_KEY`.** It signs server-island prop URLs; leaking it lets attackers forge them. Supply it via your platform's secret store and generate one with `bunx mochi-framework generate-key`.
 
 </Callout>
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
+    { href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
+  ]}
+/>

--- a/packages/docs/70-server-islands.md
+++ b/packages/docs/70-server-islands.md
@@ -111,8 +111,8 @@ bunx mochi-framework generate-key
 </Callout>
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
-    { href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
-  ]}
+demos={[
+{ href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
+{ href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
+]}
 />

--- a/packages/docs/71-island-props.md
+++ b/packages/docs/71-island-props.md
@@ -123,9 +123,9 @@ The framework appends one read-only prop to every island invocation. Destructure
 `islandId` is a reserved name on every island (`mochi:hydrate` and `mochi:defer` alike) — passing it as a literal prop is a compile error, so a component can move between directives without the name silently changing meaning. On `mochi:defer` it is also the framework's transport key inside the signed envelope, stripped server-side before the component renders; a spread carrying it there is overridden by the framework value (last key wins). For a unique id inside the component, use `$props.id()`.
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/island-props/", title: "Crossing the server-client boundary with props", hook: "How props travel from a server-rendered parent into a hydrated island — Date, Map, Set, BigInt, URL, typed arrays, and even cyclic refs survive devalue's round-trip." },
-    { href: "/demos/prop-dedup/", title: "Shared Props", hook: "Nine islands, three unique payloads — each set serialized once and referenced via props-ref." },
-    { href: "/demos/props-id/", title: "Unique IDs", hook: "Svelte's native $props.id() inside islands — SSR-consistent, unique per instance, namespaced in server islands." },
-  ]}
+demos={[
+{ href: "/demos/island-props/", title: "Crossing the server-client boundary with props", hook: "How props travel from a server-rendered parent into a hydrated island — Date, Map, Set, BigInt, URL, typed arrays, and even cyclic refs survive devalue's round-trip." },
+{ href: "/demos/prop-dedup/", title: "Shared Props", hook: "Nine islands, three unique payloads — each set serialized once and referenced via props-ref." },
+{ href: "/demos/props-id/", title: "Unique IDs", hook: "Svelte's native $props.id() inside islands — SSR-consistent, unique per instance, namespaced in server islands." },
+]}
 />

--- a/packages/docs/71-island-props.md
+++ b/packages/docs/71-island-props.md
@@ -6,6 +6,7 @@ description: 'How props are serialized and passed to hydratable islands, includi
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Passing props to islands
@@ -120,3 +121,11 @@ The framework appends one read-only prop to every island invocation. Destructure
 `isHydratable` is set by the framework, not passed by you. Read it to render an SSR-only fallback at a call site that also hydrates client-side — see [Selective hydration](selective-hydration/).
 
 `islandId` is a reserved name on every island (`mochi:hydrate` and `mochi:defer` alike) — passing it as a literal prop is a compile error, so a component can move between directives without the name silently changing meaning. On `mochi:defer` it is also the framework's transport key inside the signed envelope, stripped server-side before the component renders; a spread carrying it there is overridden by the framework value (last key wins). For a unique id inside the component, use `$props.id()`.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/island-props/", title: "Crossing the server-client boundary with props", hook: "How props travel from a server-rendered parent into a hydrated island — Date, Map, Set, BigInt, URL, typed arrays, and even cyclic refs survive devalue's round-trip." },
+    { href: "/demos/prop-dedup/", title: "Shared Props", hook: "Nine islands, three unique payloads — each set serialized once and referenced via props-ref." },
+    { href: "/demos/props-id/", title: "Unique IDs", hook: "Svelte's native $props.id() inside islands — SSR-consistent, unique per instance, namespaced in server islands." },
+  ]}
+/>

--- a/packages/docs/72-hydratable.md
+++ b/packages/docs/72-hydratable.md
@@ -6,6 +6,7 @@ description: 'Serialize computed server values into the page so the client can r
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Hydratable values (experimental)
@@ -65,3 +66,7 @@ Values are serialized with [`devalue`](https://www.npmjs.com/package/devalue), s
 **No CSP nonce wiring.** Mochi does not yet pass a `csp.nonce` through to Svelte's `render()`, so the inline lookup script will be blocked under strict `script-src` policies. Either allow `'unsafe-inline'` for scripts (which you likely already do for the island bootstrap) or wait for nonce plumbing.
 
 </Callout>
+
+<SeeItInAction
+  demos={[{ href: "/demos/hydratable/", title: "Hydratable", hook: "Compute a value once on the server with hydratable(); the hydrated island reads it from <head> instead of re-running the async work." }]}
+/>

--- a/packages/docs/72-hydratable.md
+++ b/packages/docs/72-hydratable.md
@@ -68,5 +68,5 @@ Values are serialized with [`devalue`](https://www.npmjs.com/package/devalue), s
 </Callout>
 
 <SeeItInAction
-  demos={[{ href: "/demos/hydratable/", title: "Hydratable", hook: "Compute a value once on the server with hydratable(); the hydrated island reads it from <head> instead of re-running the async work." }]}
+demos={[{ href: "/demos/hydratable/", title: "Hydratable", hook: "Compute a value once on the server with hydratable(); the hydrated island reads it from <head> instead of re-running the async work." }]}
 />

--- a/packages/docs/73-server-only-imports.md
+++ b/packages/docs/73-server-only-imports.md
@@ -56,5 +56,5 @@ getVersion from /…/db.server.ts was called on the client; this is a server-onl
 - `.server.svelte` — component-level convention is not provided. Put server-only code in plain TS and call it from a component.
 
 <SeeItInAction
-  demos={[{ href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." }]}
+demos={[{ href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." }]}
 />

--- a/packages/docs/73-server-only-imports.md
+++ b/packages/docs/73-server-only-imports.md
@@ -6,6 +6,7 @@ description: 'Keep server-only modules like bun:sqlite out of client bundles usi
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Server-only imports
@@ -53,3 +54,7 @@ getVersion from /…/db.server.ts was called on the client; this is a server-onl
 
 - `export * from './x'` — Mochi warns at build time; declare named exports in the `.server.ts` file directly.
 - `.server.svelte` — component-level convention is not provided. Put server-only code in plain TS and call it from a component.
+
+<SeeItInAction
+  demos={[{ href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." }]}
+/>

--- a/packages/docs/74-use-enhance.md
+++ b/packages/docs/74-use-enhance.md
@@ -203,9 +203,9 @@ Returning a `Response` directly from an action bypasses the JSON envelope on enh
 Reach for `enhance` when the action's outcome should update UI without a navigation flicker — interactive forms, optimistic patterns, inline validation. Stick with a plain `<form method="POST">` when the action ends in a redirect anyway and the JS bundle is not worth shipping.
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
-    { href: "/demos/form-errors/", title: "Form Errors", hook: "A thrown action error shown inline via {@attach enhance(...)}, or as the Mochi error page on plain submit." },
-    { href: "/demos/form-return-data/", title: "Using form return data", hook: "An action returns data via success({...}); {@attach enhance(...)} updates the UI in place, plain HTML re-renders the page." },
-  ]}
+demos={[
+{ href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
+{ href: "/demos/form-errors/", title: "Form Errors", hook: "A thrown action error shown inline via {@attach enhance(...)}, or as the Mochi error page on plain submit." },
+{ href: "/demos/form-return-data/", title: "Using form return data", hook: "An action returns data via success({...}); {@attach enhance(...)} updates the UI in place, plain HTML re-renders the page." },
+]}
 />

--- a/packages/docs/74-use-enhance.md
+++ b/packages/docs/74-use-enhance.md
@@ -6,6 +6,7 @@ description: 'Progressively enhance HTML forms to submit via fetch when JavaScri
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Progressively enhancing forms with enhance
@@ -200,3 +201,11 @@ Returning a `Response` directly from an action bypasses the JSON envelope on enh
 ### When to use enhance
 
 Reach for `enhance` when the action's outcome should update UI without a navigation flicker — interactive forms, optimistic patterns, inline validation. Stick with a plain `<form method="POST">` when the action ends in a redirect anyway and the JS bundle is not worth shipping.
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
+    { href: "/demos/form-errors/", title: "Form Errors", hook: "A thrown action error shown inline via {@attach enhance(...)}, or as the Mochi error page on plain submit." },
+    { href: "/demos/form-return-data/", title: "Using form return data", hook: "An action returns data via success({...}); {@attach enhance(...)} updates the UI in place, plain HTML re-renders the page." },
+  ]}
+/>

--- a/packages/docs/76-http-streaming.md
+++ b/packages/docs/76-http-streaming.md
@@ -6,6 +6,7 @@ description: 'Mochi renders each page as a complete document, with SSE, WebSocke
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## HTTP streaming
@@ -30,3 +31,7 @@ Reach for these to layer realtime UI on top of a rendered base page.
 - **Server islands** (`mochi:defer`) load slow or personalized fragments out-of-band after the shell ships. The rest of the page renders immediately; the island fetches itself once the browser sees the placeholder.
 - **Visible hydration** (`mochi:hydrate:visible`) keeps the initial JS payload small.
 - **Shared HTTP cache** (Cloudflare, CloudFront, Fastly, Varnish, nginx) in front of the origin makes render time irrelevant for the cacheable common case. Server islands can stay uncached behind a cached shell — see `Cache`.
+
+<SeeItInAction
+  demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
+/>

--- a/packages/docs/76-http-streaming.md
+++ b/packages/docs/76-http-streaming.md
@@ -33,5 +33,5 @@ Reach for these to layer realtime UI on top of a rendered base page.
 - **Shared HTTP cache** (Cloudflare, CloudFront, Fastly, Varnish, nginx) in front of the origin makes render time irrelevant for the cacheable common case. Server islands can stay uncached behind a cached shell — see `Cache`.
 
 <SeeItInAction
-  demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
+demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
 />

--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -6,6 +6,7 @@ description: 'Build-time constants for branching on render target (isServer, isB
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Environment constants
@@ -99,3 +100,7 @@ Use `isHydratable` to peek request-scoped state only when the client won't take 
 ```
 
 See the [Forms demo](/demos/login/) for a side-by-side comparison of hydrated and SSR-only render paths.
+
+<SeeItInAction
+  demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
+/>

--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -102,5 +102,5 @@ Use `isHydratable` to peek request-scoped state only when the client won't take 
 See the [Forms demo](/demos/login/) for a side-by-side comparison of hydrated and SSR-only render paths.
 
 <SeeItInAction
-  demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
+demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
 />

--- a/packages/docs/85-request-context.md
+++ b/packages/docs/85-request-context.md
@@ -6,6 +6,7 @@ description: 'Access the current URL, route params, cookies, and locals from any
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## Request context
@@ -115,3 +116,10 @@ serverProps: async () => {
   return { posts: await loadPosts() };
 };
 ```
+
+<SeeItInAction
+  demos={[
+    { href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." },
+    { href: "/demos/cookies/", title: "Cookies", hook: "Read and write cookies on the server and the client through one MochiCookieJar API." },
+  ]}
+/>

--- a/packages/docs/85-request-context.md
+++ b/packages/docs/85-request-context.md
@@ -118,8 +118,8 @@ serverProps: async () => {
 ```
 
 <SeeItInAction
-  demos={[
-    { href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." },
-    { href: "/demos/cookies/", title: "Cookies", hook: "Read and write cookies on the server and the client through one MochiCookieJar API." },
-  ]}
+demos={[
+{ href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." },
+{ href: "/demos/cookies/", title: "Cookies", hook: "Read and write cookies on the server and the client through one MochiCookieJar API." },
+]}
 />

--- a/packages/docs/90-api-routes.md
+++ b/packages/docs/90-api-routes.md
@@ -153,5 +153,5 @@ Mochi.api(async () => {
 API routes never render the HTML error page and `handleError` is **not** called for them — the JSON envelope is the only contract.
 
 <SeeItInAction
-  demos={[{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." }]}
+demos={[{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." }]}
 />

--- a/packages/docs/90-api-routes.md
+++ b/packages/docs/90-api-routes.md
@@ -6,6 +6,7 @@ description: 'Register JSON endpoints with Mochi.api() that receive a request ev
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
 </script>
 
 ## API routes
@@ -150,3 +151,7 @@ Mochi.api(async () => {
 ```
 
 API routes never render the HTML error page and `handleError` is **not** called for them — the JSON envelope is the only contract.
+
+<SeeItInAction
+  demos={[{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." }]}
+/>

--- a/packages/docs/_components/SeeItInAction.svelte
+++ b/packages/docs/_components/SeeItInAction.svelte
@@ -1,24 +1,96 @@
 <script lang="ts">
+  import type { Component } from 'svelte';
+  import Sprout from '@lucide/svelte/icons/sprout';
+  import PackageOpen from '@lucide/svelte/icons/package-open';
+  import Layers from '@lucide/svelte/icons/layers';
+  import Globe from '@lucide/svelte/icons/globe';
+  import Snowflake from '@lucide/svelte/icons/snowflake';
+  import Cookie from '@lucide/svelte/icons/cookie';
+  import Link from '@lucide/svelte/icons/link';
+  import Blend from '@lucide/svelte/icons/blend';
+  import Tornado from '@lucide/svelte/icons/tornado';
+  import DatabaseZap from '@lucide/svelte/icons/database-zap';
+  import Barcode from '@lucide/svelte/icons/barcode';
+  import Fingerprint from '@lucide/svelte/icons/fingerprint';
+  import MessageCircle from '@lucide/svelte/icons/message-circle';
+  import Webhook from '@lucide/svelte/icons/webhook';
+  import FileDown from '@lucide/svelte/icons/file-down';
+  import AudioWaveform from '@lucide/svelte/icons/audio-waveform';
+  import ComponentIcon from '@lucide/svelte/icons/component';
+  import Package2 from '@lucide/svelte/icons/package-2';
+  import Telescope from '@lucide/svelte/icons/telescope';
+  import Eye from '@lucide/svelte/icons/eye';
+  import FileText from '@lucide/svelte/icons/file-text';
+  import Boxes from '@lucide/svelte/icons/boxes';
+  import Hash from '@lucide/svelte/icons/hash';
+  import ClipboardPen from '@lucide/svelte/icons/clipboard-pen';
+  import Dices from '@lucide/svelte/icons/dices';
+  import OctagonAlert from '@lucide/svelte/icons/octagon-alert';
+  import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
+  import ShieldAlert from '@lucide/svelte/icons/shield-alert';
+  import Wind from '@lucide/svelte/icons/wind';
+  import ListTodo from '@lucide/svelte/icons/list-todo';
+
   interface DemoLink {
     href: string;
     title: string;
     hook: string;
   }
   let { demos = [] }: { demos: DemoLink[] } = $props();
+
+  // Keyed by href so the markdown only needs to pass { href, title, hook }.
+  // Mirrors the icon choices in packages/site/src/lib/demoIcons.ts; duplicated
+  // here to keep docs free of any dependency on the site package.
+  const iconFor: Record<string, Component> = {
+    '/demos/hello-world/': Sprout,
+    '/demos/server-props/': PackageOpen,
+    '/demos/hydration/': Layers,
+    '/demos/data-loading/': Globe,
+    '/demos/hydratable/': Snowflake,
+    '/demos/cookies/': Cookie,
+    '/demos/url/': Link,
+    '/demos/view-transitions/': Blend,
+    '/demos/custom-transitions/': Tornado,
+    '/demos/cache-events/': DatabaseZap,
+    '/demos/request-id/': Barcode,
+    '/cookie-vary-test/': Fingerprint,
+    '/demos/chat/': MessageCircle,
+    '/demos/api/': Webhook,
+    '/demos/file/': FileDown,
+    '/demos/streams/': AudioWaveform,
+    '/demos/server-island/': ComponentIcon,
+    '/demos/island-props/': Package2,
+    '/demos/lazy/': Telescope,
+    '/demos/lazy-server-island/': Eye,
+    '/demos/mdsvex/': FileText,
+    '/demos/prop-dedup/': Boxes,
+    '/demos/props-id/': Hash,
+    '/demos/login/': ClipboardPen,
+    '/demos/form-return-data/': Dices,
+    '/demos/form-errors/': OctagonAlert,
+    '/demos/error/': TriangleAlert,
+    '/demos/error-boundaries/': ShieldAlert,
+    '/demos/tailwind/': Wind,
+    'https://demos.mochi.fast/todo': ListTodo,
+  };
 </script>
 
 {#if demos.length > 0}
   <section class="see-it-in-action">
-    <p class="sia-label">See it in action</p>
+    <h2 class="sia-heading">See it in action</h2>
     <div class="sia-grid">
       {#each demos as demo (demo.href)}
         {@const external = demo.href.startsWith('http')}
+        {@const Icon = iconFor[demo.href]}
         <a
           class="sia-card"
           href={demo.href}
           target={external ? '_blank' : undefined}
           rel={external ? 'noopener noreferrer' : undefined}
         >
+          {#if Icon}
+            <span class="sia-icon"><Icon size={16} strokeWidth={1.5} /></span>
+          {/if}
           <span class="sia-title">{demo.title}</span>
           <span class="sia-hook">{demo.hook}</span>
         </a>
@@ -28,24 +100,35 @@
 {/if}
 
 <style>
-  /* Adapted from DemoPage.svelte .more-* (icon styles dropped). */
+  /* Card visual adapted from DemoPage.svelte .more-*. */
   .see-it-in-action {
-    margin: 2rem 0 0;
+    margin: 2.5rem 0 0;
   }
-  .sia-label {
-    font-size: 0.72rem;
-    font-weight: 600;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--text-subtle);
-    margin-bottom: 0.75rem;
+  .sia-heading {
+    font-family: var(--font-serif);
+    font-size: 1.5rem;
+    font-weight: 500;
+    letter-spacing: -0.005em;
+    color: var(--text);
+    margin: 0 0 0.85rem;
   }
   .sia-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 0.75rem;
   }
-  .sia-card {
+  /* A lone card otherwise stretches the full row, which looks unbalanced. */
+  .see-it-in-action .sia-card:only-child {
+    max-width: 50%;
+  }
+  @media (max-width: 480px) {
+    .see-it-in-action .sia-card:only-child {
+      max-width: none;
+    }
+  }
+  /* Nested under .see-it-in-action to outweigh the `.readme :global(a)`
+     link styling (underline/accent color) that wraps doc content. */
+  .see-it-in-action a.sia-card {
     display: flex;
     flex-direction: column;
     gap: 0.35rem;
@@ -53,16 +136,23 @@
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: var(--radius-lg);
+    color: inherit;
     text-decoration: none;
     transition:
       box-shadow 0.15s ease,
       transform 0.15s ease;
   }
-  .sia-card:hover {
+  .see-it-in-action a.sia-card:hover {
     transform: translateY(-2px);
+    text-decoration: none;
     box-shadow:
       inset 3px 0 0 var(--accent),
       var(--shadow-md);
+  }
+  .sia-icon {
+    color: var(--text-subtle);
+    display: inline-flex;
+    margin-bottom: 0.1rem;
   }
   .sia-title {
     font-family: var(--font-serif);
@@ -72,7 +162,7 @@
     letter-spacing: -0.005em;
     line-height: 1.3;
   }
-  .sia-card:hover .sia-title {
+  .see-it-in-action a.sia-card:hover .sia-title {
     color: var(--accent);
   }
   .sia-hook {

--- a/packages/docs/_components/SeeItInAction.svelte
+++ b/packages/docs/_components/SeeItInAction.svelte
@@ -81,12 +81,7 @@
       {#each demos as demo (demo.href)}
         {@const external = demo.href.startsWith('http')}
         {@const Icon = iconFor[demo.href]}
-        <a
-          class="sia-card"
-          href={demo.href}
-          target={external ? '_blank' : undefined}
-          rel={external ? 'noopener noreferrer' : undefined}
-        >
+        <a class="sia-card" href={demo.href} target={external ? '_blank' : undefined} rel={external ? 'noopener noreferrer' : undefined}>
           {#if Icon}
             <span class="sia-icon"><Icon size={16} strokeWidth={1.5} /></span>
           {/if}

--- a/packages/docs/_components/SeeItInAction.svelte
+++ b/packages/docs/_components/SeeItInAction.svelte
@@ -28,7 +28,6 @@
   import OctagonAlert from '@lucide/svelte/icons/octagon-alert';
   import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
   import ShieldAlert from '@lucide/svelte/icons/shield-alert';
-  import Wind from '@lucide/svelte/icons/wind';
   import ListTodo from '@lucide/svelte/icons/list-todo';
 
   interface DemoLink {
@@ -70,14 +69,14 @@
     '/demos/form-errors/': OctagonAlert,
     '/demos/error/': TriangleAlert,
     '/demos/error-boundaries/': ShieldAlert,
-    '/demos/tailwind/': Wind,
-    'https://demos.mochi.fast/todo': ListTodo,
+    'https://demos.mochi.fast/todo/': ListTodo,
   };
 </script>
 
 {#if demos.length > 0}
   <section class="see-it-in-action">
     <h2 class="sia-heading">See it in action</h2>
+    <p class="sia-subtitle">Live demos showing key concepts from this page</p>
     <div class="sia-grid">
       {#each demos as demo (demo.href)}
         {@const external = demo.href.startsWith('http')}
@@ -104,13 +103,19 @@
   .see-it-in-action {
     margin: 2.5rem 0 0;
   }
-  .sia-heading {
+  .see-it-in-action .sia-heading {
     font-family: var(--font-serif);
     font-size: 1.5rem;
     font-weight: 500;
     letter-spacing: -0.005em;
     color: var(--text);
-    margin: 0 0 0.85rem;
+    margin: 0 0 0.2rem;
+  }
+  .see-it-in-action .sia-subtitle {
+    margin: 0 0 0.9rem;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.4;
   }
   .sia-grid {
     display: grid;

--- a/packages/docs/_components/SeeItInAction.svelte
+++ b/packages/docs/_components/SeeItInAction.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+  interface DemoLink {
+    href: string;
+    title: string;
+    hook: string;
+  }
+  let { demos = [] }: { demos: DemoLink[] } = $props();
+</script>
+
+{#if demos.length > 0}
+  <section class="see-it-in-action">
+    <p class="sia-label">See it in action</p>
+    <div class="sia-grid">
+      {#each demos as demo (demo.href)}
+        {@const external = demo.href.startsWith('http')}
+        <a
+          class="sia-card"
+          href={demo.href}
+          target={external ? '_blank' : undefined}
+          rel={external ? 'noopener noreferrer' : undefined}
+        >
+          <span class="sia-title">{demo.title}</span>
+          <span class="sia-hook">{demo.hook}</span>
+        </a>
+      {/each}
+    </div>
+  </section>
+{/if}
+
+<style>
+  /* Adapted from DemoPage.svelte .more-* (icon styles dropped). */
+  .see-it-in-action {
+    margin: 2rem 0 0;
+  }
+  .sia-label {
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-subtle);
+    margin-bottom: 0.75rem;
+  }
+  .sia-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 0.75rem;
+  }
+  .sia-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    padding: 0.85rem 0.9rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    text-decoration: none;
+    transition:
+      box-shadow 0.15s ease,
+      transform 0.15s ease;
+  }
+  .sia-card:hover {
+    transform: translateY(-2px);
+    box-shadow:
+      inset 3px 0 0 var(--accent),
+      var(--shadow-md);
+  }
+  .sia-title {
+    font-family: var(--font-serif);
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--text);
+    letter-spacing: -0.005em;
+    line-height: 1.3;
+  }
+  .sia-card:hover .sia-title {
+    color: var(--accent);
+  }
+  .sia-hook {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+</style>

--- a/packages/docs/_components/SeeItInAction.svelte
+++ b/packages/docs/_components/SeeItInAction.svelte
@@ -140,14 +140,14 @@
     text-decoration: none;
     transition:
       box-shadow 0.15s ease,
+      border-color 0.15s ease,
       transform 0.15s ease;
   }
   .see-it-in-action a.sia-card:hover {
     transform: translateY(-2px);
     text-decoration: none;
-    box-shadow:
-      inset 3px 0 0 var(--accent),
-      var(--shadow-md);
+    border-color: var(--accent);
+    box-shadow: var(--shadow-md);
   }
   .sia-icon {
     color: var(--text-subtle);

--- a/packages/site/src/components/DemoPage.svelte
+++ b/packages/site/src/components/DemoPage.svelte
@@ -297,14 +297,14 @@
     text-decoration: none;
     transition:
       box-shadow 0.15s ease,
+      border-color 0.15s ease,
       transform 0.15s ease;
   }
 
   .more-card:hover {
     transform: translateY(-2px);
-    box-shadow:
-      inset 3px 0 0 var(--accent),
-      var(--shadow-md);
+    border-color: var(--accent);
+    box-shadow: var(--shadow-md);
   }
 
   .mc-icon {

--- a/packages/site/src/components/PageShell.svelte
+++ b/packages/site/src/components/PageShell.svelte
@@ -26,6 +26,12 @@
 
   const mergedMetaTags = $derived(mergeMetaTags(metaTags));
 
+  // The nav islands hydrate, so their props are serialized into the page. Each demo's
+  // server-only `files` carries paths like './src/demos/url/routes.ts'; crawlers mine
+  // those as relative URLs and resolve them against the page, producing phantom 404s.
+  // Nav never reads `.files`, so drop it before it ships to the client.
+  const navDemos = demos.map(({ files: _files, ...rest }) => rest);
+
   // These demos render their own <ViewTransitions>. Match each route and its
   // subpaths exactly so an unrelated future demo sharing the prefix (e.g.
   // /demos/view-transitions-foo) doesn't lose the site instance.
@@ -39,11 +45,11 @@
 {/if}
 
 <Banner />
-<MobileNav mochi:hydrate {docsNav} {demos} {currentSlug} />
+<MobileNav mochi:hydrate {docsNav} demos={navDemos} {currentSlug} />
 <CodeBlockCopy mochi:hydrate />
 
 <div class="page">
-  <Sidebar mochi:hydrate {docsNav} {demos} {currentSlug} />
+  <Sidebar mochi:hydrate {docsNav} demos={navDemos} {currentSlug} />
 
   <!-- Naming `.body` (rendered by the page component) confines the transition to
        it; everything else (banner, sidebar, debug bar) is part of `root` and


### PR DESCRIPTION
The hydrated Sidebar/MobileNav islands received the full demos array, whose server-only files[].path entries (e.g. ./src/demos/url/routes.ts) got serialized into the page. Crawlers resolved those as relative URLs against the page, producing phantom 404s like /docs/docker/src/demos/url/routes.ts. Nav never reads .files, so strip it before the props ship to the client.