### PR TITLE
feat: add temporary /_heapsnapshot download endpoint for leak debugging

### DIFF
--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -103,6 +103,17 @@ export const routes: Record<string, MochiRouteValue> = {
         }),
       }
     : {}),
+  // TEMP: on-demand V8 heap snapshot for memory-leak debugging. Remove when done.
+  '/_heapsnapshot': Mochi.api(() => {
+    const snapshot = Bun.generateHeapSnapshot('v8');
+    const filename = `mochi-${Date.now()}.heapsnapshot`;
+    return new Response(snapshot, {
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  }),
   '/discord': Mochi.api(() => Response.redirect('https://discord.com/invite/QCGfks4gg8', 302)),
   '/': Mochi.page('./src/Site.svelte', {
     serverProps: async () => {


### PR DESCRIPTION
## What

Adds a temporary `/_heapsnapshot` route to `packages/site` that generates a V8 heap snapshot on demand and returns it as a downloadable `.heapsnapshot` file for Chrome DevTools.

## Why

While chasing a memory leak on this branch, it's useful to grab a heap snapshot from the running server and diff two snapshots over time in DevTools' **Memory** tab — the **Delta** column reveals what's accumulating. The repo already has a `MOCHI_MEMORY_PROBE`-gated `/__mochi/health/memory` probe (just `process.memoryUsage()`), but nothing that emits a real `.heapsnapshot`.

## How to use

Hit `http://localhost:<port>/_heapsnapshot/` (trailing slash — the site enforces it). The browser downloads a timestamped `mochi-<ts>.heapsnapshot`. Load it into Chrome DevTools → **Memory** → **Load**, grab a second one later, then **Summary → Comparison** and watch the **Delta** column.

## Notes

- Uses `Bun.generateHeapSnapshot('v8')` (returns the V8-format string directly) — no temp file to write, stream back, and clean up.
- **Deliberately ungated and temporary** — meant to be removed once the leak is found. If worth keeping, it should be promoted to a framework endpoint beside `/__mochi/health/memory` under the `MOCHI_MEMORY_PROBE` gate.

## Verification

Verified end-to-end against `bun run dev:site`: `200`, correct `Content-Disposition`, ~19 MB body starting with `{"snapshot":{"meta":...` (valid V8 format). `bun run format` passes.