### PR TITLE
fix: resolve HTML validation warnings (lang, charset position, aria-label)

### DIFF
--- a/packages/demos/src/shell.html
+++ b/packages/demos/src/shell.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/packages/mochi/src/templates/default-shell.html
+++ b/packages/mochi/src/templates/default-shell.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     {{mochi.head}} {{mochi.css}}

--- a/packages/site/src/Site.svelte
+++ b/packages/site/src/Site.svelte
@@ -76,7 +76,7 @@
                   <span class="demo-title">{demo.title}</span>
                   {#if meta}
                     {@const Icon = meta.icon}
-                    <span class="demo-icon" title={meta.label} aria-label={meta.label}>
+                    <span class="demo-icon" title={meta.label} aria-hidden="true">
                       <Icon size={16} strokeWidth={1.6} />
                     </span>
                   {/if}

--- a/packages/site/src/components/DemoPage.svelte
+++ b/packages/site/src/components/DemoPage.svelte
@@ -63,7 +63,7 @@
         {#if demoIconFor[title]}
           {@const meta = demoIconFor[title]}
           {@const Icon = meta.icon}
-          <span class="demo-icon" title={meta.label} aria-label={meta.label}>
+          <span class="demo-icon" title={meta.label} aria-hidden="true">
             <Icon size={16} strokeWidth={1.6} />
           </span>
         {/if}

--- a/packages/site/src/shell.html
+++ b/packages/site/src/shell.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    {{mochi.dog}} {{mochi.head}}
+    {{mochi.head}}
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
@@ -260,6 +260,6 @@
     {{mochi.css}}
   </head>
   <body>
-    {{mochi.body}} {{mochi.script}} {{mochi.analytics}}
+    {{mochi.body}} {{mochi.script}} {{mochi.analytics}} {{mochi.dog}}
   </body>
 </html>

--- a/packages/site/src/shell.html
+++ b/packages/site/src/shell.html
@@ -1,9 +1,8 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
-    {{mochi.dog}}
     <meta charset="utf-8" />
-    {{mochi.head}}
+    {{mochi.dog}} {{mochi.head}}
     <link rel="icon" href="/favicon.ico" sizes="any" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />


### PR DESCRIPTION
## What

Fixes the HTML validation errors reported by the W3C validator against the site (`localhost:3333`).

### Genuine fixes
- **Missing `lang`** — added `lang="en"` to `<html>` in `packages/site/src/shell.html`, `packages/demos/src/shell.html`, and the framework default `packages/mochi/src/templates/default-shell.html`. (`packages/minimal/src/shell.html` already had it.)
- **`<meta charset>` after the first 1024 bytes** — the site's `asciiDog` `transformPage` hook injects a ~1 KB braille-art comment at the `{{mochi.dog}}` placeholder, which used to sit in `<head>` before `<meta charset>`. The dog is now moved to the **footer** (end of `<body>`), so `<meta charset>` is the first child of `<head>` and always lands within the first bytes.
- **`aria-label` on `<span>`** — the decorative demo-icon spans (`Site.svelte`, `DemoPage.svelte`) carried `aria-label` while having the implicit `generic` role, which HTML disallows. Since the label text is already visible next to each icon, the icons are now marked decorative: dropped `aria-label`, added `aria-hidden="true"`, kept `title` for the hover tooltip.

### Intentionally left as-is
- **`@view-transition` / `::view-transition-*` CSS "parse errors"** — valid modern CSS emitted by `ViewTransitions.svelte`; the W3C CSS checker just doesn't recognize it yet.
- **Trailing-slash-on-void-element Info notices** — valid HTML5; the bulk are emitted by Svelte SSR and `svelte-meta-tags`, which we don't author.

## Verification
- Confirmed on a live dev server: `<html lang="en">`, `<meta charset>` first in `<head>` with no dog comment there, the dog comment now rendering once at the bottom of `<body>`, and demo-icon spans showing `aria-hidden="true"` / no `aria-label`.
- Lint / format / typecheck clean; all test files pass except a pre-existing, unrelated `publicDirSpaces.test.ts` failure (Svelte resolution in `checkEnvironment.ts`) that reproduces on `main` with these changes stashed.