### PR TITLE
feat: separate dev build cache from production .mochi output

### DIFF
--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -58,7 +58,7 @@ In production (`development: false`), prebuilt JS/CSS bundles served from `asset
 - `compressServerIslandProps`: Deflate-compress server-island props when it reduces size. Default: `true`.
 - `logger`: Built-in request logger. Default: `{ enabled: true }`. Pass `{ enabled: false }` to disable, or override `slowThreshold` / `verySlowThreshold`.
 - `publicDir`: Directory served as static assets (cwd-relative). Default: `./public`.
-- `outDir`: Directory for build artifacts and dev cache (cwd-relative). Default: `./.mochi`.
+- `outDir`: Base directory for build artifacts and dev cache (cwd-relative). Default: `./.mochi`. Production writes here directly; development nests under `<outDir>/dev` so a dev run can't collide with a production build (and is wiped clean on every dev startup).
 - `assetPrefix`: URL prefix for framework client assets and the server-island endpoint. Must start with `/`, must not be `/`, must not end with `/`, must not contain whitespace or `..`. Default: `/_mochi`.
 - `additionalWatchPaths`: Extra dev-mode watcher paths added to the defaults `src` and `public`. Default: `[]`.
 - `svelteConfigPath`: Path to a Svelte config file. Default: `./svelte.config.js`. See `Svelte config`.

--- a/packages/docs/183-cli.md
+++ b/packages/docs/183-cli.md
@@ -39,7 +39,7 @@ Produces a production bundle by reading config straight from your entry's `Mochi
 | Option                  | Default          | Description                                                                             |
 | ----------------------- | ---------------- | --------------------------------------------------------------------------------------- |
 | `--entry <path>`        | `./src/index.ts` | Runtime entry whose `Mochi.serve()` call supplies `routes`, `markdown`, and `optimize`. |
