### PR TITLE
test: force-kill orphaned children in shutdown-signal suite

### DIFF
--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -40,7 +40,7 @@ In production (`development: false`), prebuilt JS/CSS bundles served from `asset
 
 **Shutdown signals.** `Mochi.serve()` installs `SIGTERM` and `SIGINT` listeners that fire the [`mochi:shutdown`](/docs/extensions/#mochishutdown) hook, drain queues, then stop the server and exit with code 0. In-flight requests get `shutdownTimeout` ms to finish; anything still connected after that is force-closed. A second signal exits immediately with code 1. Existing user listeners on those signals are not displaced — Node.js dispatches signals to every registered listener.
 
-The forced fallback is not optional: a plain `server.stop()` never resolves while a WebSocket is open, so in development a single browser tab holding the live-reload socket would otherwise wedge the process until it is `SIGKILL`ed.
+The forced fallback is not optional: a plain `server.stop()` never resolves while a WebSocket is open, so in development a single browser tab holding the live-reload socket would otherwise wedge the process until it is `SIGKILL`ed. The same applies in production to any live `Mochi.ws` connection — while one is open the graceful drain never completes, so shutdown always waits the full `shutdownTimeout` before force-closing. Keep the timeout tight enough for your orchestrator's grace period.
 
 </Callout>
 
@@ -50,7 +50,7 @@ The forced fallback is not optional: a plain `server.stop()` never resolves whil
 - `hostname`: Interface to bind. Defaults to Bun's default (`0.0.0.0`).
 - `development`: Enables live reload, debug bar, and the dev error overlay. Default: `true`.
 - `liveReload`: Enable the dev-mode live-reload WebSocket (`/__mochi_live_reload` + the `mochi-live-reload` web component). Default: matches `development`. Set to `false` to keep the debug bar but skip the WS — useful behind a proxy where the socket is flaky.
-- `shutdownTimeout`: Grace period in ms for in-flight requests to finish on `SIGTERM`/`SIGINT` before connections are force-closed and the process exits. Default: `5000` in production, `0` in development. `0` force-closes immediately.
+- `shutdownTimeout`: Grace period in ms for in-flight requests to finish on `SIGTERM`/`SIGINT` before connections are force-closed and the process exits. Default: `5000` in production, `0` in development. `0` force-closes immediately. Note that an open WebSocket never drains, so shutdown pins to this full value whenever one is connected — set it no larger than your orchestrator's kill grace period.
 - `routes`: `Record<string, MochiRouteValue>` of route paths to `Mochi.page` / `Mochi.api` / `Mochi.ws` / `Mochi.sse` registrations.
 - `fetch`: `(req, server) => Response` fallback handler invoked when no route matches. Default: built-in 404.
 - `manifest`: Path to a prebuilt manifest JSON. Default: `<outDir>/manifest.json`.

--- a/packages/mochi/src/shutdownSignal.test.ts
+++ b/packages/mochi/src/shutdownSignal.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, expect, test } from 'bun:test';
+import { afterAll, afterEach, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 
@@ -7,6 +7,18 @@ import path from 'node:path';
 // `utils/shutdownSignalServer.ts` as a child, connects a WebSocket, and signals it.
 const serverScript = path.join(import.meta.dir, 'utils', 'shutdownSignalServer.ts');
 const outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-shutdown-signal-'));
+
+// A test asserts the child exited on its own; when that assertion fails the
+// child is still running. Force-kill any survivor so it doesn't orphan a bun
+// process or keep writing into the shared outDir while the next test runs.
+const liveChildren = new Set<Bun.Subprocess>();
+
+afterEach(() => {
+  for (const proc of liveChildren) {
+    proc.kill('SIGKILL');
+  }
+  liveChildren.clear();
+});
 
 afterAll(() => {
   rmSync(outDir, { recursive: true, force: true });
@@ -19,6 +31,8 @@ async function startChild(shutdownTimeout: number, development = false): Promise
     stdout: 'pipe',
     stderr: 'pipe',
   });
+  liveChildren.add(proc);
+  void proc.exited.then(() => liveChildren.delete(proc));
   // The child prints `port=<n>` once it is listening. In dev mode it also emits
   // startup warnings first, so scan for the marker rather than taking line one.
   const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();


### PR DESCRIPTION
Follow-up cleanup on top of #176 (now merged).

## Changes

**Test hardening — `shutdownSignal.test.ts`**
Each case asserts the child process exited on its own; when that assertion fails the child is left running. Added a `liveChildren` set (children self-remove on `proc.exited`) and an `afterEach` that `SIGKILL`s any survivor — so a failing test no longer orphans a bun process or keeps writing into the shared `outDir` while the next test runs.

**Docs — `160-serve-options.md`**
Clarified that the "a non-forced `server.stop()` never resolves while a WebSocket is open" behavior isn't dev-only: any live `Mochi.ws` connection in production also blocks the graceful drain, so shutdown always waits the full `shutdownTimeout` before force-closing. Added the practical guidance to keep the timeout no larger than the orchestrator's kill grace period.

## Verification
`bun run checks` passes — lint clean, 0 typecheck errors, all tests green (mochi-framework 114/114, including `shutdownSignal.test.ts`), nothing reformatted.