### PR TITLE
chore: run packages/site on Bun canary (1.4.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,11 @@ jobs:
             image: ghcr.io/khromov/mochi
             caprover_app: mochi
             caprover_token_secret: APP_TOKEN
-            # Temporary: try the site on the Bun canary tag while demos
-            # stays on the stable default pinned in the Dockerfile.
-            bun_image: oven/bun:canary-alpine
+            # Temporary: try the site on the Bun canary line (Bun 1.4.0)
+            # while demos stays on the stable default pinned in the Dockerfile.
+            # Pinned by digest so the moving canary tag can't drift the deploy
+            # underneath us; bump the digest to intentionally move forward.
+            bun_image: oven/bun:canary-alpine@sha256:bba48f6599532b99017f1d7aabf80a80bbce9dd33e6faf6ac7f76b8f2d75fac8
           # Standalone demos site, also deployed in dev mode. Requires repo
           # secret APP_TOKEN_DEMOS — the per-app deploy token from the
           # mochi-demos CapRover app's "Deployment" tab.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
             image: ghcr.io/khromov/mochi
             caprover_app: mochi
             caprover_token_secret: APP_TOKEN
+            # Temporary: try the site on the Bun canary tag while demos
+            # stays on the stable default pinned in the Dockerfile.
+            bun_image: oven/bun:canary-alpine
           # Standalone demos site, also deployed in dev mode. Requires repo
           # secret APP_TOKEN_DEMOS — the per-app deploy token from the
           # mochi-demos CapRover app's "Deployment" tab.
@@ -40,6 +43,7 @@ jobs:
             image: ghcr.io/khromov/mochi-demos
             caprover_app: mochi-demos
             caprover_token_secret: APP_TOKEN_DEMOS
+            bun_image: oven/bun:1.3.14-alpine
 
     steps:
       - name: Checkout Repository
@@ -74,6 +78,7 @@ jobs:
             PUBLIC_DISABLE_OPFS=false
             WORKSPACE=${{ matrix.workspace }}
             PORT=${{ matrix.port }}
+            BUN_IMAGE=${{ matrix.bun_image }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,16 @@
 # Prebuilt production variants live at Dockerfile.production and
 # packages/demos/Dockerfile.production if we ever need to flip back.
 #
-# Base image is oven/bun:1.3.14-alpine (pure musl alpine, multi-arch).
-# Earlier revisions used frolvlad/alpine-glibc with a copied bun binary;
-# that combo broke @tailwindcss/oxide's native binding on linux/arm64
+# Base image defaults to oven/bun:1.3.14-alpine (pure musl alpine, multi-arch),
+# overridable via the BUN_IMAGE build arg so a single workspace can ride a
+# different Bun tag without moving the others — the site is temporarily pinned
+# to oven/bun:canary-alpine in .github/workflows/build.yml while demos stays on
+# the stable default. Earlier revisions used frolvlad/alpine-glibc with a copied
+# bun binary; that combo broke @tailwindcss/oxide's native binding on linux/arm64
 # because the glibc compat shim was loaded in place of musl libc.
 
-FROM oven/bun:1.3.14-alpine AS base
+ARG BUN_IMAGE=oven/bun:1.3.14-alpine
+FROM ${BUN_IMAGE} AS base
 WORKDIR /usr/src/app
 
 # install dependencies into a temp directory. We copy the whole packages/


### PR DESCRIPTION
## What

Trial the **site** (`packages/site`) on the Bun **canary** tag (currently Bun **1.4.0**) while leaving demos on the stable pin.

Both site and demos build from the shared root `Dockerfile`, differentiated only by the `WORKSPACE` build arg, so I couldn't just bump the `FROM` line without moving demos too. Instead:

- **`Dockerfile`** — the base image is now a `BUN_IMAGE` build arg, defaulting to the current stable pin `oven/bun:1.3.14-alpine`. Local builds, `Dockerfile.production`, and anything that doesn't pass the arg are unchanged.
- **`.github/workflows/build.yml`** — each matrix entry now sets `bun_image`, passed through as `BUN_IMAGE`:
  - `site` → `oven/bun:canary-alpine` (Bun 1.4.0)
  - `demos` → `oven/bun:1.3.14-alpine` (unchanged)

This is intentionally easy to revert once we're done trialing — drop the site override (and optionally the arg).

## Verification

Built and ran the site image locally with colima using the exact CI build args:

```
docker build --build-arg BUN_IMAGE=oven/bun:canary-alpine --build-arg WORKSPACE=site ...
```

- `bun --version` inside the image → **1.4.0**
- Container boots; `/health/` → 200, `/` → 200

## Note for later

While this override is in place, the `update-bun` skill's stable bump should also touch the `demos` `bun_image` entry in `build.yml` (new pinned location). Not wired into the skill here since it's temporary.