### PR TITLE
fix(email): stop leaking a nodemailer TS7016 error into consumers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -23,7 +23,7 @@
     },
     "packages/cli": {
       "name": "create-mochi",
-      "version": "0.2.5",
+      "version": "0.3.0",
       "bin": {
         "create-mochi": "src/cli.js",
       },
@@ -81,7 +81,7 @@
     },
     "packages/mochi": {
       "name": "mochi-framework",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "bin": {
         "mochi-framework": "src/cli/cli.js",
       },
@@ -107,7 +107,6 @@
         "@tailwindcss/node": "^4.3.3",
         "@tailwindcss/oxide": "^4.3.3",
         "@types/bun": "1.3.14",
-        "@types/nodemailer": "^8.0.1",
         "@types/smtp-server": "3.5.13",
         "smtp-server": "3.19.2",
         "svelte": "^5.56.7",

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -115,7 +115,6 @@
     "@tailwindcss/node": "^4.3.3",
     "@tailwindcss/oxide": "^4.3.3",
     "@types/bun": "1.3.14",
-    "@types/nodemailer": "^8.0.1",
     "@types/smtp-server": "3.5.13",
     "smtp-server": "3.19.2",
     "svelte": "^5.56.7",

--- a/packages/mochi/src/email/transports.ts
+++ b/packages/mochi/src/email/transports.ts
@@ -65,6 +65,12 @@ type NodemailerTransporter = {
   close(): void;
 };
 
+// Only `createTransport` is used. Typing against a local interface instead of
+// `typeof import('nodemailer')` keeps consumers from having to resolve
+// nodemailer's types — it ships none, and `@types/nodemailer` is not a runtime
+// dep — since the package publishes source that consumers type-check.
+type NodemailerModule = { createTransport(opts: unknown): NodemailerTransporter };
+
 /** Delivers over SMTP. nodemailer is imported lazily on first send. */
 class SmtpTransport implements EmailTransport {
   readonly name = 'smtp' as const;
@@ -92,9 +98,9 @@ class SmtpTransport implements EmailTransport {
   }
 
   private async buildTransporter(): Promise<NodemailerTransporter> {
-    let nodemailer: typeof import('nodemailer');
+    let nodemailer: NodemailerModule;
     try {
-      nodemailer = await import('nodemailer');
+      nodemailer = (await import('nodemailer')) as unknown as NodemailerModule;
     } catch (err) {
       throw new EmailError(
         "Failed to load 'nodemailer' for the SMTP transport. It ships as a dependency of mochi-framework, so this usually means dependencies weren't installed correctly — try reinstalling (`bun install`).",
@@ -110,7 +116,7 @@ class SmtpTransport implements EmailTransport {
       ...(auth ? { auth } : {}),
       ...(pool ? { pool: true } : {}),
       ...(tls ? { tls } : {}),
-    }) as unknown as NodemailerTransporter;
+    });
   }
 
   send(message: ResolvedEmailMessage): Promise<MochiEmailResult> {


### PR DESCRIPTION
## Problem

`mochi-framework` publishes raw `.ts` source (`exports["."].types` → `./src/index.ts`), so every consumer's `tsc` / `svelte-check` type-checks the framework's whole module graph — including `packages/mochi/src/email/transports.ts`. That file's SMTP transport typed a lazy-imported local as the **type-level** import `typeof import('nodemailer')`, forcing consumers to resolve nodemailer's types.

But `nodemailer` ships no bundled `.d.ts`, and `@types/nodemailer` was only a **devDependency** of the framework (never installed transitively). So every downstream project that installed only mochi's runtime deps failed type-checking with:

```
node_modules/mochi-framework/src/email/transports.ts(95,35): error TS7016:
  Could not find a declaration file for module 'nodemailer'. ...
```

— even when it never touches the email/SMTP feature. Build and runtime were unaffected; this was a type-resolution leak only.

## Fix

Only `createTransport` is ever used, and its result already flows into the local structural type `NodemailerTransporter`. So:

- Type the lazy-imported local against a minimal local `NodemailerModule` interface (`{ createTransport(opts: unknown): NodemailerTransporter }`) instead of `typeof import('nodemailer')`. The dynamic `await import('nodemailer')` runtime path is unchanged; the now-redundant `as unknown as NodemailerTransporter` cast on the `createTransport` call is dropped.
- Remove the now-unused `@types/nodemailer` devDependency. Nothing else in the framework references nodemailer's types, and its 8.x major lagged nodemailer's 9.x runtime.

This keeps the "ships source" model honest: every type-level import the package exposes now resolves using only its **runtime** dependencies.

## Verification

- **Consumer leak gone** — type-checking `transports.ts` with `@types/nodemailer` stripped from resolution (`types: []`, `typeRoots: []`) produces no `TS7016` / nodemailer error.
- **Runtime unaffected** — `mailer.integration.test.ts` (drives the real nodemailer client against a local fake SMTP server) + `config.test.ts` pass (12/12).
- **Full gate** — `bun run checks` (lint:fix + format + typecheck + test) green across every workspace.