### PR TITLE
ci: point CapRover deploys at the S1 server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
             port: 3333
             image: ghcr.io/khromov/mochi
             caprover_app: mochi
-            caprover_token_secret: APP_TOKEN
+            caprover_token_secret: APP_TOKEN_S1
             # Temporary: try the site on the Bun canary line (Bun 1.4.0)
             # while demos stays on the stable default pinned in the Dockerfile.
             # Pinned by digest so the moving canary tag can't drift the deploy
@@ -47,7 +47,7 @@ jobs:
             port: 3334
             image: ghcr.io/khromov/mochi-demos
             caprover_app: mochi-demos
-            caprover_token_secret: APP_TOKEN_DEMOS
+            caprover_token_secret: APP_TOKEN_DEMOS_S1
             bun_image: oven/bun:1.3.14-alpine
           # Support form (support.mochi.fast). The only leg on the prebuilt
           # Dockerfile.production rather than the dev-mode Dockerfile — a contact
@@ -62,7 +62,7 @@ jobs:
             port: 3336
             image: ghcr.io/khromov/mochi-support
             caprover_app: mochi-support
-            caprover_token_secret: APP_TOKEN_SUPPORT
+            caprover_token_secret: APP_TOKEN_SUPPORT_S1
             bun_image: oven/bun:1.3.14-alpine
             # Dockerfile.production refuses to boot without ADMIN_PASSWORD +
             # SMTP_HOST + MOCHI_ORIGIN; the transport only connects on send and
@@ -187,9 +187,9 @@ jobs:
           printf '%s\n' "${{ steps.meta.outputs.tags }}" | xargs -n1 docker push
 
       - name: Deploy on CapRover
-        uses: caprover/deploy-from-github@v1.1.2
+        uses: caprover/deploy-from-github@v1.2.0
         with:
-          server: '${{ secrets.APP_SERVER }}'
+          server: '${{ secrets.APP_SERVER_S1 }}'
           app: ${{ matrix.caprover_app }}
           token: '${{ secrets[matrix.caprover_token_secret] }}'
           image: '${{ matrix.image }}:main'


### PR DESCRIPTION
Points all three CapRover deploy legs — site, demos and support — at the `S1` server, and bumps `caprover/deploy-from-github` from v1.1.2 to v1.2.0.

| | before | after |
| --- | --- | --- |
| server | `APP_SERVER` | `APP_SERVER_S1` |
| site | `APP_TOKEN` | `APP_TOKEN_S1` |
| demos | `APP_TOKEN_DEMOS` | `APP_TOKEN_DEMOS_S1` |
| support | `APP_TOKEN_SUPPORT` | `APP_TOKEN_SUPPORT_S1` |

## Before merging

`build.yml` runs `on: push → main`, so this deploys the moment it lands. All four `_S1` secrets need to exist in repo settings first — a missing one fails every leg at the **Deploy on CapRover** step. The image build and `ghcr.io` push run earlier and would still succeed, so a failure here leaves the registry updated but the apps on their old release.

Worth a glance at the v1.1.2 → v1.2.0 release notes for the deploy action too, since it runs with the CapRover token.
