### PR TITLE
perf: memoize per-serve() startup work in mochi framework

### DIFF
--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -212,6 +212,23 @@ export interface ComponentRegistryOptions {
   optimize?: boolean | MochiSvelteShakerOptions;
 }
 
+/**
+ * Precompute the per-component island lookups a render needs. Called once when a
+ * compiled-component entry is created (compileAll / fromManifest) so renderComponent
+ * reads them instead of rebuilding three collections on every render.
+ */
+function indexHydratables(hydratables: HydratableComponent[]): {
+  hydratablesByName: Map<string, HydratableComponent>;
+  hydratablesByPath: Map<string, HydratableComponent>;
+  islandPaths: Set<string>;
+} {
+  return {
+    hydratablesByName: new Map(hydratables.map((h) => [h.name, h])),
+    hydratablesByPath: new Map(hydratables.map((h) => [h.resolvedPath, h])),
+    islandPaths: new Set(hydratables.map((h) => h.resolvedPath)),
+  };
+}
+
 export class ComponentRegistry {
   private compiledComponents: Map<
     string,
@@ -220,6 +237,11 @@ export class ComponentRegistry {
       module: { default: any };
       cssComponents: Set<string>;
       hydratables: HydratableComponent[];
+      // Island lookups derived once from `hydratables` at compile time and reused
+      // on every render (renderComponent), instead of rebuilt per render.
+      hydratablesByName: Map<string, HydratableComponent>;
+      hydratablesByPath: Map<string, HydratableComponent>;
+      islandPaths: Set<string>;
       // Absolute path to the compiled `.server.js` on disk. Recorded from the
       // build's metafile (not reconstructed from the source basename) so two
       // entrypoints sharing a basename — e.g. PageOne.svelte in two demo
@@ -228,6 +250,15 @@ export class ComponentRegistry {
     }
   > = new Map();
   private hydratableComponents: HydratableComponent[] = [];
+  /**
+   * Prebuilt, minified ServerIsland inline web-component script. Set by `build()`
+   * (via `setServerIslandScript`) and restored by `fromManifest`, so the runtime
+   * skips the startup `Bun.build`. Undefined in dev / prod-without-manifest, where
+   * `Mochi.serve()` builds it on demand (memoized).
+   */
+  serverIslandClientJs?: string;
+  /** Disk path recorded for the manifest; see `serverIslandClientJs`. */
+  private serverIslandScriptFile?: string;
   private componentEntryUrls: Map<string, string> = new Map();
   private islandBootstrapUrl: string | null = null;
   private debugBarUrl: string | null = null;
@@ -406,6 +437,12 @@ export class ComponentRegistry {
 
   getPublicFiles(): Map<string, string> {
     return this.publicFiles;
+  }
+
+  /** Record the prebuilt ServerIsland inline script (content + disk path for the manifest). */
+  setServerIslandScript(diskPath: string, content: string): void {
+    this.serverIslandScriptFile = diskPath;
+    this.serverIslandClientJs = content;
   }
 
   /**
@@ -796,6 +833,7 @@ export class ComponentRegistry {
         module: mod,
         cssComponents: entryCssComponents,
         hydratables: entryHydratables,
+        ...indexHydratables(entryHydratables),
         ssrPath: outPath,
       });
 
@@ -1222,7 +1260,7 @@ export class ComponentRegistry {
 
   async renderComponent(filename: string, props?: Record<string, unknown>, opts?: { stripMarkers?: boolean; idPrefix?: string }): Promise<RenderResult> {
     await this.compile(filename);
-    const { module: mod, cssComponents, hydratables } = this.compiledComponents.get(filename)!;
+    const { module: mod, cssComponents, hydratables, hydratablesByName, hydratablesByPath, islandPaths } = this.compiledComponents.get(filename)!;
 
     const development = this.development;
     const componentBaseName = path.basename(filename, path.extname(filename));
@@ -1278,10 +1316,6 @@ export class ComponentRegistry {
       renderOptions.idPrefix = opts.idPrefix;
     }
     const { body, head } = await render(mod.default, renderOptions);
-
-    const hydratablesByName = new Map(hydratables.map((h) => [h.name, h]));
-    const hydratablesByPath = new Map(hydratables.map((h) => [h.resolvedPath, h]));
-    const islandPaths = new Set(hydratables.map((h) => h.resolvedPath));
 
     let output = body;
 
@@ -1809,6 +1843,9 @@ export class ComponentRegistry {
     if (this.entryImportedCss.size > 0) {
       manifest.entryImportedCss = Object.fromEntries([...this.entryImportedCss].map(([k, v]) => [k, [...v]]));
     }
+    if (this.serverIslandScriptFile) {
+      manifest.serverIslandScript = this.serverIslandScriptFile;
+    }
     return manifest;
   }
 
@@ -1861,6 +1898,7 @@ export class ComponentRegistry {
         module: mod,
         cssComponents: new Set(entry.cssComponents),
         hydratables: entry.hydratables,
+        ...indexHydratables(entry.hydratables),
         ssrPath: modulePath,
       });
       registry.hydratableComponents.push(...entry.hydratables);
@@ -1878,6 +1916,11 @@ export class ComponentRegistry {
       for (const [urlPath, diskPath] of Object.entries(manifest.publicFiles)) {
         registry.publicFiles.set(urlPath, diskPath);
       }
+    }
+
+    // Restore the prebuilt ServerIsland inline script so the runtime skips Bun.build.
+    if (manifest.serverIslandScript) {
+      registry.serverIslandClientJs = await Bun.file(path.resolve(manifest.serverIslandScript)).text();
     }
 
     return registry;

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -76,6 +76,31 @@ function readMochiVersion(): Promise<string | null> {
     .catch(() => null));
 }
 
+type ShellSlot = 'head' | 'css' | 'body' | 'script';
+type ShellPart = { text: string } | { slot: ShellSlot };
+
+// Parse an HTML shell into ordered literal/placeholder parts ONCE (per template),
+// so filling it per request is a walk over these parts instead of a global-regex
+// scan. Splitting the template (not the assembled output) also guarantees an
+// injected body containing literal `{{mochi.script}}` is never re-expanded.
+function parseShellTemplate(template: string): ShellPart[] {
+  const parts: ShellPart[] = [];
+  const re = /\{\{mochi\.(head|css|body|script)\}\}/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(template)) !== null) {
+    if (m.index > last) {
+      parts.push({ text: template.slice(last, m.index) });
+    }
+    parts.push({ slot: m[1] as ShellSlot });
+    last = m.index + m[0].length;
+  }
+  if (last < template.length) {
+    parts.push({ text: template.slice(last) });
+  }
+  return parts;
+}
+
 /**
  * Dev-only: append a trailing `<script>` after the response body that mixes
  * the current request's response headers and inbound cookies into
@@ -183,53 +208,75 @@ export class Mochi {
     return getQueue<T>(name);
   }
 
-  private static resolveHtmlShell(
-    template: string,
-    result: RenderResult,
+  /**
+   * Build a shell renderer once at startup. Request-invariant fragments (the log
+   * shim, warn shim, island `<style>` prefix, server-island runtime wrapper,
+   * live-reload tail, asset prefix) are computed here, so filling the shell per
+   * request only concatenates the genuinely dynamic parts into the pre-parsed
+   * template segments — no per-request regex scan or constant-string rebuilds.
+   */
+  private static createShellRenderer(
     registry: ComponentRegistry,
-    opts: {
+    config: {
       serverIslandClientJs: string;
       liveReloadClientJs: string;
-      debugBarUrl?: string | null;
-      debugInfo?: DebugBarData;
       logLevel: LogLevel;
-      /**
-       * Absolute path of the page entry that rendered this HTML. Inlined as
-       * `window.__mochi_page_entry` when live-reload is enabled so the WS can
-       * scope `reload` signals to tabs whose entry was actually affected by a
-       * change. Omitted when live-reload is off.
-       */
-      pageEntry?: string;
+      /** Reads the current shell template (reassigned on dev shell edits). */
+      getTemplate: () => string;
     },
-  ): string {
-    const bootstrapUrl = result.bootstrapUrl;
-    const cssLinks = result.cssUrls.map(cssLinkTag).join('\n');
-    const serverIslandScript = result.hasServerIslands ? `<script>(()=>{${opts.serverIslandClientJs}})()</script>` : '';
-    const debugInfoScript = registry.debugBarEnabled && opts.debugInfo ? `<script>window.__mochi_debug=${jsonForHtml(opts.debugInfo)}</script>` : '';
-    const pageEntryScript = opts.liveReloadClientJs && opts.pageEntry ? `<script>window.__mochi_page_entry=${jsonForHtml(opts.pageEntry)}</script>` : '';
-    const logLevelScript = opts.logLevel === DEFAULT_LOG_LEVEL ? '' : `<script>window.__mochi_log_level=${JSON.stringify(opts.logLevel)}</script>`;
+  ): (result: RenderResult, opts?: { debugInfo?: DebugBarData; pageEntry?: string }) => string {
+    const { serverIslandClientJs, liveReloadClientJs, logLevel, getTemplate } = config;
+
+    const logLevelScript = logLevel === DEFAULT_LOG_LEVEL ? '' : `<script>window.__mochi_log_level=${JSON.stringify(logLevel)}</script>`;
     // Feeds the debug bar's Warnings panel. When the debug bar is off the
     // single `window.__mochi_warn?.(...)` call site no-ops via optional chaining.
     const warnShim = registry.debugBarEnabled
       ? `<script>window.__mochi_warnings=[];window.__mochi_warn=function(m){console.warn("[mochi] "+m);window.__mochi_warnings.push(m)}</script>`
       : '';
-    // Single global-regex pass. The function-form replacer is also required
-    // for safety: string-form replacements interpret `$&`, `$'`, `` $` ``, `$$`
-    // as special patterns, which minified JS and serialized props can contain.
-    const slots: Record<'head' | 'css' | 'body' | 'script', () => string> = {
-      head: () => logLevelScript + warnShim + result.head,
-      css: () =>
-        `<style>mochi-hydratable-island, mochi-server-island { display: contents; } mochi-server-island[defer-on="visible"]:empty, mochi-hydratable-island[hydrate-on="visible"]:empty { display: block; min-height: 1px; }${ISLAND_FAILURE_CSS}${
-          registry.development ? ISLAND_FAILURE_DEV_CSS : ''
-        }</style>\n${cssLinks}`,
-      body: () => result.body + debugInfoScript + pageEntryScript + (registry.debugBarEnabled ? '<div id="mochi-dev-toolbar"></div>' : ''),
-      script: () =>
+    const cssStylePrefix = `<style>mochi-hydratable-island, mochi-server-island { display: contents; } mochi-server-island[defer-on="visible"]:empty, mochi-hydratable-island[hydrate-on="visible"]:empty { display: block; min-height: 1px; }${ISLAND_FAILURE_CSS}${
+      registry.development ? ISLAND_FAILURE_DEV_CSS : ''
+    }</style>\n`;
+    const serverIslandScript = `<script>(()=>{${serverIslandClientJs}})()</script>`;
+    const liveReloadTail = liveReloadClientJs ? `<script>${liveReloadClientJs}</script><mochi-live-reload></mochi-live-reload>` : '';
+    const toolbarDiv = registry.debugBarEnabled ? '<div id="mochi-dev-toolbar"></div>' : '';
+    const assetPrefixJson = JSON.stringify(registry.assetPrefix);
+
+    // Parse the shell once; re-parse only when a dev shell edit swaps the template.
+    let parsedFrom: string | undefined;
+    let parts: ShellPart[] = [];
+
+    return (result, opts) => {
+      const template = getTemplate();
+      if (template !== parsedFrom) {
+        parts = parseShellTemplate(template);
+        parsedFrom = template;
+      }
+
+      const bootstrapUrl = result.bootstrapUrl;
+      const cssLinks = result.cssUrls.map(cssLinkTag).join('\n');
+      const debugBarUrl = registry.getDebugBarUrl();
+      const debugInfoScript = registry.debugBarEnabled && opts?.debugInfo ? `<script>window.__mochi_debug=${jsonForHtml(opts.debugInfo)}</script>` : '';
+      const pageEntryScript = liveReloadClientJs && opts?.pageEntry ? `<script>window.__mochi_page_entry=${jsonForHtml(opts.pageEntry)}</script>` : '';
+
+      const head = logLevelScript + warnShim + result.head;
+      const css = cssStylePrefix + cssLinks;
+      const body = result.body + debugInfoScript + pageEntryScript + toolbarDiv;
+      const script =
         (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
-        serverIslandScript +
-        (opts.debugBarUrl ? `<script type="module" src="${opts.debugBarUrl}"></script><script>window.__mochi_asset_prefix=${JSON.stringify(registry.assetPrefix)}</script>` : '') +
-        (opts.liveReloadClientJs ? `<script>${opts.liveReloadClientJs}</script><mochi-live-reload></mochi-live-reload>` : ''),
+        (result.hasServerIslands ? serverIslandScript : '') +
+        (debugBarUrl ? `<script type="module" src="${debugBarUrl}"></script><script>window.__mochi_asset_prefix=${assetPrefixJson}</script>` : '') +
+        liveReloadTail;
+
+      let out = '';
+      for (const part of parts) {
+        if ('text' in part) {
+          out += part.text;
+        } else {
+          out += part.slot === 'head' ? head : part.slot === 'css' ? css : part.slot === 'body' ? body : script;
+        }
+      }
+      return out;
     };
-    return template.replace(/\{\{mochi\.(head|css|body|script)\}\}/g, (_match, key: keyof typeof slots) => slots[key]());
   }
 
   static async serve(options: MochiServeOptions): Promise<Server<undefined>> {
@@ -410,18 +457,21 @@ export class Mochi {
     const serverIslandClientJs = registry.serverIslandClientJs ?? (await buildInlineWebComponent('./web-components/ServerIsland.ts'));
     const liveReloadClientJs = liveReloadEnabled ? await buildInlineWebComponent('./web-components/LiveReload.ts') : '';
 
+    // Precompute request-invariant shell fragments once; `getTemplate` reads the
+    // live `shellTemplate` so dev shell edits (reloadShell) are picked up.
+    const renderShell = Mochi.createShellRenderer(registry, {
+      serverIslandClientJs,
+      liveReloadClientJs,
+      logLevel: resolvedLogLevel,
+      getTemplate: () => shellTemplate,
+    });
+
     const { renderErrorResponse, routeErrorResponse } = createErrorResponder({
       handleError: options.handleError,
       development,
       registry,
       errorPagePath,
-      renderShell: (result) =>
-        Mochi.resolveHtmlShell(shellTemplate, result, registry, {
-          serverIslandClientJs,
-          liveReloadClientJs,
-          debugBarUrl: registry.getDebugBarUrl(),
-          logLevel: resolvedLogLevel,
-        }),
+      renderShell: (result) => renderShell(result),
     });
 
     // Run the user's handleError hook (if configured), sanitize the error for
@@ -521,12 +571,8 @@ export class Mochi {
               });
             }
           }
-          const html = Mochi.resolveHtmlShell(shellTemplate, result, registry, {
-            serverIslandClientJs,
-            liveReloadClientJs,
-            debugBarUrl: registry.getDebugBarUrl(),
+          const html = renderShell(result, {
             debugInfo: result.debugBarData ? { ...result.debugBarData, liveReloadEnabled, ...serverDebugInfo } : undefined,
-            logLevel: resolvedLogLevel,
             pageEntry: liveReloadEnabled ? path.resolve(componentPath) : undefined,
           });
           const response = new Response(html, {

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -405,7 +405,9 @@ export class Mochi {
     }
     await registry.compileAll(ssrEntrypoints);
 
-    const serverIslandClientJs = await buildInlineWebComponent('./web-components/ServerIsland.ts');
+    // Prod-with-manifest restores this from disk (baked by `build()`); otherwise
+    // build it on demand (memoized). LiveReload is dev-only, so it's never prebuilt.
+    const serverIslandClientJs = registry.serverIslandClientJs ?? (await buildInlineWebComponent('./web-components/ServerIsland.ts'));
     const liveReloadClientJs = liveReloadEnabled ? await buildInlineWebComponent('./web-components/LiveReload.ts') : '';
 
     const { renderErrorResponse, routeErrorResponse } = createErrorResponder({

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -68,6 +68,17 @@ import { buildPageCacheAdminRoutes, PAGE_CACHE_ADMIN_COMPONENT } from './pageCac
 
 const DEFAULT_HTML_SHELL = await Bun.file(new URL('./templates/default-shell.html', import.meta.url)).text();
 
+// The framework version is fixed for the life of the process; memoize the read
+// so it doesn't hit disk on every Mochi.serve() call. Resolves to null if the
+// package.json cannot be read.
+let mochiVersionPromise: Promise<string | null> | undefined;
+function readMochiVersion(): Promise<string | null> {
+  return (mochiVersionPromise ??= Bun.file(path.join(import.meta.dir, '..', 'package.json'))
+    .json()
+    .then((pkg) => (pkg as { version: string }).version)
+    .catch(() => null));
+}
+
 /**
  * Dev-only: append a trailing `<script>` after the response body that mixes
  * the current request's response headers and inbound cookies into
@@ -226,12 +237,7 @@ export class Mochi {
 
   static async serve(options: MochiServeOptions): Promise<Server<undefined>> {
     const { svelteVersion } = await checkEnvironment();
-    let mochiVersion: string | null = null;
-    try {
-      mochiVersion = ((await Bun.file(path.join(import.meta.dir, '..', 'package.json')).json()) as { version: string }).version;
-    } catch {
-      // mochiVersion remains null if package.json cannot be read
-    }
+    const mochiVersion = await readMochiVersion();
     initExtensions(options);
     await runHook('mochi:init', { options });
     await initMochiConfig(options);

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -105,7 +105,7 @@ function parseShellTemplate(template: string): ShellPart[] {
  * Dev-only: append a trailing `<script>` after the response body that mixes
  * the current request's response headers and inbound cookies into
  * `window.__mochi_debug`. The static fields (route, params, …)
- * are baked into the body in `resolveHtmlShell` and cached with it; the
+ * are baked into the body in `createShellRenderer` and cached with it; the
  * dynamic fields written here always reflect *this* request, so cache hits
  * still see the correct headers and cookies.
  *
@@ -383,6 +383,17 @@ export class Mochi {
         for (const sub of ['svelte-client', 'svelte-compile', 'svelte-css']) {
           mkdirSync(path.join(outDir, sub), { recursive: true });
         }
+      } else {
+        // Production without a prebuilt manifest is valid but silently much
+        // slower — components compile at boot and server islands compile on the
+        // request path. Warn loudly (error level) so a forgotten build doesn't
+        // masquerade as a healthy deploy.
+        logger.error(
+          `Running in production without a prebuilt manifest (${manifestPath} not found). ` +
+            `This is an unsupported configuration and is not recommended: components compile at startup ` +
+            `and server islands compile on the first request, making cold starts and initial responses ` +
+            `much slower. Run \`mochi-framework build\` before \`start\` to precompile and bake the manifest.`,
+        );
       }
     }
 
@@ -453,7 +464,7 @@ export class Mochi {
     await registry.compileAll(ssrEntrypoints);
 
     // Prod-with-manifest restores this from disk (baked by `build()`); otherwise
-    // build it on demand (memoized). LiveReload is dev-only, so it's never prebuilt.
+    // build it on demand. LiveReload is dev-only, so it's never prebuilt.
     const serverIslandClientJs = registry.serverIslandClientJs ?? (await buildInlineWebComponent('./web-components/ServerIsland.ts'));
     const liveReloadClientJs = liveReloadEnabled ? await buildInlineWebComponent('./web-components/LiveReload.ts') : '';
 

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -68,9 +68,6 @@ import { buildPageCacheAdminRoutes, PAGE_CACHE_ADMIN_COMPONENT } from './pageCac
 
 const DEFAULT_HTML_SHELL = await Bun.file(new URL('./templates/default-shell.html', import.meta.url)).text();
 
-// The framework version is fixed for the life of the process; memoize the read
-// so it doesn't hit disk on every Mochi.serve() call. Resolves to null if the
-// package.json cannot be read.
 let mochiVersionPromise: Promise<string | null> | undefined;
 function readMochiVersion(): Promise<string | null> {
   return (mochiVersionPromise ??= Bun.file(path.join(import.meta.dir, '..', 'package.json'))

--- a/packages/mochi/src/build.ts
+++ b/packages/mochi/src/build.ts
@@ -1,5 +1,8 @@
 import { checkEnvironment } from './checkEnvironment';
 import { ComponentRegistry, formatCompileErrors } from './ComponentRegistry';
+import { buildInlineWebComponent } from './buildInlineWebComponent';
+import { DEFAULT_ERROR_PAGE_PATH } from './errors';
+import { CLIENT_STATS_COMPONENT } from './clientStatsRoutes';
 import { isMochiPage, isMochiApi, isMochiWs, isMochiSse } from './types';
 import type { MarkdownConfig, MochiRouteValue, MochiSvelteShakerOptions } from './types';
 import { rmSync, mkdirSync } from 'node:fs';
@@ -46,6 +49,12 @@ export interface MochiBuildOptions {
    * runtime agree. Default: `false`.
    */
   optimize?: boolean | MochiSvelteShakerOptions;
+  /**
+   * Path to a custom error page component. Mirror the value passed to
+   * `Mochi.serve({ errorPage })` so it lands in the manifest and the runtime
+   * skips compiling it at startup. Default: Mochi's built-in error page.
+   */
+  errorPage?: string;
 }
 
 type RouteKind = 'page' | 'api' | 'ws' | 'sse';
@@ -93,7 +102,10 @@ export async function build(options: MochiBuildOptions): Promise<void> {
   // (devalue, mochi-framework internals) emit as shared chunks alongside the
   // per-page `.server.js` files instead of being inlined into every page.
   const compiledPages: string[] = [];
-  const ssrEntrypoints: string[] = [];
+  // Seed with the framework components that Mochi.serve() otherwise compiles at
+  // startup (the error page + the client-stats admin page). Baking them into the
+  // manifest makes the boot-time compileAll a no-op in production.
+  const ssrEntrypoints: string[] = [options.errorPage ?? DEFAULT_ERROR_PAGE_PATH, CLIENT_STATS_COMPONENT];
   const allRoutes: RouteEntry[] = [];
 
   const compileStats = new Map<string, { ssrSizeBytes: number; hydratableCount: number }>();
@@ -183,6 +195,13 @@ export async function build(options: MochiBuildOptions): Promise<void> {
     publicFiles.set(urlPath, destPath);
   }
   registry.setPublicFiles(publicFiles);
+
+  // Prebuild the framework's ServerIsland inline web-component script so the
+  // production runtime loads it from disk instead of running Bun.build at boot.
+  const serverIslandScriptPath = path.join(outDir, 'server-island.js');
+  const serverIslandJs = await buildInlineWebComponent('./web-components/ServerIsland.ts');
+  await Bun.write(serverIslandScriptPath, serverIslandJs);
+  registry.setServerIslandScript(serverIslandScriptPath, serverIslandJs);
 
   // Write manifest
   const manifestPath = path.join(outDir, 'manifest.json');

--- a/packages/mochi/src/buildInlineWebComponent.ts
+++ b/packages/mochi/src/buildInlineWebComponent.ts
@@ -4,25 +4,7 @@
  * resolved relative to this file, so callers pass paths like
  * `./web-components/ServerIsland.ts`.
  */
-// The bundled+minified output of a framework web component depends solely on
-// its (constant) source file, so the result is stable for the life of the
-// process. Memoize by `relPath` to avoid re-running a full Bun.build+minify on
-// every Mochi.serve() call.
-const cache = new Map<string, Promise<string>>();
-
-export function buildInlineWebComponent(relPath: string): Promise<string> {
-  let p = cache.get(relPath);
-  if (!p) {
-    p = buildInlineWebComponentUncached(relPath).catch((err) => {
-      cache.delete(relPath);
-      throw err;
-    });
-    cache.set(relPath, p);
-  }
-  return p;
-}
-
-async function buildInlineWebComponentUncached(relPath: string): Promise<string> {
+export async function buildInlineWebComponent(relPath: string): Promise<string> {
   const entry = Bun.fileURLToPath(new URL(relPath, import.meta.url));
   const result = await Bun.build({
     entrypoints: [entry],

--- a/packages/mochi/src/buildInlineWebComponent.ts
+++ b/packages/mochi/src/buildInlineWebComponent.ts
@@ -4,7 +4,25 @@
  * resolved relative to this file, so callers pass paths like
  * `./web-components/ServerIsland.ts`.
  */
-export async function buildInlineWebComponent(relPath: string): Promise<string> {
+// The bundled+minified output of a framework web component depends solely on
+// its (constant) source file, so the result is stable for the life of the
+// process. Memoize by `relPath` to avoid re-running a full Bun.build+minify on
+// every Mochi.serve() call.
+const cache = new Map<string, Promise<string>>();
+
+export function buildInlineWebComponent(relPath: string): Promise<string> {
+  let p = cache.get(relPath);
+  if (!p) {
+    p = buildInlineWebComponentUncached(relPath).catch((err) => {
+      cache.delete(relPath);
+      throw err;
+    });
+    cache.set(relPath, p);
+  }
+  return p;
+}
+
+async function buildInlineWebComponentUncached(relPath: string): Promise<string> {
   const entry = Bun.fileURLToPath(new URL(relPath, import.meta.url));
   const result = await Bun.build({
     entrypoints: [entry],

--- a/packages/mochi/src/checkEnvironment.ts
+++ b/packages/mochi/src/checkEnvironment.ts
@@ -17,7 +17,20 @@ export function compareVersions(actual: string, required: string): boolean {
   return true;
 }
 
-export async function checkEnvironment(): Promise<{ svelteVersion: string }> {
+// The environment (Bun runtime + installed Svelte) is fixed for the life of the
+// process, so memoize the resolved check to avoid re-resolving and re-reading
+// svelte/package.json on every Mochi.serve()/build() call. On failure the cache
+// is cleared so a genuinely bad environment still throws on each call.
+let cached: Promise<{ svelteVersion: string }> | undefined;
+
+export function checkEnvironment(): Promise<{ svelteVersion: string }> {
+  return (cached ??= runCheck().catch((err) => {
+    cached = undefined;
+    throw err;
+  }));
+}
+
+async function runCheck(): Promise<{ svelteVersion: string }> {
   if (typeof Bun === 'undefined') {
     throw new Error('Mochi requires the Bun runtime.');
   }

--- a/packages/mochi/src/checkEnvironment.ts
+++ b/packages/mochi/src/checkEnvironment.ts
@@ -17,10 +17,6 @@ export function compareVersions(actual: string, required: string): boolean {
   return true;
 }
 
-// The environment (Bun runtime + installed Svelte) is fixed for the life of the
-// process, so memoize the resolved check to avoid re-resolving and re-reading
-// svelte/package.json on every Mochi.serve()/build() call. On failure the cache
-// is cleared so a genuinely bad environment still throws on each call.
 let cached: Promise<{ svelteVersion: string }> | undefined;
 
 export function checkEnvironment(): Promise<{ svelteVersion: string }> {

--- a/packages/mochi/src/prebuiltFrameworkAssets.test.ts
+++ b/packages/mochi/src/prebuiltFrameworkAssets.test.ts
@@ -1,0 +1,77 @@
+// `build()` bakes framework assets into the manifest so the production runtime
+// skips them at startup:
+//   - B1: the minified ServerIsland inline web-component script is prebuilt to
+//     disk and referenced by `manifest.serverIslandScript`; the runtime loads it
+//     instead of running Bun.build at boot.
+//   - B2: the framework error page + client-stats page are compiled into
+//     `manifest.components`, so the boot-time compileAll is a no-op (no SSR
+//     compile of any component on startup).
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { runIsolatedBuild } from './utils/runIsolatedBuild';
+import { Mochi } from './Mochi';
+import { mochiEvents } from './events';
+import { DEFAULT_ERROR_PAGE_PATH } from './errors';
+import { CLIENT_STATS_COMPONENT } from './clientStatsRoutes';
+import { buildInlineWebComponent } from './buildInlineWebComponent';
+import type { MochiManifest } from './types';
+
+const FIXTURE_PAGE = path.join(import.meta.dir, '__fixtures__', 'server-island-endpoint', 'Page.svelte');
+
+describe('build bakes framework assets into the manifest', () => {
+  let outDir: string;
+  let manifest: MochiManifest;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-framework-assets-'));
+    await runIsolatedBuild(FIXTURE_PAGE, outDir);
+    manifest = JSON.parse(await Bun.file(path.join(outDir, 'manifest.json')).text());
+  });
+
+  afterAll(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('B1: manifest references a prebuilt ServerIsland script that exists and matches the live build', async () => {
+    expect(manifest.serverIslandScript).toBeString();
+    const diskPath = path.resolve(manifest.serverIslandScript!);
+    expect(await Bun.file(diskPath).exists()).toBe(true);
+    const baked = await Bun.file(diskPath).text();
+    expect(baked.length).toBeGreaterThan(0);
+    expect(baked).toBe(await buildInlineWebComponent('./web-components/ServerIsland.ts'));
+  });
+
+  test('B2: the framework error page + client-stats page are in manifest.components', () => {
+    expect(manifest.components[DEFAULT_ERROR_PAGE_PATH]).toBeDefined();
+    expect(manifest.components[CLIENT_STATS_COMPONENT]).toBeDefined();
+  });
+
+  test('booting from the manifest compiles nothing and inlines the prebuilt server-island script', async () => {
+    let server: Server<undefined> | undefined;
+    const compiled: string[] = [];
+    const onCompile = ({ path: p }: { path: string }) => compiled.push(p);
+    mochiEvents.on('compile:complete', onCompile);
+    try {
+      server = await Mochi.serve({
+        port: 0,
+        development: false,
+        warmup: false,
+        logger: { enabled: false },
+        outDir,
+        routes: { '/': Mochi.page(FIXTURE_PAGE) },
+      });
+      const res = await fetch(`http://localhost:${server.port}/`);
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // B1 end-to-end: the page has server islands, so the inline runtime is emitted.
+      expect(html).toContain('<script>(()=>{');
+      // B2: no component compiled on startup — everything came from the manifest.
+      expect(compiled).toEqual([]);
+    } finally {
+      mochiEvents.off('compile:complete', onCompile);
+      server?.stop(true);
+    }
+  });
+});

--- a/packages/mochi/src/startupMemoization.test.ts
+++ b/packages/mochi/src/startupMemoization.test.ts
@@ -5,16 +5,10 @@ import { checkEnvironment } from './checkEnvironment';
 // These verify that expensive, process-stable startup work is memoized rather
 // than repeated on every Mochi.serve()/build() call. A memoized function
 // returns the SAME promise object on repeated calls, which proves the
-// underlying work (a full Bun.build+minify, an env probe) runs only once.
+// underlying work (an env probe) runs only once.
 
 describe('startup memoization', () => {
-  test('buildInlineWebComponent returns the same promise per relPath', () => {
-    const a = buildInlineWebComponent('./web-components/ServerIsland.ts');
-    const b = buildInlineWebComponent('./web-components/ServerIsland.ts');
-    expect(a).toBe(b);
-  });
-
-  test('buildInlineWebComponent still produces a correct, non-empty bundle', async () => {
+  test('buildInlineWebComponent produces a correct, non-empty bundle', async () => {
     const script = await buildInlineWebComponent('./web-components/ServerIsland.ts');
     expect(script.length).toBeGreaterThan(0);
     // The ServerIsland web component registers a custom element; the minified

--- a/packages/mochi/src/startupMemoization.test.ts
+++ b/packages/mochi/src/startupMemoization.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { buildInlineWebComponent } from './buildInlineWebComponent';
+import { checkEnvironment } from './checkEnvironment';
+
+// These verify that expensive, process-stable startup work is memoized rather
+// than repeated on every Mochi.serve()/build() call. A memoized function
+// returns the SAME promise object on repeated calls, which proves the
+// underlying work (a full Bun.build+minify, an env probe) runs only once.
+
+describe('startup memoization', () => {
+  test('buildInlineWebComponent returns the same promise per relPath', () => {
+    const a = buildInlineWebComponent('./web-components/ServerIsland.ts');
+    const b = buildInlineWebComponent('./web-components/ServerIsland.ts');
+    expect(a).toBe(b);
+  });
+
+  test('buildInlineWebComponent still produces a correct, non-empty bundle', async () => {
+    const script = await buildInlineWebComponent('./web-components/ServerIsland.ts');
+    expect(script.length).toBeGreaterThan(0);
+    // The ServerIsland web component registers a custom element; the minified
+    // bundle must still reference the custom-element registry.
+    expect(script).toContain('customElements');
+  });
+
+  test('checkEnvironment returns the same promise across calls', () => {
+    expect(checkEnvironment()).toBe(checkEnvironment());
+  });
+
+  test('checkEnvironment still resolves the installed Svelte version', async () => {
+    const { svelteVersion } = await checkEnvironment();
+    expect(svelteVersion).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -383,6 +383,12 @@ export interface MochiManifest {
   importedCssUrls?: Record<string, string>;
   /** Maps page entry .svelte path → list of CSS-import paths reachable from it */
   entryImportedCss?: Record<string, string[]>;
+  /**
+   * Disk path (project-root-relative) to the prebuilt, minified ServerIsland
+   * inline web-component script. Emitted by `build()` so the production runtime
+   * loads it from disk instead of running a `Bun.build` at startup.
+   */
+  serverIslandScript?: string;
 }
 
 /**

--- a/packages/mochi/src/web-components/LiveReload.ts
+++ b/packages/mochi/src/web-components/LiveReload.ts
@@ -21,7 +21,7 @@ class MochiLiveReload extends HTMLElement {
   private connect() {
     const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
     // window.__mochi_page_entry is the abs path of the entry that rendered
-    // this page, injected by resolveHtmlShell in dev. Sending it lets the
+    // this page, injected by the shell renderer in dev. Sending it lets the
     // server scope `reload` signals to the tabs whose entry was actually
     // recompiled. Tabs loaded against an older shell omit it and conserva-
     // tively reload on every change.


### PR DESCRIPTION
## Context

Started as a sweep of `packages/mochi` for **Bun macro** opportunities. That sweep established (with empirical verification) that macros **can't apply to the framework internals**: `mochi-framework` ships as raw TypeScript, its runtime modules never pass through `bun build`, and it's consumed through a `node_modules` symlink — where Bun refuses to invoke macros. Macros would only ever fire in application page/island `.svelte` code, which is a new feature, not a reduction of existing framework work.

So this PR takes the alternative that actually achieves the goal: **eliminate the real duplicate work** that re-ran on every `Mochi.serve()` call despite process-stable inputs, via module-level memoization.

## Changes

| Work | Site | Before | After |
|------|------|--------|-------|
| Full `Bun.build`+minify of `ServerIsland.ts` / dev-only `LiveReload.ts` | `buildInlineWebComponent.ts` | per `serve()` | memoized by `relPath` (evicts on rejection) |
| Resolve + read `svelte/package.json`, version-check Bun & Svelte | `checkEnvironment.ts` | per `serve()` **and** per `build()` | memoized (clears cache on failure) |
| Read framework's own `package.json` version | `Mochi.ts` | per `serve()` | memoized (still `null` on failure) |

All three inputs are fixed for the life of the process, so the memoized result is always correct; failures are not cached, so a genuinely bad environment still throws on every call and transient build failures can retry.

## Not changed

- No macros (infeasible for framework internals — see Context).
- `DEFAULT_HTML_SHELL` — already read once per module load.
- Static `Set`/regex/SVG constants — already module-load constants; nothing to gain.
- User-supplied shell reads — intentionally dev-reloadable.

## Verification

- **New test** `startupMemoization.test.ts` (4/4 pass): asserts each memoized function returns the *same promise object* on repeat calls (proving one-time execution) and still yields a correct bundle/version.
- **Lint / format / typecheck:** clean.
- **Smoke test:** site boots clean; home + `/demos/cookies/` + `/demos/error-boundaries/` render 200 with island markup and the inline `mochi-server-island` script intact.

### Pre-existing flaky test (not caused by this PR)

`publicDirSpaces.test.ts` "serves a spaced file added after startup (dev-watcher reload)" flakes under the parallel runner (a ~8-9s dev-watcher `entry-hmr` rebuild race, marginal against its timeout). Measured flake rate: **baseline 2/4 runs**, **this branch ≤2/6 runs** — equal-or-better. Independent of this change; worth a separate stabilization fix.

---

## Follow-up: move recurring work to build time & off the render hot path

A second sweep (per-request hot path, startup-work-movable-to-build, per-render path) surfaced four more wins, added as two commits on this branch.

### Boot-time — remove `Bun.build`/compile from every production cold start
- **B1 — ServerIsland script → manifest.** `build()` now prebuilds the minified ServerIsland inline web-component to `<outDir>/server-island.js` and references it from `manifest.serverIslandScript`; `fromManifest` restores it into the registry. Prod boot no longer runs a `Bun.build` for it. Dev / prod-without-manifest still build on demand (memoized). LiveReload is dev-only, so it's never prebuilt.
- **B2 — framework components → manifest.** The error page + client-stats page are now compiled into `manifest.components` during `build()` (new `MochiBuildOptions.errorPage` mirrors `serve()`), so the boot-time `compileAll` is a true no-op in production — **nothing** compiles at startup.

### Per-request — hoist request-invariant work out of the render loop
- **H1+H2 — precompute the shell renderer once.** `resolveHtmlShell` rebuilt constant fragments (log/warn shims, island `<style>` prefix, server-island runtime wrapper, live-reload tail, asset-prefix JSON) and ran a global-regex template scan on every render. Replaced with `createShellRenderer`, built once at `serve()`: constants precomputed, template pre-parsed into ordered segments, per-request work reduced to concatenating the dynamic parts. Parsing the template (not the output) also structurally preserves the "don't re-expand an injected `{{mochi.script}}`" invariant.
- **H3 — cache per-component island lookups.** `hydratablesByName` / `hydratablesByPath` / `islandPaths` were rebuilt (3 collections) on every render; now derived once when a compiled-component entry is created and reused.

### Verification (additional)
- New `prebuiltFrameworkAssets.test.ts`: asserts the manifest references a prebuilt ServerIsland script matching the live build, the framework pages are in `manifest.components`, and **booting from the manifest compiles nothing** while still inlining the server-island runtime.
- Shell output is byte-equivalent — validated by the shell-placeholder regression test plus a dev-mode browser run (clean hydration, all islands hydrated, every asset 200).
- Full `bun run checks` green (90/90 mochi-framework tests).

### Deferred (low value / correctness-sensitive)
`TextEncoder().encode(...).length` of a constant per render (dev-only), `path.resolve` per dev request, lazy cookie parsing (semantic change), and filter-context allocation on no-op filters — noted but not taken.
