### PR TITLE
fix(demos): generate Tailwind CSS at startup when missing

### DIFF
--- a/packages/demos/src/todo/routes.ts
+++ b/packages/demos/src/todo/routes.ts
@@ -1,16 +1,20 @@
+import { existsSync } from 'node:fs';
 import { Mochi } from 'mochi-framework';
 import type { MochiRouteValue } from 'mochi-framework';
 
-// Build-time CSS generation lives in scripts/prebuild.ts so `compileAll`
-// can resolve ./app.generated.css deterministically. Here we only attach
-// the dev-mode watcher — dynamically imported so production never loads
-// @tailwindcss/oxide's native binding.
-if (process.env.MODE === 'development') {
+// TodoPage.svelte statically imports ./app.generated.css, so it must exist on
+// disk before compileAll bundles the page. In prod it's normally baked by
+// scripts/prebuild.ts (fast path: skip here, never loading @tailwindcss/oxide).
+// In dev we always run setupTailwind to also attach the rebuild watcher. If the
+// file is missing for any reason (e.g. a release image that didn't carry the
+// prebuilt CSS), generate it once at startup rather than 500-ing the whole site.
+const isDev = process.env.MODE === 'development';
+if (isDev || !existsSync('./src/todo/app.generated.css')) {
   const { setupTailwind } = await import('mochi-framework/tailwind');
   await setupTailwind({
     input: './src/todo/app.css',
     output: './src/todo/app.generated.css',
-    minify: false,
+    minify: !isDev,
   });
 }
 


### PR DESCRIPTION
## Problem

The `mochi-demos` deploy was 500-ing at boot with:

```
error: Svelte SSR build failed:
  src/todo/TodoPage.svelte:4:8 — Could not resolve: "./app.generated.css"
    at compileAll (packages/mochi/src/compiler/ComponentRegistry.ts:662)
    at async serve (packages/mochi/src/Mochi.ts:496)
```

## Root cause

`packages/demos/src/todo/TodoPage.svelte` statically imports `./app.generated.css` — a **gitignored, generated** file. It was only ever produced by:

1. **Build time:** `scripts/prebuild.ts` (inside `bun run build`), or
2. **Dev startup:** `setupTailwind()` in `routes.ts`, gated behind `MODE === 'development'`.

In any prod-mode boot where the prebuilt CSS isn't present on disk, neither path runs, so Mochi's on-demand `compileAll` can't resolve the static import and the whole site fails to boot. `packages/demos/Dockerfile.production` even anticipates startup generation (it `chown`s `src` and installs `libgcc` for oxide with the comment *"tailwind.ts writes app.generated.css into src/ at startup"*), but `routes.ts` gated that write behind dev mode — that mismatch is the bug.

Reproduced locally byte-for-byte by running the demos server with `MODE` unset.

## Fix

`routes.ts` now generates the CSS at startup whenever it's missing, regardless of `MODE`, while:
- **preserving the prod fast path** — when the prebuilt CSS exists, it skips generation entirely (never loading `@tailwindcss/oxide`), and
- **keeping the dev rebuild watcher** in development.

## Verification (no Docker in env — process-level repro)

| Case | Mode | CSS before | Result |
|---|---|---|---|
| prod, missing | `MODE` unset | absent | self-heals → minified CSS, `/todo/` **200** (was the 500) |
| prod, present | `MODE` unset | present | skipped (mtime unchanged), **200** — fast path intact |
| dev, missing | `MODE=development` | absent | generated (unminified) + watcher, **200** |

`bun run checks` (lint + typecheck + test) passes; no files auto-modified.