### PR TITLE
fix(logger): make queue added/completed lines visible at the production log level

### DIFF
--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -192,7 +192,7 @@ See the [bunqueue docs](https://bunqueue.dev/guide/simple-mode/) for the full op
 
 ### Observability
 
-Queues emit [events](/docs/events/) on the `mochiEvents` bus — `queue:added`, `queue:active`, `queue:completed`, `queue:failed`, `queue:error` — and the built-in [console logger](/docs/logging/) prints a `QUEUE` line for `added`, `completed`, `failed`, and `error`. The per-attempt `active` line needs `logger: { level: 'debug' }`. Wire your own metrics directly:
+Queues emit [events](/docs/events/) on the `mochiEvents` bus — `queue:added`, `queue:active`, `queue:completed`, `queue:failed`, `queue:error` — and the built-in [console logger](/docs/logging/) prints a `QUEUE` line for `added`, `completed`, `failed`, and `error`. Those four print at `warn`, so they're visible under the production default level; demote them with the [`consoleLogger:level` filter](/docs/extensions/) if you don't want them there. The per-attempt `active` line needs `logger: { level: 'debug' }`. Wire your own metrics directly:
 
 ```ts
 import { mochiEvents } from 'mochi-framework';

--- a/packages/docs/146-logging.md
+++ b/packages/docs/146-logging.md
@@ -39,14 +39,14 @@ await Mochi.serve({
 
 `level` accepts `'silent' | 'error' | 'warn' | 'info' | 'log' | 'debug'`. A method runs when its severity is at or above the active level, so `'warn'` lets `error` and `warn` through while suppressing `info`, `log`, and `debug`.
 
-| Level      | What you see                                                                           | When to reach for it                            |
-| ---------- | -------------------------------------------------------------------------------------- | ----------------------------------------------- |
-| `'silent'` | Nothing — no boot line, no requests, no errors                                         | Tests; CLI scripts that don't want any noise    |
-| `'debug'`  | Everything `'log'` shows plus per-asset request lines (CSS, JS, images) and fallbacks  | Investigating asset fetches or unmatched routes |
-| `'log'`    | Adds chatty client-side hydration traces and other verbose detail                      | Debugging hydration / island lifecycle issues   |
-| `'info'`   | Boot line, page/api/file requests, file-change notifications, plus warnings and errors | Default in development                          |
-| `'warn'`   | Slow requests, 5xx responses, deprecations, recoverable problems, plus errors          | Default in production                           |
-| `'error'`  | Only handler failures — `logger.error` calls and unhandled exceptions                  | Production with a separate alerting pipeline    |
+| Level      | What you see                                                                                   | When to reach for it                            |
+| ---------- | ---------------------------------------------------------------------------------------------- | ----------------------------------------------- |
+| `'silent'` | Nothing — no boot line, no requests, no errors                                                 | Tests; CLI scripts that don't want any noise    |
+| `'debug'`  | Everything `'log'` shows plus per-asset request lines (CSS, JS, images) and fallbacks          | Investigating asset fetches or unmatched routes |
+| `'log'`    | Adds chatty client-side hydration traces and other verbose detail                              | Debugging hydration / island lifecycle issues   |
+| `'info'`   | Boot line, page/api/file requests, file-change notifications, plus warnings and errors         | Default in development                          |
+| `'warn'`   | Slow requests, 5xx responses, queue lifecycle, deprecations, recoverable problems, plus errors | Default in production                           |
+| `'error'`  | Only handler failures — `logger.error` calls and unhandled exceptions                          | Production with a separate alerting pipeline    |
 
 Which severity each event lands on is a framework default — request lines are `info`, asset and image lines are `debug`, and so on. Remap them per app with the [`consoleLogger:level` filter](/docs/extensions/): promote the events you care about, demote the ones you don't, without moving the global level.
 
@@ -77,7 +77,7 @@ The level applies on both sides: the server captures it once at startup, and the
 ### Method semantics
 
 - `logger.error` (red) — failures the operator should see.
-- `logger.warn` (yellow) — slow requests, 5xx responses, deprecations, recoverable problems.
+- `logger.warn` (yellow) — slow requests, 5xx responses, queue lifecycle (`added`/`completed`/`failed`), deprecations, recoverable problems.
 - `logger.info` (green) — boot, page/api request lines, file-change notifications.
 - `logger.log` (dim) — verbose / trace output, e.g. hydration lifecycle. Off unless `level: 'log'` or `'debug'`.
 - `logger.debug` (dim) — high-volume, low-signal lines like asset requests and fallback routes. Off unless `level: 'debug'`.

--- a/packages/mochi/src/dev/consoleLogger.ts
+++ b/packages/mochi/src/dev/consoleLogger.ts
@@ -246,16 +246,18 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     level: 'warn',
   }));
 
-  // `added` is the only signal that work entered the system — with a slow
-  // processor it's the sole line for as long as the job runs — so it prints at
-  // the default level. Per-attempt `active` repeats on every retry and adds
-  // nothing over added + completed/failed, so it stays on `logger.debug`.
-  // `completed` carries the duration (escalated to warn when slow);
-  // `failed`/`error` always warn.
+  // Queue lifecycle is operational signal, so `added` and `completed` are
+  // pinned at `warn` to survive the production default level ('warn') — an
+  // `info` default would hide `added` entirely and leave `completed` visible
+  // only when the job trips the slow-escalation. Per-attempt `active` repeats
+  // on every retry and adds nothing over added + completed/failed, so it stays
+  // on `logger.debug`. `failed`/`error` always warn. Apps that find the
+  // lifecycle chatty can demote it with the `consoleLogger:level` filter.
   subscribe('queue:added', ({ queue, jobName, jobId }) => ({
     label: 'QUEUE',
     path: `${queue}/${jobName}`,
     note: styleText('dim', `+ ${jobId}`),
+    level: 'warn',
   }));
   subscribe('queue:active', ({ queue, jobName }) => ({
     label: 'QUEUE',
@@ -270,6 +272,7 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     duration,
     slow,
     verySlow,
+    level: 'warn',
   }));
   subscribe('queue:failed', ({ queue, jobName, attempt, error }) => ({
     label: 'QUEUE',

--- a/packages/mochi/src/dev/consoleLoggerLevel.test.ts
+++ b/packages/mochi/src/dev/consoleLoggerLevel.test.ts
@@ -80,4 +80,34 @@ describe('consoleLogger:level changes where a line is written', () => {
     request('/promoted');
     expect(seen).toBe('warn');
   });
+
+  // Queue lifecycle must be visible at the production default level ('warn'),
+  // not just under the dev default — see the queue subscribers in consoleLogger.ts.
+  describe('queue lifecycle at the production level', () => {
+    beforeAll(() => {
+      setLogLevel('warn');
+    });
+
+    afterAll(() => {
+      setLogLevel('debug');
+    });
+
+    test('queue:added is written through console.warn', () => {
+      mochiEvents.emit('queue:added', { queue: 'emails', jobId: 'j1', jobName: 'send' });
+      const line = calls.find((c) => c.text.includes('emails/send'));
+      expect(line?.method).toBe('warn');
+    });
+
+    test('a fast queue:completed still prints, without relying on slow-escalation', () => {
+      mochiEvents.emit('queue:completed', { queue: 'emails', jobId: 'j1', jobName: 'send', attempt: 1, duration: 5 });
+      const line = calls.find((c) => c.text.includes('emails/send'));
+      expect(line?.method).toBe('warn');
+      expect(line?.text).toContain('done');
+    });
+
+    test('queue:active stays debug-gated and prints nothing', () => {
+      mochiEvents.emit('queue:active', { queue: 'emails', jobId: 'j1', jobName: 'send', attempt: 1 });
+      expect(calls).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Problem

Adding a job to a queue never showed in production logs, while finishing one did.

Root cause: production resolves the logger level to `'warn'` by default (`Mochi.ts`), and the `queue:added` console line had no explicit level, so it printed at `'info'` — filtered out in production. `queue:completed` was also `'info'`, but it passes a duration, and `emit()` escalates any line with `duration >= slowThreshold` (500ms) to `'warn'` — so "done" lines for jobs taking ≥500ms leaked through while "added" lines never did. Jobs finishing under 500ms showed nothing at all.

## Change

Queue lifecycle is operational signal, not debug noise:

- Pin `queue:added` and `queue:completed` at `level: 'warn'` in `consoleLogger.ts`, so both survive the production default level instead of `completed` riding the accidental slow-escalation. This matches `queue:failed`/`queue:error`, which were already `warn`.
- `queue:active` stays `debug` (per-retry noise).
- Apps that find the lifecycle chatty can demote it with the `consoleLogger:level` filter (noted in the code comment and docs).

## Tests

New describe block in `consoleLoggerLevel.test.ts` running at level `'warn'` (the production default):
- `queue:added` lands on `console.warn`
- a fast (5ms) `queue:completed` still prints — no longer depends on slow-escalation
- `queue:active` prints nothing

## Docs

- `115-queues.md`: observability section notes the four `QUEUE` lines print at `warn` and are visible under the production default.
- `146-logging.md`: queue lifecycle added to the `'warn'` level-table row and method-semantics bullet.

`bun run checks` passes (lint, format, typecheck, all tests).