-| `--out-dir <path>`      | `./.mochi`       | Build output directory.                                                                 |
+| `--out-dir <path>`      | `./.mochi`       | Base build output directory. `--dev` builds nest under `<out-dir>/dev`.                 |
 | `--public-dir <path>`   | `./public`       | Static assets directory.                                                                |
 | `--asset-prefix <path>` | `/_mochi`        | URL prefix for framework client assets.                                                 |
 | `--dev`                 | off              | Build with `development: true`.                                                         |

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -246,7 +246,11 @@ export class Mochi {
     const debugBarEnabled = development && (options.debugBar ?? true);
     const liveReloadEnabled = options.liveReload ?? development;
     const middleware = options.handle;
-    const outDir = options.outDir ?? './.mochi';
+    const baseOutDir = options.outDir ?? './.mochi';
+    // Keep dev artifacts out of the production .mochi so the two modes never
+    // collide (stale manifest/public from a prod build, or dev chunks served by
+    // a later `start`). Prod stays at the root so Docker/deploys are unaffected.
+    const outDir = development ? path.join(baseOutDir, 'dev') : baseOutDir;
     const publicDir = options.publicDir ?? './public';
     // Only a file-based shell can be watched/re-read; an inline-string shell
     // has no source file, and the built-in default is bundled, not a runtime file.
@@ -319,9 +323,11 @@ export class Mochi {
       // compiles at startup, so the shake must run before the first compile.
       await registry.prepareShake();
       if (development) {
-        for (const dir of [`${outDir}/svelte-client`, `${outDir}/svelte-compile`, `${outDir}/svelte-css`]) {
-          rmSync(dir, { recursive: true, force: true });
-          mkdirSync(dir, { recursive: true });
+        // outDir is the dev-only dir (.mochi/dev). Wipe it whole each startup so
+        // stale entry-hmr / import-css / compiled chunks can't leak across restarts.
+        rmSync(outDir, { recursive: true, force: true });
+        for (const sub of ['svelte-client', 'svelte-compile', 'svelte-css']) {
+          mkdirSync(path.join(outDir, sub), { recursive: true });
         }
       }
     }

--- a/packages/mochi/src/build.ts
+++ b/packages/mochi/src/build.ts
@@ -15,7 +15,10 @@ import prettyBytes from './lib/prettyBytes';
 export interface MochiBuildOptions {
   routes: Record<string, MochiRouteValue>;
   development?: boolean;
-  /** Directory for build output (cwd-relative). Default: `./.mochi`. */
+  /**
+   * Base directory for build output (cwd-relative). Default: `./.mochi`.
+   * A `--dev` build nests under `<outDir>/dev`; production writes to the root.
+   */
   outDir?: string;
   /** Static assets directory (cwd-relative). Default: `./public`. */
   publicDir?: string;
@@ -63,7 +66,10 @@ export async function build(options: MochiBuildOptions): Promise<void> {
   console.log('Starting build...\n');
   const startedAt = performance.now();
   const development = options.development ?? false;
-  const outDir = options.outDir ?? './.mochi';
+  const baseOutDir = options.outDir ?? './.mochi';
+  // Mirror the dev/prod split in Mochi.serve(): a `--dev` build nests under
+  // `dev/` so it can't clobber the production manifest at the root.
+  const outDir = development ? path.join(baseOutDir, 'dev') : baseOutDir;
   const publicDir = options.publicDir ?? './public';
 
   // Clean previous build artifacts

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -503,7 +503,11 @@ export interface MochiServeOptions {
   } & import('./consoleLogger').ConsoleLoggerOptions;
   /** Directory served as static assets (cwd-relative). Default: `./public`. */
   publicDir?: string;
-  /** Directory for build artifacts and dev cache (cwd-relative). Default: `./.mochi`. */
+  /**
+   * Base directory for build artifacts and dev cache (cwd-relative). Default: `./.mochi`.
+   * Production writes here directly; development nests under `<outDir>/dev` so the two
+   * modes never collide.
+   */
   outDir?: string;
   /**
    * URL prefix under which framework client assets (JS bundles, CSS, bundle


### PR DESCRIPTION
## What

Dev mode and production builds previously wrote to the **same** `./.mochi` directory with identical subpaths (`svelte-client`, `svelte-compile`, `svelte-css`, `import-css`, `entry-hmr`, `manifest.json`, `public/`). There was no mode branching on the output path, so the two collided: a prod build's stale `manifest.json` / `public/` could leak into a dev run, and dev-compiled chunks could be served by a later `start` if no manifest existed.

This routes **dev** output to `<outDir>/dev` (default `.mochi/dev`). **Production stays at the root** (`.mochi`) so Docker images and existing deploys that read `.mochi/manifest.json` are unaffected.

It also fixes incomplete dev cleanup: dev startup used to wipe only the three `svelte-*` subdirs, leaving `entry-hmr` and `import-css` to accumulate stale HMR/import chunks across restarts. Dev now wipes the **entire** dev dir each startup.

## How

`outDir` is resolved once per entry point that knows `development`:
- **Dev:** `<base>/dev`
- **Prod:** `<base>` (unchanged)

Everything downstream (`ComponentRegistry`, `devWatcher`, manifest path, the dev wipe) already derives from that single `outDir`, so the split propagates without scattered edits. `ComponentRegistry`'s own `?? './.mochi'` default is untouched — it never fires in real runs (callers always pass an explicit, already-resolved `outDir`), which avoids any double-nesting.

## Files
- `packages/mochi/src/Mochi.ts` — dev-suffix resolution; whole-dir dev wipe on startup.
- `packages/mochi/src/build.ts` — same resolution (affects `mochi-framework build --dev`); existing `rmSync(outDir)` already full-cleans.
- `packages/mochi/src/types.ts`, `build.ts` doc comments + `packages/docs/160-serve-options.md`, `packages/docs/183-cli.md` — documented the split.

No `clean` scripts or `.gitignore` changes needed — `rimraf .mochi` and the `.mochi` ignore already cover the nested `dev/`.

## Testing
- `bun run checks` — lint, format, typecheck, and 127 tests all green.
- Smoke-tested `packages/minimal`:
  - Dev → `.mochi/dev/{svelte-client,svelte-compile,svelte-css,entry-hmr}`, root otherwise empty, serves 200.
  - Prod build → `.mochi/manifest.json` + `svelte-*` at root, no `dev/`, serves 200 from the prebuilt manifest.
  - Running dev alongside an existing prod build left the prod manifest and compiled output untouched.