### PR TITLE
ci: smoke-test image boot + island assets before push and deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,14 @@ jobs:
             caprover_app: mochi-support
             caprover_token_secret: APP_TOKEN_SUPPORT
             bun_image: oven/bun:1.3.14-alpine
+            # Dockerfile.production refuses to boot without SMTP_HOST +
+            # MOCHI_ORIGIN; the transport only connects on send, so dummy
+            # values are enough for a boot smoke test.
+            smoke_env: >-
+              -e SMTP_HOST=smtp.invalid
+              -e SMTP_USER=smoke
+              -e SMTP_PASSWORD=smoke
+              -e MOCHI_ORIGIN=https://support.mochi.fast
 
     steps:
       - name: Checkout Repository
@@ -84,13 +92,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and Push Docker Image
+      # Build locally (no push) so the image can be smoke-tested before it
+      # ever reaches the registry — a broken :main tag must not exist, even
+      # un-deployed, since Swarm re-pulls it on task restarts.
+      - name: Build Docker Image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: ${{ matrix.dockerfile }}
           platforms: linux/amd64
-          push: true
+          push: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
@@ -100,6 +112,54 @@ jobs:
             BUN_IMAGE=${{ matrix.bun_image }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      # Boot the freshly built container and verify it actually serves before
+      # pushing/deploying: /health/ answers, and the island JS referenced by
+      # the served HTML resolves on the same server (guards the class of
+      # incident where stale/mismatched bundle hashes 404 in production).
+      - name: Smoke test image
+        run: |
+          set -uo pipefail
+          IMAGE="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)"
+          BASE="http://127.0.0.1:${{ matrix.port }}"
+          docker run -d --name smoke ${{ matrix.smoke_env }} \
+            -p "127.0.0.1:${{ matrix.port }}:${{ matrix.port }}" "$IMAGE"
+
+          ready=""
+          for _ in $(seq 1 50); do
+            if curl -fsSL --max-time 5 -o /dev/null "$BASE/health/"; then
+              ready=1
+              break
+            fi
+            if [ "$(docker inspect -f '{{.State.Running}}' smoke)" != "true" ]; then
+              echo "::error::container exited during boot"
+              docker logs smoke
+              exit 1
+            fi
+            sleep 3
+          done
+          if [ -z "$ready" ]; then
+            echo "::error::/health/ not ready after 150s"
+            docker logs smoke
+            exit 1
+          fi
+
+          ASSET="$(curl -fsSL --max-time 10 "$BASE/" | grep -o '/_mochi/client/[A-Za-z0-9_.-]*\.js' | head -n1 || true)"
+          if [ -n "$ASSET" ]; then
+            echo "checking island asset $ASSET"
+            if ! curl -fsS --max-time 10 -o /dev/null "$BASE$ASSET"; then
+              echo "::error::HTML references $ASSET but the server 404s it"
+              docker logs smoke
+              exit 1
+            fi
+          else
+            echo "no /_mochi/client asset referenced on / — skipping asset check"
+          fi
+          docker rm -f smoke
+
+      - name: Push Docker Image
+        run: |
+          printf '%s\n' "${{ steps.meta.outputs.tags }}" | xargs -n1 docker push
 
       - name: Deploy on CapRover
         uses: caprover/deploy-from-github@v1.1.2


### PR DESCRIPTION
## Why

During the 2026-07-17 incident, a deploy shipped an image that crashed on boot (`task: non-zero exit (1)`), which wedged the Swarm update and left a stale old-build container serving alongside the new one. Since island JS is served from a per-process in-memory map keyed by content hash, the two builds 404'd each other's `/_mochi/client/*` assets (and failed cross-container `/_mochi/island/*` prop decryption), causing the random 404s / corrupted-content errors on mochi.fast.

A boot-broken image should die in CI, not in Swarm.

## What

Splits the single build-and-push step into **build → smoke test → push → deploy** for every matrix leg (site, demos, support):

- **Build** with `push: false, load: true` — a broken build never reaches the registry, so a bad `:main` tag can't exist even un-deployed (Swarm re-pulls `:main` on task restarts).
- **Smoke test** — boots the container, polls `/health/` (up to 150s, failing fast with `docker logs` if the container exits), then fetches `/`, extracts the first `/_mochi/client/*.js` referenced by the HTML, and asserts the same server serves it with a 200 — a direct regression guard for the incident's failure class.
- **Push** the tags, then the unchanged CapRover deploy step.

The support leg passes dummy `SMTP_HOST`/`MOCHI_ORIGIN` to the smoke container since `Dockerfile.production` refuses to boot without them (the transport only connects on send).

## Validation

- Workflow YAML parses; `bun run format` clean.
- The smoke-test script logic was exercised verbatim against a live dev site on port 4444: `/health/` ready, island asset extracted from `/` HTML (`/_mochi/client/_hydrate-MobileNav_….js`), asset fetch 200.
- The docker steps themselves can't run in the devcontainer (no docker); first exercise will be the merge-to-main run — worth watching that one.

## Not in this PR (follow-ups from the incident)

- Set a stable `MOCHI_KEY` on the CapRover apps (each process currently generates a random key; cross-container island-prop decryption fails during deploy overlap).
- Deploy by image digest instead of mutable `:main`.
- Optional framework hardening: disk fallback for stale `/_mochi/client/*` hashes.