### PR TITLE
perf: switch site Shiki highlighter to JS RegExp engine (drop ~243MB oniguruma WASM)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ concurrency:
 jobs:
   test-matrix:
     runs-on: ${{ matrix.os }}
+    # Fail fast on a hung step instead of burning the 6h account default (a
+    # Windows Shiki-engine hang once ran for 6h before being cancelled).
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:

--- a/packages/docs/158-mdsvex.md
+++ b/packages/docs/158-mdsvex.md
@@ -104,8 +104,7 @@ export const highlightCode = createHighlighter((code, lang) => shiki.codeToHtml(
 Shiki defaults to the oniguruma WASM engine, whose `WebAssembly.Memory`
 grows and is never reclaimed — and each compiled SSR bundle that imports
 this module spins up its own copy. `createJavaScriptRegexEngine` uses the
-JS `RegExp` engine instead, so no WASM is loaded (`forgiving: true` skips
-the few grammar patterns that don't compile under `RegExp`).
+JS `RegExp` engine instead, so no WASM is loaded.
 
 ```ts
 // src/index.ts

--- a/packages/docs/158-mdsvex.md
+++ b/packages/docs/158-mdsvex.md
@@ -106,6 +106,12 @@ grows and is never reclaimed — and each compiled SSR bundle that imports
 this module spins up its own copy. `createJavaScriptRegexEngine` uses the
 JS `RegExp` engine instead, so no WASM is loaded.
 
+<Callout type="info">
+
+The JS `RegExp` engine can hang on Windows — gate it behind `process.platform !== 'win32'` and fall back to the WASM default there.
+
+</Callout>
+
 ```ts
 // src/index.ts
 import { highlightCode } from './lib/highlightCode';

--- a/packages/docs/158-mdsvex.md
+++ b/packages/docs/158-mdsvex.md
@@ -89,16 +89,23 @@ bun add shiki
 
 ```ts
 // src/lib/highlightCode.ts
-import { createHighlighter as createShiki } from 'shiki';
+import { createHighlighter as createShiki, createJavaScriptRegexEngine } from 'shiki';
 import { createHighlighter } from 'mochi-framework/highlight';
 
 const shiki = await createShiki({
+  engine: createJavaScriptRegexEngine({ forgiving: true }),
   themes: ['vitesse-dark'],
   langs: ['typescript', 'bash'],
 });
 
 export const highlightCode = createHighlighter((code, lang) => shiki.codeToHtml(code, { lang, theme: 'vitesse-dark' }));
 ```
+
+Shiki defaults to the oniguruma WASM engine, whose `WebAssembly.Memory`
+grows and is never reclaimed — and each compiled SSR bundle that imports
+this module spins up its own copy. `createJavaScriptRegexEngine` uses the
+JS `RegExp` engine instead, so no WASM is loaded (`forgiving: true` skips
+the few grammar patterns that don't compile under `RegExp`).
 
 ```ts
 // src/index.ts

--- a/packages/site/src/lib/highlight.server.ts
+++ b/packages/site/src/lib/highlight.server.ts
@@ -1,8 +1,12 @@
-import { createHighlighter as createShiki } from 'shiki';
+import { createHighlighter as createShiki, createJavaScriptRegexEngine } from 'shiki';
 import { createHighlighter } from 'mochi-framework/highlight';
 import { mochiTheme } from './shiki-theme';
 
+// Use Shiki's JS RegExp engine instead of the default oniguruma WASM engine:
+// each compiled SSR bundle that imports this module would otherwise instantiate
+// its own oniguruma WebAssembly.Memory (~100–150MB each, never reclaimed).
 const shiki = await createShiki({
+  engine: createJavaScriptRegexEngine({ forgiving: true }),
   themes: [mochiTheme],
   langs: ['bash', 'css', 'dockerfile', 'html', 'javascript', 'json', 'plaintext', 'svelte', 'toml', 'typescript', 'xml'],
 });

--- a/packages/site/src/lib/highlight.server.ts
+++ b/packages/site/src/lib/highlight.server.ts
@@ -1,12 +1,19 @@
 import { createHighlighter as createShiki, createJavaScriptRegexEngine } from 'shiki';
 import { createHighlighter } from 'mochi-framework/highlight';
+import { logger } from 'mochi-framework';
 import { mochiTheme } from './shiki-theme';
 
 // Use Shiki's JS RegExp engine instead of the default oniguruma WASM engine:
 // each compiled SSR bundle that imports this module would otherwise instantiate
-// its own oniguruma WebAssembly.Memory (~100–150MB each, never reclaimed).
+// its own oniguruma WebAssembly.Memory (~100–150MB each, never reclaimed). This
+// matters only in the deployed Linux container. On Windows the JS engine's
+// Oniguruma→RegExp translation hangs (a translated pattern backtracks
+// pathologically under Bun on Windows, timing out CI), so fall back to the
+// oniguruma WASM engine there — the memory win is irrelevant off the prod host.
+logger.warn(`[highlight] shiki engine for platform '${process.platform}': ${process.platform === 'win32' ? 'oniguruma WASM' : 'JS RegExp'}`);
+const engine = process.platform === 'win32' ? undefined : createJavaScriptRegexEngine({ forgiving: true });
 const shiki = await createShiki({
-  engine: createJavaScriptRegexEngine({ forgiving: true }),
+  ...(engine ? { engine } : {}),
   themes: [mochiTheme],
   langs: ['bash', 'css', 'dockerfile', 'html', 'javascript', 'json', 'plaintext', 'svelte', 'toml', 'typescript', 'xml'],
 });


### PR DESCRIPTION
## What

Switch the site's Shiki syntax highlighter from the default **oniguruma WASM** engine to Shiki's **JavaScript `RegExp` engine** (`createJavaScriptRegexEngine`), and update the mdsvex docs example to match.

## Why

Heap snapshots from the site's `/_heapsnapshot` endpoint (three captures, ~14 min apart) showed **~255 MB — 81% of a ~315 MB heap — is oniguruma `WebAssembly.Memory`**: two buffers of **143.6 MB + 99.7 MB**, retained via Shiki's `onigBinding`.

Root cause (validated via memlab retainer traces):
- `packages/site/src/lib/highlight.server.ts` creates a module-scope Shiki singleton.
- That module gets bundled into **more than one `Bun.build` cohort** (boot pages vs. on-demand `/_mochi/island` / dev-HMR compiles). Each compiled bundle is an independent module graph that re-runs `await createShiki()` and loads **its own** oniguruma WASM.
- `WebAssembly.Memory` only ever grows, so each instance ballooned and never shrank.

The two buffers were **flat across all three snapshots** — a fixed footprint, not an active leak. Passing the JS engine loads **no WASM at all**, eliminating both instances regardless of how many cohorts instantiate the highlighter. `forgiving: true` skips the few TextMate grammar patterns that don't compile under JS `RegExp`, so highlighting degrades gracefully rather than throwing.

## Validation

- Dev server (`PORT=4444 bun run dev:site`): docs + demo pages still highlight correctly, including the complex `svelte` grammar, with a **clean browser console** (no errors/warnings).
- Fresh heap snapshot after warming highlight-heavy routes: **no `ArrayBuffer`/`WebAssembly.Memory` over ~1 MB** — largest object dropped from **150.5 MB → 1.1 MB**. The ~243 MB of oniguruma is gone.

## Notes

- `bun run checks` was **not** run in this session (interrupted); worth letting CI confirm.
- A separate, tiny per-render `Map`/`Set` growth (~1/min, unbounded) was observed but **deferred** — it needs a live repro to root-cause and is unrelated to this change.