### PR TITLE
fix(site): bake blog barrel into the dev-mode Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,13 @@ RUN apk add --no-cache ncdu
 # tailwind step writes app.generated.css into src/ at startup (no-op for site).
 RUN mkdir -p packages/${WORKSPACE}/.mochi && chown -R bun:bun packages/${WORKSPACE}/.mochi packages/${WORKSPACE}/src
 
+# Bake every generated barrel into the image. Dev mode regenerates these at
+# boot (index.ts), but the deployed rootfs is read-only for the `bun` user, so
+# the runtime write is a no-op that recovers onto whatever file is already
+# present — the barrel MUST exist in the image or the SSR compile fails with
+# "Could not resolve". Any new src/lib/*.generated.ts barrel needs a line here.
 RUN bun packages/site/src/lib/generateDocsBarrel.ts
+RUN bun packages/site/src/lib/generateBlogBarrel.ts
 
 ENV WORKSPACE=${WORKSPACE}
 ENV PORT=${PORT}


### PR DESCRIPTION
## Problem

Production site crashes at startup:

```
error: Svelte SSR build failed:
  src/BlogPost.svelte:6:32 — Could not resolve: "./lib/blogComponents.generated"
    at compileAll (packages/mochi/src/compiler/ComponentRegistry.ts:882:17)
```

`BlogPost.svelte` imports `src/lib/blogComponents.generated`, a **gitignored** barrel that doesn't exist in a fresh (CI) checkout. The dev-mode `Dockerfile` bakes the **docs** barrel (`RUN bun …generateDocsBarrel.ts`, added in #29 for exactly this reason) but never got the **blog** equivalent when the blog section landed in #151 — even though `generateBlogBarrel.ts` was written with the same read-only-container recovery logic that only makes sense against a build-time-baked file.

## Root cause (empirically verified)

`index.ts` regenerates the barrel at boot, but only inside `if (MODE === 'development')`. Reproduced the failure space with real Docker builds from a clean clone:

| Condition | Outcome |
|---|---|
| `dev:site` (MODE=development), writable `src` | ✅ boots, barrel created at runtime |
| `dev:site`, read-only `src` | ❌ `EACCES` from `generateBlogBarrel.ts:48` |
| **MODE≠development, barrel absent** | ❌ **`compileAll: Could not resolve` — byte-for-byte the production error** |

Production hits the third row: the generation block is skipped, so the container is effectively **not** running with `MODE=development`. Docs survives only because it's baked at build time.

## Fix

Bake the blog barrel alongside docs in the dev-mode `Dockerfile`, making the image self-sufficient regardless of runtime `MODE` or a read-only `src`. `Dockerfile.production` already runs the full `build` (prebuild generates both barrels), so it needs no change.

## Validation

Built the image from a clean checkout and booted under the exact reproducing condition (`MODE=production`, no runtime regeneration):

- Before fix → `compileAll: Could not resolve` (production error reproduced).
- After fix → `BOOT … prod`, `Server running`, `/blog/` → 200.
- Normal `dev:site` path still boots cleanly (runtime regen matches the baked content byte-for-byte → `existing === content` early-return, no overwrite).