### PR TITLE
fix: avoid HTMLRewriter onEndTag request-context leak

### DIFF
--- a/packages/mochi/src/ComponentRegistry.ts
+++ b/packages/mochi/src/ComponentRegistry.ts
@@ -1464,39 +1464,46 @@ export class ComponentRegistry {
     const renderedIslandNames = new Set<string>();
     let hasServerIslands = false;
     if (hasIslandsOrServerIslands || shouldStrip) {
-      let islandDepth = 0;
-      const trackIsland = {
-        element(el: HTMLRewriterTypes.Element) {
-          islandDepth++;
-          el.onEndTag(() => {
-            islandDepth--;
-          });
-        },
-      };
+      // NOTE(bun<1.4.0): don't use `el.onEndTag()` to track island nesting
+      // depth — registering it inside a request's AsyncLocalStorage context
+      // leaks the context frame (and the whole request) for the life of the
+      // process on Bun 1.3.x. We instead flag island-internal comments via
+      // element-scoped `comments` handlers, which lol-html invokes immediately
+      // before the document handler for the same comment. Revert to an onEndTag
+      // depth counter once the minimum supported Bun is >= 1.4.0.
+      let insideIsland = false;
       const rewriter = new HTMLRewriter();
       if (hasIslandsOrServerIslands) {
         rewriter
           .on('mochi-hydratable-island', {
             element(el) {
-              trackIsland.element(el);
               const raw = el.getAttribute('component-name');
               if (raw) {
                 renderedIslandNames.add(raw);
               }
               injectIslandPropsBlock(el, propsById, emittedProps);
             },
+            comments() {
+              insideIsland = true;
+            },
           })
           .on('mochi-server-island', {
-            element(el) {
+            element() {
               hasServerIslands = true;
-              trackIsland.element(el);
+            },
+            comments() {
+              insideIsland = true;
             },
           });
       }
       if (shouldStrip) {
         rewriter.onDocument({
           comments(comment) {
-            if (islandDepth === 0 && isSvelteMarker(comment.text)) {
+            if (insideIsland) {
+              insideIsland = false;
+              return;
+            }
+            if (isSvelteMarker(comment.text)) {
               comment.remove();
             }
           },

--- a/packages/mochi/src/utils.test.ts
+++ b/packages/mochi/src/utils.test.ts
@@ -76,6 +76,48 @@ describe('stripHydrationMarkers', () => {
     const html = '<mochi-server-island id-x><!--[--><div>placeholder</div><!--]--></mochi-server-island>';
     expect(stripHydrationMarkers(html)).toBe(html);
   });
+
+  // The tests below pin the lol-html dispatch invariants the flag-based
+  // implementation depends on (see the NOTE(bun<1.4.0) in utils.ts): the
+  // element-scoped comments handler must fire before the document handler for
+  // the same comment, and must cover descendant comments. If a Bun upgrade
+  // ever breaks either, these fail loudly instead of hydration breaking
+  // silently in production.
+  test('does not touch <mochi-hydratable-island> contents', () => {
+    const html = '<mochi-hydratable-island id-x><!--[--><div>counter</div><!--]--></mochi-hydratable-island>';
+    expect(stripHydrationMarkers(html)).toBe(html);
+  });
+
+  test('keeps markers in deep descendants of an island', () => {
+    const html = '<mochi-hydratable-island id-x><div><span><!--[--><em>deep</em><!--]--></span></div></mochi-hydratable-island>';
+    expect(stripHydrationMarkers(html)).toBe(html);
+  });
+
+  test('keeps markers inside nested islands', () => {
+    const html = '<mochi-hydratable-island id-outer><!--[--><mochi-server-island id-inner><!--[--><p>inner</p><!--]--></mochi-server-island><!--]--></mochi-hydratable-island>';
+    expect(stripHydrationMarkers(html)).toBe(html);
+  });
+
+  test('removes markers between two sibling islands', () => {
+    const island = (id: string) => `<mochi-hydratable-island ${id}><!--[--><p>x</p><!--]--></mochi-hydratable-island>`;
+    const html = `${island('a')}<!--[--><p>between</p><!--]-->${island('b')}`;
+    const expected = `${island('a')}<p>between</p>${island('b')}`;
+    expect(stripHydrationMarkers(html)).toBe(expected);
+  });
+
+  test('removes a marker immediately after an island close tag', () => {
+    const html = '<mochi-server-island id-x><!--[--><p>in</p><!--]--></mochi-server-island><!--]-->';
+    const expected = '<mochi-server-island id-x><!--[--><p>in</p><!--]--></mochi-server-island>';
+    expect(stripHydrationMarkers(html)).toBe(expected);
+  });
+
+  test('leaves non-marker comments alone everywhere', () => {
+    // <!--note--> is word-only, so it counts as a Svelte hash marker and
+    // survives only because it sits inside an island; the outside comments
+    // survive because whitespace disqualifies them as markers.
+    const html = '<!-- plain --><mochi-hydratable-island id-x><!--note--><p>x</p></mochi-hydratable-island><!-- plain2 -->';
+    expect(stripHydrationMarkers(html)).toBe(html);
+  });
 });
 
 describe('normalizeIslandHydrationMarkers', () => {

--- a/packages/mochi/src/utils.ts
+++ b/packages/mochi/src/utils.ts
@@ -219,25 +219,34 @@ export function normalizeIslandHydrationMarkers(html: string): string {
  *
  * Uses Bun's HTMLRewriter (based on Cloudflare's lol-html) to properly parse
  * HTML and track element nesting instead of fragile regex/manual scanning.
+ *
+ * NOTE(bun<1.4.0): the obvious implementation tracks island nesting depth with
+ * `el.onEndTag(() => islandDepth--)`, but registering an `onEndTag` callback
+ * while inside a request's `AsyncLocalStorage` context leaks that context
+ * frame — and thus the whole request (BunRequest, cookies, …) — for the life
+ * of the process on Bun 1.3.x. Instead we flag island-internal comments via an
+ * element-scoped `comments` handler, which lol-html invokes immediately before
+ * the document handler for the same comment. Once the minimum supported Bun is
+ * >= 1.4.0, revert this to the simpler onEndTag depth counter.
  */
 export function stripHydrationMarkers(html: string): string {
-  let islandDepth = 0;
-
-  const trackIsland = {
-    element(el: HTMLRewriterTypes.Element) {
-      islandDepth++;
-      el.onEndTag(() => {
-        islandDepth--;
-      });
+  let insideIsland = false;
+  const markInside = {
+    comments() {
+      insideIsland = true;
     },
   };
 
   return new HTMLRewriter()
-    .on('mochi-hydratable-island', trackIsland)
-    .on('mochi-server-island', trackIsland)
+    .on('mochi-hydratable-island', markInside)
+    .on('mochi-server-island', markInside)
     .onDocument({
       comments(comment) {
-        if (islandDepth === 0 && isSvelteMarker(comment.text)) {
+        if (insideIsland) {
+          insideIsland = false;
+          return;
+        }
+        if (isSvelteMarker(comment.text)) {
           comment.remove();
         }
       },


### PR DESCRIPTION
## Summary

Rendering any page with a `mochi:hydrate*` or server island leaked the **entire request context** (`BunRequest`, `MochiCookieJar`, `URL`, captured strings) for the life of the process. Heap grew ~1 retained request per island-bearing request, unbounded — a 24h production heap snapshot showed 753 retained requests.

## Root cause

A Bun bug: `HTMLRewriter`'s `el.onEndTag(cb)`, when registered **inside a request's `AsyncLocalStorage` context**, captures the async-context frame and never releases it. Even an empty callback leaks. Reduced to a standalone repro:

```
ALS + HTMLRewriter, NO  onEndTag : 1/100 contexts retained (ok)
ALS + HTMLRewriter, WITH onEndTag: 100/100 contexts retained  <== LEAK
```

Confirmed **already fixed in Bun 1.4.0** (`with onEndTag` → 2/100). This PR is a belt-and-suspenders guard for anyone still on Bun 1.3.x.

## Change

The island-marker passes (`ComponentRegistry.ts` inline pass + `utils.ts` `stripHydrationMarkers`) only used `onEndTag` to maintain an island nesting depth so the hydration-marker stripper skips markers *inside* islands. Replaced with an element-scoped `comments` handler that flags island-internal comments — lol-html invokes it immediately before the document handler for the same comment — same behavior, no `onEndTag`.

Both sites carry a `NOTE(bun<1.4.0)` to revert to the simpler depth counter once the minimum supported Bun is >= 1.4.0.

## Verification

- Island-page repro: **+300 → +0** retained requests per 300 requests on Bun 1.3.14.
- Strip correctness verified on deep-nested / nested-island / multiple-island / non-marker cases (matches old behavior).
- Marker-strip unit tests + full `bun run checks` (lint, format, typecheck, test) pass across all workspaces.
- `/demos/island-depth/`, `/demos/nested-islands/`, `/demos/server-island/` hydrate with zero console errors.

## Out of scope

`email/mailer.ts` (2×) still uses `onEndTag` and would leak the request context if an email is rendered during a request — left for a follow-up.