### PR TITLE
test: de-flake public-dir spaces dev-watcher reload test

### DIFF
--- a/packages/mochi/src/publicDirSpaces.test.ts
+++ b/packages/mochi/src/publicDirSpaces.test.ts
@@ -4,18 +4,27 @@ import path from 'node:path';
 import type { Server } from 'bun';
 import { Mochi } from './Mochi';
 
-// Poll a URL until it returns the expected status or the deadline passes. The
-// dev watcher debounces public-dir changes (~100ms) and chokidar's event
-// latency varies by platform, so the live-add assertion can't fetch immediately.
-async function fetchUntil(url: string, status: number, timeoutMs = 8000): Promise<Response> {
+// Poll a URL until it returns the expected status or the deadline passes,
+// re-touching the file once per outer cycle. Under full-suite parallel load,
+// chokidar/fsevents can drop (or never deliver) a single fs event, so one write
+// may be missed permanently — no timeout can recover a missed event. Re-touching
+// gives the watcher repeated chances to observe a change and re-register the
+// route. The re-touch cadence must stay wider than the watcher's ~100ms reload
+// debounce, or successive writes would keep resetting it and the reload would
+// never fire; hence a burst of quick polls between touches rather than touching
+// on every poll.
+async function pollWithRetouch(url: string, touch: () => void, status: number, timeoutMs = 20_000): Promise<Response> {
   const deadline = performance.now() + timeoutMs;
   let last: Response | undefined;
   while (performance.now() < deadline) {
-    last = await fetch(url);
-    if (last.status === status) {
-      return last;
+    touch();
+    for (let i = 0; i < 6 && performance.now() < deadline; i++) {
+      last = await fetch(url);
+      if (last.status === status) {
+        return last;
+      }
+      await Bun.sleep(150);
     }
-    await Bun.sleep(50);
   }
   return last!;
 }
@@ -74,11 +83,8 @@ describe('public files with spaces in their names are served', () => {
   // Regression for the dev-watcher reload path: adding a spaced file at runtime
   // previously re-registered every public file under its raw key, 404-ing them.
   test('serves a spaced file added after startup (dev-watcher reload)', async () => {
-    writeFileSync(path.join(publicDir, 'added later.txt'), 'SPACED_LIVE_ADD');
-    // Generous deadline: under full-suite parallel load, chokidar's watch+debounce
-    // latency can exceed the default 8s, causing a flaky 404 before the route is
-    // re-registered. 20s keeps the assertion meaningful without flaking.
-    const res = await fetchUntil(`${base}/added%20later.txt`, 200, 20_000);
+    const added = path.join(publicDir, 'added later.txt');
+    const res = await pollWithRetouch(`${base}/added%20later.txt`, () => writeFileSync(added, 'SPACED_LIVE_ADD'), 200);
     expect(res.status).toBe(200);
     expect(await res.text()).toBe('SPACED_LIVE_ADD');
   });


### PR DESCRIPTION
## Problem
`packages/mochi/src/publicDirSpaces.test.ts` → *"serves a spaced file added after startup (dev-watcher reload)"* was flaky (~40% failure under full-suite parallel load), failing `bun run checks` intermittently.

## Root cause (reproduced)
The test wrote the file once, then polled expecting the dev-watcher to re-register the route. Correlating logs across runs:

| result | `Public file added` reload log |
|--------|-------------------------------|
| pass | fired |
| fail | **never fired** |

Under parallel load, chokidar/fsevents **drops (or never delivers) the single `add` event**, so the route is never registered and the request 404s until the deadline. Bumping the timeout does not help — a missed event can't be recovered by waiting (confirmed: failing runs exhausted a 20s deadline).

## Fix
Replace single-write-then-poll with `pollWithRetouch`, which re-touches the file once per outer cycle:
- The watcher handler reacts to **any** fs event under the public dir (`devWatcher.ts` `on('all', …)`), so a re-touch emits a fresh `change` that triggers the reload — giving the watcher repeated chances to observe it.
- The re-touch cadence stays **wider than the watcher's ~100ms reload debounce** (a burst of quick polls between touches), so successive writes don't keep resetting the debounce and starving the reload.

Regression coverage is preserved: it still verifies a spaced public file added at runtime is served via its percent-encoded URL.

## Verification
- Before: ~40% failure under load (repeatedly reproduced).
- After: **6/6 green** under full-suite parallel load; `bun run checks` fully green (mochi 90/90, site 6/6, demos 31/31, minimal 1/1; lint/format/typecheck clean).