### PR TITLE
fix(email): stop nodemailer TS7016 leaking from the value-level import

### DIFF
--- a/packages/mochi/src/email/transports.ts
+++ b/packages/mochi/src/email/transports.ts
@@ -100,7 +100,12 @@ class SmtpTransport implements EmailTransport {
   private async buildTransporter(): Promise<NodemailerTransporter> {
     let nodemailer: NodemailerModule;
     try {
-      nodemailer = (await import('nodemailer')) as unknown as NodemailerModule;
+      // nodemailer ships no bundled types and @types/nodemailer is not a runtime dep. Because mochi
+      // publishes source, consumers type-check this file — a *literal* import('nodemailer') would
+      // make their tsc/svelte-check demand nodemailer's types (TS7016). An indirect specifier keeps
+      // the runtime import intact while opting this line out of static module-type resolution.
+      const nodemailerSpecifier = 'nodemailer';
+      nodemailer = (await import(nodemailerSpecifier)) as unknown as NodemailerModule;
     } catch (err) {
       throw new EmailError(
         "Failed to load 'nodemailer' for the SMTP transport. It ships as a dependency of mochi-framework, so this usually means dependencies weren't installed correctly — try reinstalling (`bun install`).",

--- a/packages/mochi/src/email/transports.typecheck.test.ts
+++ b/packages/mochi/src/email/transports.typecheck.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+// mochi publishes source, so a consumer's tsc/svelte-check type-checks transports.ts. nodemailer
+// ships no bundled types and @types/nodemailer is not a runtime dep, so a *literal*
+// import('nodemailer') leaks a TS7016 into every consumer that never touches email (see #192 and
+// transports.ts). This guard reproduces a consumer's resolution and asserts the leak is gone.
+//
+// It can't just point tsc at the real transports.ts: the monorepo's node_modules still carries a
+// stray @types/nodemailer, which satisfies resolution from the file's real location no matter what
+// `types`/`typeRoots` say. So we copy the real source into an isolated /tmp project whose only
+// nodemailer is an untyped fake and which has no @types anywhere up its chain — exactly a consumer.
+// The two local imports are stubbed loosely; only the nodemailer specifier's resolution is under test.
+
+const TRANSPORTS_SRC = readFileSync(path.join(import.meta.dir, 'transports.ts'), 'utf8');
+const TSC = path.join(import.meta.dir, '..', '..', '..', '..', 'node_modules', 'typescript', 'bin', 'tsc');
+
+const TYPES_STUB = `
+export class EmailError extends Error {
+  constructor(message?: string, options?: unknown) {
+    super(message);
+    void options;
+  }
+}
+export type MochiEmailResult = { transport: string; [k: string]: unknown };
+export type MochiEmailTransportConfig = any;
+export type ResolvedEmailMessage = any;
+`;
+const DEVOUTBOX_STUB = `export function recordDevEmail(_message: unknown): void {}`;
+
+async function typecheckIsolated(source: string): Promise<string> {
+  const dir = mkdtempSync(path.join(tmpdir(), 'mochi-nm-guard-'));
+  try {
+    writeFileSync(path.join(dir, 'transports.ts'), source);
+    writeFileSync(path.join(dir, 'types.ts'), TYPES_STUB);
+    writeFileSync(path.join(dir, 'devOutbox.ts'), DEVOUTBOX_STUB);
+    // An untyped nodemailer, like a real consumer's install: a package with a .js entry and no types,
+    // and — crucially — no @types/nodemailer anywhere above this /tmp dir.
+    const nm = path.join(dir, 'node_modules', 'nodemailer');
+    mkdirSync(path.join(nm, 'lib'), { recursive: true });
+    writeFileSync(path.join(nm, 'package.json'), JSON.stringify({ name: 'nodemailer', version: '9.0.0', main: 'lib/nodemailer.js' }));
+    writeFileSync(path.join(nm, 'lib', 'nodemailer.js'), 'module.exports = { createTransport() {} };');
+    writeFileSync(
+      path.join(dir, 'tsconfig.json'),
+      JSON.stringify({
+        compilerOptions: { noImplicitAny: true, strict: true, module: 'esnext', moduleResolution: 'bundler', noEmit: true, skipLibCheck: true, types: [], typeRoots: [] },
+        files: ['transports.ts'],
+      }),
+    );
+
+    const proc = Bun.spawn([process.execPath, TSC, '-p', path.join(dir, 'tsconfig.json')], { stdout: 'pipe', stderr: 'pipe' });
+    const [, stdout, stderr] = await Promise.all([proc.exited, new Response(proc.stdout).text(), new Response(proc.stderr).text()]);
+    return stdout + stderr;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+describe('email SMTP transport type leak (consumer view)', () => {
+  it('does not force consumers to resolve nodemailer types', async () => {
+    const output = await typecheckIsolated(TRANSPORTS_SRC);
+    // Narrow on purpose: unrelated diagnostics from the stubbed local imports must not make the guard
+    // flaky — it fails only when the nodemailer type resolution leak returns.
+    expect(output).not.toContain('TS7016');
+    expect(output.toLowerCase()).not.toContain('nodemailer');
+  });
+
+  it('would fail if the nodemailer import used a literal specifier (guard self-check)', async () => {
+    // Prove the fixture actually reproduces the leak, so the assertion above is meaningful and not
+    // vacuously green. A literal import('nodemailer') in this same isolated project must trip TS7016.
+    const withLiteral = TRANSPORTS_SRC.replace(
+      /const nodemailerSpecifier = 'nodemailer';\s*\n\s*nodemailer = \(await import\(nodemailerSpecifier\)\)/,
+      "nodemailer = (await import('nodemailer'))",
+    );
+    expect(withLiteral).toContain("await import('nodemailer')");
+    const output = await typecheckIsolated(withLiteral);
+    expect(output).toContain('TS7016');
+  });
+});


### PR DESCRIPTION
## Problem

Follow-up to #192. That PR fixed the **type-level** import (`typeof import('nodemailer')` → a local `NodemailerModule` interface) but left the **value-level** lazy import at `transports.ts` using a string-**literal** specifier:

```ts
nodemailer = (await import('nodemailer')) as unknown as NodemailerModule;
```

TypeScript resolves module *types* for any `import('…')` whose specifier is a string literal — even a runtime dynamic one, and even behind `as unknown as` (the cast changes the *awaited result* type but does **not** suppress TS7016, which fires at specifier resolution). Since mochi publishes source, every consumer's `tsc` / `svelte-check` type-checks this file; nodemailer ships no `.d.ts` and `@types/nodemailer` is no longer a dep, so consumers on 0.8.1 still fail:

```
node_modules/mochi-framework/src/email/transports.ts:103:34
Could not find a declaration file for module 'nodemailer'. ... implicitly has an 'any' type.
```

Build and runtime are unaffected — this is a type-resolution leak only.

## Fix

Load nodemailer through a **non-literal specifier** so TypeScript declines static module-type resolution for that one line, while the runtime `import()` is byte-for-byte unchanged:

```ts
const nodemailerSpecifier = 'nodemailer';
nodemailer = (await import(nodemailerSpecifier)) as unknown as NodemailerModule;
```

Chosen over `@ts-ignore` (which suppresses *all* errors on the line) and `@ts-expect-error` (which would itself error for a consumer who *does* install `@types/nodemailer`).

## Regression guard

Adds `transports.typecheck.test.ts`. The monorepo can't catch this via `bun run typecheck` — a stray `@types/nodemailer` sits in root `node_modules` and satisfies resolution from the file's real location regardless of `types`/`typeRoots` (verified: a guard pointed at the real file passes even with the literal import). So the guard instead type-checks a **copy** of the real source in an isolated `/tmp` project with an untyped fake nodemailer and no `@types` up its chain — a faithful consumer view — plus a **self-check** that reintroduces the literal specifier and asserts TS7016 *does* fire, so the main assertion can never go vacuously green.

## Verification

- Original repro (both `tsc` and `svelte-check`): current code errors, fix is clean (0 errors).
- Guard: 2/2 pass (real source clean; literal-specifier self-check trips TS7016).
- Runtime unaffected: `mailer.integration.test.ts` + `config.test.ts` → 12/12 (drives the real nodemailer client against a local fake SMTP server).
- `bun run checks` → PASS (lint, format, typecheck 0 errors, all tests green).