### PR TITLE
ci: make image smoke test fail red on a broken boot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,44 +117,66 @@ jobs:
       # pushing/deploying: /health/ answers, and the island JS referenced by
       # the served HTML resolves on the same server (guards the class of
       # incident where stale/mismatched bundle hashes 404 in production).
+      #
+      # Every failure path must turn the job RED. The earlier version piped
+      # `curl "$BASE/"` straight into grep with `|| true`, so a reset/5xx on /
+      # collapsed to an empty match and was silently treated as "page has no
+      # island asset — skip", passing green. Here `GET /` is checked on its own
+      # and fails hard, and transient resets are absorbed by curl's own --retry
+      # rather than swallowed.
       - name: Smoke test image
         run: |
           set -uo pipefail
           IMAGE="$(printf '%s\n' "${{ steps.meta.outputs.tags }}" | head -n1)"
           BASE="http://127.0.0.1:${{ matrix.port }}"
+
+          fail() {
+            echo "::error::$1"
+            echo "----- docker logs smoke -----"
+            docker logs smoke 2>&1 || true
+            docker rm -f smoke >/dev/null 2>&1 || true
+            exit 1
+          }
+          # Absorb one-off resets/refused within a single call; a persistently
+          # broken server exhausts the retries and correctly fails.
+          curl_retry() { curl -fsS --retry 5 --retry-delay 1 --retry-all-errors --retry-connrefused "$@"; }
+
           docker run -d --name smoke ${{ matrix.smoke_env }} \
             -p "127.0.0.1:${{ matrix.port }}:${{ matrix.port }}" "$IMAGE"
 
+          # 1) Readiness. The loop is the retry mechanism, so plain curl (no -S):
+          # transient boot errors are expected and shouldn't spam the log — real
+          # trouble is surfaced by docker logs on the not-ready fail() below.
           ready=""
           for _ in $(seq 1 50); do
-            if curl -fsSL --max-time 5 -o /dev/null "$BASE/health/"; then
+            if curl -fs --max-time 5 -o /dev/null "$BASE/health/"; then
               ready=1
               break
             fi
-            if [ "$(docker inspect -f '{{.State.Running}}' smoke)" != "true" ]; then
-              echo "::error::container exited during boot"
-              docker logs smoke
-              exit 1
-            fi
+            [ "$(docker inspect -f '{{.State.Running}}' smoke)" = "true" ] || fail "container exited during boot"
             sleep 3
           done
-          if [ -z "$ready" ]; then
-            echo "::error::/health/ not ready after 150s"
-            docker logs smoke
-            exit 1
-          fi
+          [ -n "$ready" ] || fail "/health/ not ready after 150s"
 
-          ASSET="$(curl -fsSL --max-time 10 "$BASE/" | grep -o '/_mochi/client/[A-Za-z0-9_.-]*\.js' | head -n1 || true)"
-          if [ -n "$ASSET" ]; then
-            echo "checking island asset $ASSET"
-            if ! curl -fsS --max-time 10 -o /dev/null "$BASE$ASSET"; then
-              echo "::error::HTML references $ASSET but the server 404s it"
-              docker logs smoke
-              exit 1
+          # 2) GET / must succeed, and the island bundle it references must
+          # resolve on the same server. Re-fetch / on each attempt so a dev-mode
+          # recompile that re-hashes the bundle URL can't fail us on a stale hash.
+          verified=""
+          for attempt in $(seq 1 8); do
+            html="$(curl_retry --max-time 15 "$BASE/")" || fail "GET / failed"
+            asset="$(printf '%s' "$html" | grep -o '/_mochi/client/[A-Za-z0-9_.-]*\.js' | head -n1 || true)"
+            [ -n "$asset" ] || fail "GET / returned 200 but referenced no /_mochi/client bundle (broken render/shell)"
+            echo "attempt $attempt: verifying island asset $asset"
+            if curl_retry --max-time 15 -o /dev/null "$BASE$asset"; then
+              echo "island asset $asset resolves (200)"
+              verified=1
+              break
             fi
-          else
-            echo "no /_mochi/client asset referenced on / — skipping asset check"
-          fi
+            echo "attempt $attempt: $asset did not resolve — re-fetching / and retrying"
+            sleep 3
+          done
+          [ -n "$verified" ] || fail "HTML references an island bundle the server won't serve"
+
           docker rm -f smoke
 
       - name: Push Docker Image


### PR DESCRIPTION
## Why

The image smoke test (`.github/workflows/build.yml`, added in #164) could go **green even when the served image was broken**. The step ran with `set -uo pipefail` but **no `set -e`**, and extracted the island asset like:

```sh
ASSET="$(curl -fsSL "$BASE/" | grep -o '/_mochi/client/...\.js' | head -n1 || true)"
if [ -n "$ASSET" ]; then ...; else echo "no asset — skipping"; fi
docker rm -f smoke   # exit 0
```

When `GET /` itself failed (connection reset / 5xx / timeout), the trailing `|| true` collapsed the failure into an **empty `ASSET`**, which took the "skip" branch and the step exited **0 / green**. A genuinely broken homepage was indistinguishable from an island-free page. Only the `/health/` readiness poll was retried; the `/` and asset fetches were single-shot and their failures were silently absorbed.

## What

Rewrites only the `Smoke test image` step so **every failure path turns the job red**:

- `fail()` helper — prints `::error::`, dumps `docker logs smoke`, removes the container, `exit 1`.
- `GET /` is fetched on its own and checked with an explicit `|| fail "GET / failed"` — the core fix.
- Island bundle verified in a retry loop that **re-fetches `/` each attempt**, so a dev-mode recompile that re-hashes the bundle URL can't fail on a stale hash. A missing bundle after a `200 /` is also a hard fail (every deployed leg ships at least one island).
- `curl_retry` wrapper (`--retry 5 --retry-all-errors --retry-connrefused`) absorbs one-off transient resets so genuine blips don't cause false reds, while a persistently broken server exhausts retries and correctly goes red.
- Readiness poll drops `-S` (the loop is the retry mechanism) so expected boot-time errors don't spam the log — this was the confusing `curl: (56) Recv failure: Connection reset by peer` noise.

No framework/app source, matrix entries, or other steps change.

## Testing

No Docker locally, so validated:
- YAML parses.
- Stubbed-`docker`/`curl` run of six scenarios: **healthy → exit 0**; container-died, health-never-ready, **GET / 500 (the false-green case)**, no-asset, and asset-404 all → **exit 1**.

Authoritative check is this PR's CI run across the site/demos/support legs.