### PR TITLE
docs: reword demo hooks to concept-led descriptions with keywords

### DIFF
--- a/packages/docs/100-websocket-routes.md
+++ b/packages/docs/100-websocket-routes.md
@@ -154,7 +154,7 @@ Every WebSocket emits `ws:open`, `ws:message`, and `ws:close` on `mochiEvents`. 
 
 <SeeItInAction
 demos={[
-{ href: "/demos/chat/", title: "Real-time Chat", hook: "A hydrated island over a Mochi.ws() route, with pub/sub broadcast and in-memory history." },
-{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." },
+{ href: "/demos/chat/", title: "Real-time Chat", hook: "How WebSocket routes work — a hydrated island over Mochi.ws() with pub/sub broadcast and in-memory history." },
+{ href: "/demos/streams/", title: "Real-time Streams", hook: "How server-sent events and WebSocket streaming work — live SSE and WebSocket clocks, lazily hydrated via mochi:hydrate:visible." },
 ]}
 />

--- a/packages/docs/11-your-first-mochi-app.md
+++ b/packages/docs/11-your-first-mochi-app.md
@@ -193,7 +193,7 @@ The finished app is running on this site at [**/docs/your-first-mochi-app/hello/
 
 <SeeItInAction
 demos={[
-{ href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
-{ href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
+{ href: "/demos/hello-world/", title: "Hello World", hook: "How server-side rendering works — a Mochi.page() renders Svelte on the server and ships zero JavaScript." },
+{ href: "/demos/server-props/", title: "Server Props", hook: "How server props work — pass fresh per-request data into a page via serverProps on Mochi.page()." },
 ]}
 />

--- a/packages/docs/110-server-sent-events.md
+++ b/packages/docs/110-server-sent-events.md
@@ -78,5 +78,5 @@ stream.onClose(() => sub.unsubscribe());
 `Mochi.sse` emits `sse:open`, `sse:message`, and `sse:close` on `mochiEvents`. `logger()` prints them by default.
 
 <SeeItInAction
-demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
+demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "How server-sent events and WebSocket streaming work — live SSE and WebSocket clocks, lazily hydrated via mochi:hydrate:visible." }]}
 />

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -272,5 +272,5 @@ await Mochi.serve({
 Mochi uses bunqueue as the underlying implementation for queues. bunqueue pulls in `msgpackr`, whose optional native accelerator (`msgpackr-extract`) would otherwise drag platform-specific prebuilt binaries into your install — so Mochi swaps it out via a `package.json` `overrides` entry pointing at [`@mochi-framework/msgpackr-extract-stub`](https://www.npmjs.com/package/@mochi-framework/msgpackr-extract-stub), an empty stub that keeps `msgpackr` on its pure-JS codec so no native binaries are installed. New projects scaffolded with `create-mochi` ship this override by default — to opt out and use the native bindings, just delete the `overrides` entry from your `package.json`.
 
 <SeeItInAction
-demos={[{ href: "/demos/queue/", title: "Background jobs with queues", hook: "Offload work to a Mochi.queue() with an embedded worker — no Redis." }]}
+demos={[{ href: "/demos/queue/", title: "Background jobs with queues", hook: "How background job queues work — offload work to a Mochi.queue() with an embedded worker, no Redis." }]}
 />

--- a/packages/docs/120-middleware.md
+++ b/packages/docs/120-middleware.md
@@ -160,5 +160,5 @@ await Mochi.serve({
 `asset`, `fallback`, and `error` events pass through unchanged — framework bundles already get long-lived immutable caching in production. WebSocket upgrades and SSE streams never reach the middleware.
 
 <SeeItInAction
-demos={[{ href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." }]}
+demos={[{ href: "/demos/request-id/", title: "Request ID", hook: "How request IDs work — every request gets a UUID v7 on getRequestContext().requestId that rides every lifecycle event for correlation." }]}
 />

--- a/packages/docs/122-rate-limiting.md
+++ b/packages/docs/122-rate-limiting.md
@@ -180,6 +180,6 @@ const rateLimit = getRequestContext().rateLimit;
 
 <SeeItInAction
 demos={[
-{ href: "/demos/rate-limit/", title: "Rate Limiting", hook: "5 requests per minute per IP — reload past the limit to hit the 429 error page." },
+{ href: "/demos/rate-limit/", title: "Rate Limiting", hook: "How rate limiting works — a rateLimit config on the route caps requests per IP per minute and serves the 429 error page past the limit." },
 ]}
 />

--- a/packages/docs/130-error-handling.md
+++ b/packages/docs/130-error-handling.md
@@ -146,5 +146,5 @@ Uncaught throws inside a `Mochi.api` handler are coerced to `500 Internal Server
 If the user's `errorPage` itself throws during render, Mochi returns a plain-text response that mentions both the original error and the secondary render failure — the error page cannot crash the server.
 
 <SeeItInAction
-demos={[{ href: "/demos/error/", title: "Error Handling", hook: "Catch render errors and unmatched routes via Mochi.serve()'s errorPage option and the handleError hook." }]}
+demos={[{ href: "/demos/error/", title: "Error Handling", hook: "How error handling works — catch render errors and unmatched routes via Mochi.serve()'s errorPage option and the handleError hook." }]}
 />

--- a/packages/docs/135-error-boundaries.md
+++ b/packages/docs/135-error-boundaries.md
@@ -80,5 +80,5 @@ The `MochiIslandErrorKind` type also reserves `'client-hydrate'`, but client-sid
 - [Selective hydration](/docs/selective-hydration/), [Lazy hydration](/docs/lazy-hydration/), [Server islands](/docs/server-islands/) — the directives boundaries wrap.
 
 <SeeItInAction
-demos={[{ href: "/demos/error-boundaries/", title: "Error Boundaries", hook: "Contain island failures with <svelte:boundary> so one broken component does not crash the page." }]}
+demos={[{ href: "/demos/error-boundaries/", title: "Error Boundaries", hook: "How error boundaries work — contain island failures with <svelte:boundary> so one broken component doesn't crash the page." }]}
 />

--- a/packages/docs/140-utility-helpers.md
+++ b/packages/docs/140-utility-helpers.md
@@ -78,5 +78,5 @@ const opened = decryptPayload(token, { aad: 'my-form' }); // string | null
 ```
 
 <SeeItInAction
-demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
+demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "How the isomorphic URL helper works — one import that reads the request URL on the server and window.location on the client." }]}
 />

--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -169,8 +169,8 @@ See the [Cache Events demo](/demos/cache-events/) for a working example that pip
 
 <SeeItInAction
 demos={[
-{ href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." },
-{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." },
-{ href: "/cookie-vary-test/", title: "Cookie Vary Test", hook: "A page that sets Vary: Cookie on its response — useful for testing cookie-partitioned cache keys." },
+{ href: "/demos/data-loading/", title: "Data Loading", hook: "How server-side data loading works — fetch on the server, cache with MochiCache, and render at request time." },
+{ href: "/demos/cache-events/", title: "Cache Events", hook: "How cache events work — subscribe to MochiCache lifecycle events (hit, miss, set, evict) through mochiEvents for observability." },
+{ href: "/cookie-vary-test/", title: "Cookie Vary Test", hook: "How cookie-partitioned caching works — a page that sets Vary: Cookie so responses key on cookies." },
 ]}
 />

--- a/packages/docs/146-logging.md
+++ b/packages/docs/146-logging.md
@@ -104,5 +104,5 @@ getLogLevel(); // 'error'
 The event bus (`mochiEvents`) is a separate concern: it carries structured payloads to any subscriber you wire up, regardless of console output. The built-in `consoleLogger()` — the thing that prints request lines like `GET /foo 200 12ms` — is just one consumer subscribing to those events and calling `logger.info` / `logger.warn` per event. Plug Sentry, OpenTelemetry, or your own pipeline directly into `mochiEvents`; use `logger` for ad-hoc messages.
 
 <SeeItInAction
-demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
+demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "How cache events work — subscribe to MochiCache lifecycle events (hit, miss, set, evict) through mochiEvents for observability." }]}
 />

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -523,5 +523,5 @@ Emitted by `MochiCache` — see [Subscribing to cache events](/docs/cache/#subsc
 `logger()` (see `logger`) already prints `request`, `ws:*`, `sse:*`, `server:*`, `error`, and `cache:revalidate` lines. Pass `{ cache: 'verbose' }` to also print every `cache:read`, or `{ cache: false }` to silence cache logging entirely.
 
 <SeeItInAction
-demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console." }]}
+demos={[{ href: "/demos/cache-events/", title: "Cache Events", hook: "How cache events work — subscribe to MochiCache lifecycle events (hit, miss, set, evict) through mochiEvents for observability." }]}
 />

--- a/packages/docs/148-view-transitions.md
+++ b/packages/docs/148-view-transitions.md
@@ -134,7 +134,7 @@ If you'd rather wire it by hand — or need finer control — give the element a
 
 <SeeItInAction
 demos={[
-{ href: "/demos/view-transitions/", title: "View Transitions", hook: "Drop <ViewTransitions /> into a shared layout to animate full-page navigations with zero JavaScript." },
-{ href: "/demos/custom-transitions/", title: "Custom Transitions", hook: "Bring your own @keyframes to <ViewTransitions /> via custom={{ in, out }} — here, a funky 3D spin." },
+{ href: "/demos/view-transitions/", title: "View Transitions", hook: "How view transitions work — drop <ViewTransitions /> into a layout to animate full-page navigations with zero JavaScript." },
+{ href: "/demos/custom-transitions/", title: "Custom Transitions", hook: "How custom view transitions work — supply your own @keyframes to <ViewTransitions /> via custom={{ in, out }}." },
 ]}
 />

--- a/packages/docs/15-coming-from-sveltekit.md
+++ b/packages/docs/15-coming-from-sveltekit.md
@@ -959,8 +959,8 @@ await Mochi.serve({
 
 <SeeItInAction
 demos={[
-{ href: "/demos/server-props/", title: "Server Props", hook: "Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request." },
-{ href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
-{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
+{ href: "/demos/server-props/", title: "Server Props", hook: "How server props work — pass fresh per-request data into a page via serverProps on Mochi.page()." },
+{ href: "/demos/login/", title: "Form Actions", hook: "How form actions work — a form rendered twice, as a plain HTML POST and intercepted with {@attach enhance(...)}." },
+{ href: "/demos/api/", title: "API Endpoints", hook: "How API routes work — define JSON endpoints with Mochi.api(), tested live against the running server." },
 ]}
 />

--- a/packages/docs/150-captcha.md
+++ b/packages/docs/150-captcha.md
@@ -329,7 +329,7 @@ Solving requires JavaScript: the widget is a hydrated island, and it renders not
 
 <SeeItInAction
 demos={[
-{ href: "/demos/captcha/", title: "Captcha", hook: "Slide-to-verify with a hash chain and proof-of-work — no third party, no tracking." },
-{ href: "/demos/captcha-styling/", title: "Captcha Styling", hook: "The same captcha four ways — every colour is a CSS custom property with a built-in fallback." },
+{ href: "/demos/captcha/", title: "Captcha", hook: "How the captcha works — slide-to-verify backed by a hash chain and proof-of-work, with no third party and no tracking." },
+{ href: "/demos/captcha-styling/", title: "Captcha Styling", hook: "How captcha theming works — the same captcha four ways, every colour a CSS custom property with a built-in fallback." },
 ]}
 />

--- a/packages/docs/155-css-imports.md
+++ b/packages/docs/155-css-imports.md
@@ -64,6 +64,6 @@ A `.css` edit triggers a fast rebundle and a page reload — no SSR recompile. E
 <SeeItInAction
 demos={[
 { href: "https://demos.mochi.fast/todo/", title: "Tailwind Todo App", hook: "Classic todo app styled with Tailwind CSS." },
-{ href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+{ href: "/demos/lazy/", title: "Lazy Islands", hook: "How lazy hydration works — islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
 ]}
 />

--- a/packages/docs/158-mdsvex.md
+++ b/packages/docs/158-mdsvex.md
@@ -152,5 +152,5 @@ importing one then surfaces as a "no loader" error from Bun's bundler. Your
 </Callout>
 
 <SeeItInAction
-demos={[{ href: "/demos/mdsvex/", title: "MdSvex", hook: "A .md file compiled through mdsvex and rendered as a Svelte component, with an embedded <script> block." }]}
+demos={[{ href: "/demos/mdsvex/", title: "MdSvex", hook: "How mdsvex works — a .md file compiled through mdsvex and rendered as a Svelte component, embedded <script> and all." }]}
 />

--- a/packages/docs/40-defining-routes.md
+++ b/packages/docs/40-defining-routes.md
@@ -230,8 +230,8 @@ Files under `./public` are served automatically; no route entry is needed. A use
 
 <SeeItInAction
 demos={[
-{ href: "/demos/hello-world/", title: "Hello World", hook: "The simplest possible Mochi page — pure server-rendered Svelte." },
-{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." },
-{ href: "/demos/file/", title: "File Routes", hook: "Serve a file from disk with Mochi.file() — static path or a per-request resolver." },
+{ href: "/demos/hello-world/", title: "Hello World", hook: "How server-side rendering works — a Mochi.page() renders Svelte on the server and ships zero JavaScript." },
+{ href: "/demos/api/", title: "API Endpoints", hook: "How API routes work — define JSON endpoints with Mochi.api(), tested live against the running server." },
+{ href: "/demos/file/", title: "File Routes", hook: "How file routes work — serve a file from disk with Mochi.file(), as a static path or a per-request resolver." },
 ]}
 />

--- a/packages/docs/50-selective-hydration.md
+++ b/packages/docs/50-selective-hydration.md
@@ -176,8 +176,8 @@ Add `:visible` to defer the fetch until the placeholder scrolls into view, with 
 
 <SeeItInAction
 demos={[
-{ href: "/demos/hydration/", title: "Hydration Modes", hook: "The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island." },
-{ href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
-{ href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
+{ href: "/demos/hydration/", title: "Hydration Modes", hook: "How the hydration modes work — mochi:hydrate, mochi:hydrate:visible, rootMargin tuning, and mochi:defer server islands side by side." },
+{ href: "/demos/lazy/", title: "Lazy Islands", hook: "How lazy hydration works — islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+{ href: "/demos/server-island/", title: "Server Islands", hook: "How server islands work — components marked mochi:defer render server-side on demand after the initial page is delivered." },
 ]}
 />

--- a/packages/docs/60-lazy-hydration.md
+++ b/packages/docs/60-lazy-hydration.md
@@ -44,7 +44,7 @@ See `Selective hydration` for the eager `mochi:hydrate` directive and `Server is
 
 <SeeItInAction
 demos={[
-{ href: "/demos/lazy/", title: "Lazy Islands", hook: "Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
-{ href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
+{ href: "/demos/lazy/", title: "Lazy Islands", hook: "How lazy hydration works — islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view." },
+{ href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "How lazy server islands work — server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
 ]}
 />

--- a/packages/docs/70-server-islands.md
+++ b/packages/docs/70-server-islands.md
@@ -146,8 +146,8 @@ bunx mochi-framework generate-key
 
 <SeeItInAction
 demos={[
-{ href: "/demos/server-island/", title: "Server Islands", hook: "Components marked mochi:defer render server-side on demand after the initial page is delivered." },
-{ href: "/demos/nested-islands/", title: "Nested Islands", hook: "Islands inside islands — a mochi:defer server island wrapping mochi:hydrate components, and a server island nesting more server islands." },
-{ href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
+{ href: "/demos/server-island/", title: "Server Islands", hook: "How server islands work — components marked mochi:defer render server-side on demand after the initial page is delivered." },
+{ href: "/demos/nested-islands/", title: "Nested Islands", hook: "How nested islands work — a mochi:defer server island wrapping mochi:hydrate components, and server islands nesting more server islands." },
+{ href: "/demos/lazy-server-island/", title: "Lazy Server Islands", hook: "How lazy server islands work — server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view." },
 ]}
 />

--- a/packages/docs/71-island-props.md
+++ b/packages/docs/71-island-props.md
@@ -118,8 +118,8 @@ To branch on whether the current render will hydrate, call [`isHydratable()`](/d
 
 <SeeItInAction
 demos={[
-{ href: "/demos/island-props/", title: "Crossing the server-client boundary with props", hook: "How props travel from a server-rendered parent into a hydrated island — Date, Map, Set, BigInt, URL, typed arrays, and even cyclic refs survive devalue's round-trip." },
-{ href: "/demos/prop-dedup/", title: "Shared Props", hook: "Nine islands, three unique payloads — each set serialized once and referenced via props-ref." },
-{ href: "/demos/props-id/", title: "Unique IDs", hook: "Svelte's native $props.id() inside islands — SSR-consistent, unique per instance, namespaced in server islands." },
+{ href: "/demos/island-props/", title: "Crossing the server-client boundary with props", hook: "How props cross the server-client boundary — Date, Map, Set, BigInt, URL, typed arrays, and even cyclic refs survive devalue's round-trip into a hydrated island." },
+{ href: "/demos/prop-dedup/", title: "Shared Props", hook: "How island prop deduplication works — nine islands share three unique payloads, each serialized once and referenced via props-ref." },
+{ href: "/demos/props-id/", title: "Unique IDs", hook: "How stable island IDs work — Svelte's native $props.id() gives SSR-consistent, per-instance ids, namespaced inside server islands." },
 ]}
 />

--- a/packages/docs/72-hydratable.md
+++ b/packages/docs/72-hydratable.md
@@ -68,5 +68,5 @@ Values are serialized with [`devalue`](https://www.npmjs.com/package/devalue), s
 </Callout>
 
 <SeeItInAction
-demos={[{ href: "/demos/hydratable/", title: "Hydratable", hook: "Compute a value once on the server with hydratable(); the hydrated island reads it from <head> instead of re-running the async work." }]}
+demos={[{ href: "/demos/hydratable/", title: "Hydratable", hook: "How hydratable() works — compute a value once on the server and reuse it on the client instead of re-running async work during hydration." }]}
 />

--- a/packages/docs/73-server-only-imports.md
+++ b/packages/docs/73-server-only-imports.md
@@ -81,5 +81,5 @@ getVersion from /…/db.server.ts was called on the client; this is a server-onl
 - `.server.svelte` — component-level convention is not provided. Put server-only code in plain TS and call it from a component.
 
 <SeeItInAction
-demos={[{ href: "/demos/data-loading/", title: "Data Loading", hook: "Server-side fetch from PokéAPI cached via MochiCache and rendered at request time." }]}
+demos={[{ href: "/demos/data-loading/", title: "Data Loading", hook: "How server-side data loading works — fetch on the server, cache with MochiCache, and render at request time." }]}
 />

--- a/packages/docs/74-use-enhance.md
+++ b/packages/docs/74-use-enhance.md
@@ -204,8 +204,8 @@ Reach for `enhance` when the action's outcome should update UI without a navigat
 
 <SeeItInAction
 demos={[
-{ href: "/demos/login/", title: "Form Actions", hook: "A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}." },
-{ href: "/demos/form-errors/", title: "Form Errors", hook: "A thrown action error shown inline via {@attach enhance(...)}, or as the Mochi error page on plain submit." },
-{ href: "/demos/form-return-data/", title: "Using form return data", hook: "An action returns data via success({...}); {@attach enhance(...)} updates the UI in place, plain HTML re-renders the page." },
+{ href: "/demos/login/", title: "Form Actions", hook: "How form actions work — a form rendered twice, as a plain HTML POST and intercepted with {@attach enhance(...)}." },
+{ href: "/demos/form-errors/", title: "Form Errors", hook: "How form action errors work — a thrown action error shows inline via {@attach enhance(...)}, or as the Mochi error page on a plain submit." },
+{ href: "/demos/form-return-data/", title: "Using form return data", hook: "How form action return data works — an action returns success({...}); {@attach enhance(...)} updates the UI in place, plain HTML re-renders." },
 ]}
 />

--- a/packages/docs/76-http-streaming.md
+++ b/packages/docs/76-http-streaming.md
@@ -33,5 +33,5 @@ Reach for these to layer realtime UI on top of a rendered base page.
 - **Shared HTTP cache** (Cloudflare, CloudFront, Fastly, Varnish, nginx) in front of the origin makes render time irrelevant for the cacheable common case. Server islands can stay uncached behind a cached shell — see `Cache`.
 
 <SeeItInAction
-demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible." }]}
+demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "How server-sent events and WebSocket streaming work — live SSE and WebSocket clocks, lazily hydrated via mochi:hydrate:visible." }]}
 />

--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -89,5 +89,5 @@ Use `isHydratable()` to peek request-scoped state only when the client won't tak
 See the [Forms demo](/demos/login/) for a side-by-side comparison of hydrated and SSR-only render paths.
 
 <SeeItInAction
-demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "One import for the current URL — reads from the request on the server, window.location on the client." }]}
+demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "How the isomorphic URL helper works — one import that reads the request URL on the server and window.location on the client." }]}
 />

--- a/packages/docs/85-request-context.md
+++ b/packages/docs/85-request-context.md
@@ -119,7 +119,7 @@ serverProps: async () => {
 
 <SeeItInAction
 demos={[
-{ href: "/demos/request-id/", title: "Request ID", hook: "Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation." },
-{ href: "/demos/cookies/", title: "Cookies", hook: "Read and write cookies on the server and the client through one MochiCookieJar API." },
+{ href: "/demos/request-id/", title: "Request ID", hook: "How request IDs work — every request gets a UUID v7 on getRequestContext().requestId that rides every lifecycle event for correlation." },
+{ href: "/demos/cookies/", title: "Cookies", hook: "How cookies work — read and write on the server and the client through one MochiCookieJar API (cookies.get/set/delete)." },
 ]}
 />

--- a/packages/docs/90-api-routes.md
+++ b/packages/docs/90-api-routes.md
@@ -153,5 +153,5 @@ Mochi.api(async () => {
 API routes never render the HTML error page and `handleError` is **not** called for them — the JSON envelope is the only contract.
 
 <SeeItInAction
-demos={[{ href: "/demos/api/", title: "API Endpoints", hook: "JSON routes defined with Mochi.api(), tested live against the running server." }]}
+demos={[{ href: "/demos/api/", title: "API Endpoints", hook: "How API routes work — define JSON endpoints with Mochi.api(), tested live against the running server." }]}
 />

--- a/packages/site/src/lib/demos.ts
+++ b/packages/site/src/lib/demos.ts
@@ -77,7 +77,7 @@ export const demos: Demo[] = [
     slug: 'hello-world',
     files: helloWorld,
     title: 'Hello World',
-    hook: 'The simplest possible Mochi page — pure server-rendered Svelte.',
+    hook: 'How server-side rendering works — a Mochi.page() renders Svelte on the server and ships zero JavaScript.',
     category: 'hydration',
   },
   {
@@ -85,7 +85,7 @@ export const demos: Demo[] = [
     slug: 'server-props',
     files: serverProps,
     title: 'Server Props',
-    hook: 'Define serverProps on Mochi.page() to pass fresh data into a Svelte page on every request.',
+    hook: 'How server props work — pass fresh per-request data into a page via serverProps on Mochi.page().',
     category: 'data',
   },
   {
@@ -93,7 +93,7 @@ export const demos: Demo[] = [
     slug: 'hydration',
     files: hydration,
     title: 'Hydration Modes',
-    hook: 'The same component rendered five ways — eager, lazy, visible, rootMargin-tuned, and deferred server island.',
+    hook: 'How the hydration modes work — mochi:hydrate, mochi:hydrate:visible, rootMargin tuning, and mochi:defer server islands side by side.',
     category: 'hydration',
   },
   {
@@ -101,7 +101,7 @@ export const demos: Demo[] = [
     slug: 'data-loading',
     files: dataLoading,
     title: 'Data Loading',
-    hook: 'Server-side fetch from PokéAPI cached via MochiCache and rendered at request time.',
+    hook: 'How server-side data loading works — fetch on the server, cache with MochiCache, and render at request time.',
     category: 'data',
   },
   {
@@ -109,7 +109,7 @@ export const demos: Demo[] = [
     slug: 'hydratable',
     files: hydratable,
     title: 'Hydratable',
-    hook: 'Compute a value once on the server with hydratable(); the hydrated island reads it from <head> instead of re-running the async work.',
+    hook: 'How hydratable() works — compute a value once on the server and reuse it on the client instead of re-running async work during hydration.',
     category: 'hydration',
   },
   {
@@ -117,7 +117,7 @@ export const demos: Demo[] = [
     slug: 'is-hydratable',
     files: isHydratableFiles,
     title: 'isHydratable()',
-    hook: 'Ask from any nesting depth whether the current subtree will hydrate on this page load — no prop forwarding needed.',
+    hook: 'How isHydratable() works — detect from any depth whether the current subtree will hydrate, for SSR-only fallbacks without prop forwarding.',
     category: 'hydration',
   },
   {
@@ -125,7 +125,7 @@ export const demos: Demo[] = [
     slug: 'cookies',
     files: cookies,
     title: 'Cookies',
-    hook: 'Read and write cookies on the server and the client through one MochiCookieJar API.',
+    hook: 'How cookies work — read and write on the server and the client through one MochiCookieJar API (cookies.get/set/delete).',
     category: 'data',
   },
   {
@@ -133,19 +133,19 @@ export const demos: Demo[] = [
     slug: 'url',
     files: url,
     title: 'Isomorphic URL',
-    hook: 'One import for the current URL — reads from the request on the server, window.location on the client.',
+    hook: 'How the isomorphic URL helper works — one import that reads the request URL on the server and window.location on the client.',
     category: 'data',
   },
   {
     href: '/demos/view-transitions/',
     title: 'View Transitions',
-    hook: 'Drop <ViewTransitions /> into a shared layout to animate full-page navigations with zero JavaScript.',
+    hook: 'How view transitions work — drop <ViewTransitions /> into a layout to animate full-page navigations with zero JavaScript.',
     category: 'hydration',
   },
   {
     href: '/demos/custom-transitions/',
     title: 'Custom Transitions',
-    hook: 'Bring your own @keyframes to <ViewTransitions /> via custom={{ in, out }} — here, a funky 3D spin.',
+    hook: 'How custom view transitions work — supply your own @keyframes to <ViewTransitions /> via custom={{ in, out }}.',
     category: 'hydration',
   },
   {
@@ -153,7 +153,7 @@ export const demos: Demo[] = [
     slug: 'cache-events',
     files: cacheEvents,
     title: 'Cache Events',
-    hook: 'Subscribe to MochiCache lifecycle events through mochiEvents and log them to the server console.',
+    hook: 'How cache events work — subscribe to MochiCache lifecycle events (hit, miss, set, evict) through mochiEvents for observability.',
     category: 'data',
   },
   {
@@ -161,7 +161,7 @@ export const demos: Demo[] = [
     slug: 'image',
     files: image,
     title: 'Image: Component',
-    hook: 'The <Image> component — named sizes, ThumbHash blur-up placeholders, a gallery, and island usage. It only mints an encrypted URL; the endpoint does the work.',
+    hook: 'How the <Image> component works — named sizes, ThumbHash blur-up placeholders, and encrypted deferred URLs whose transforms run lazily on the endpoint.',
     category: 'data',
   },
   {
@@ -169,7 +169,7 @@ export const demos: Demo[] = [
     slug: 'image-invalidation',
     files: imageInvalidation,
     title: 'Image: Invalidation',
-    hook: 'Clear a cached image on demand with invalidateImage() — hard-evict the shared original and watch every named size re-fetch in lockstep.',
+    hook: 'How image invalidation works — invalidateImage() hard-evicts the shared original so every named size re-fetches in lockstep.',
     category: 'data',
   },
   {
@@ -177,7 +177,7 @@ export const demos: Demo[] = [
     slug: 'image-pipeline',
     files: imagePipeline,
     title: 'Image: Named sizes',
-    hook: 'Declare resize / rotate / flip / modulate / format transforms once as named sizes; getImageUrl mints a deferred URL and getImage runs one inline for bytes + metadata.',
+    hook: 'How the image transform pipeline works — declare resize / rotate / flip / modulate / format as named sizes; getImageUrl mints a deferred URL, getImage runs one inline.',
     category: 'data',
   },
   {
@@ -185,7 +185,7 @@ export const demos: Demo[] = [
     slug: 'image-events',
     files: imageEvents,
     title: 'Image: Events',
-    hook: 'Subscribe to image:store / image:delete on mochiEvents to mirror the <Image> cache to durable storage like S3.',
+    hook: 'How image events work — subscribe to image:store / image:delete on mochiEvents to mirror the <Image> cache to durable storage like S3.',
     category: 'data',
   },
   {
@@ -193,7 +193,7 @@ export const demos: Demo[] = [
     slug: 'request-id',
     files: requestId,
     title: 'Request ID',
-    hook: 'Every request gets a UUID v7 — read it server-side via getRequestContext().requestId; the same id rides every lifecycle event for correlation.',
+    hook: 'How request IDs work — every request gets a UUID v7 on getRequestContext().requestId that rides every lifecycle event for correlation.',
     category: 'data',
   },
   {
@@ -201,7 +201,7 @@ export const demos: Demo[] = [
     slug: 'cookie-vary-test',
     files: cookieVaryTest,
     title: 'Cookie Vary Test',
-    hook: 'A page that sets Vary: Cookie on its response — useful for testing cookie-partitioned cache keys.',
+    hook: 'How cookie-partitioned caching works — a page that sets Vary: Cookie so responses key on cookies.',
     category: 'data',
   },
   {
@@ -209,7 +209,7 @@ export const demos: Demo[] = [
     slug: 'chat',
     files: chat,
     title: 'Real-time Chat',
-    hook: 'A hydrated island over a Mochi.ws() route, with pub/sub broadcast and in-memory history.',
+    hook: 'How WebSocket routes work — a hydrated island over Mochi.ws() with pub/sub broadcast and in-memory history.',
     category: 'endpoints',
   },
   {
@@ -217,7 +217,7 @@ export const demos: Demo[] = [
     slug: 'api',
     files: api,
     title: 'API Endpoints',
-    hook: 'JSON routes defined with Mochi.api(), tested live against the running server.',
+    hook: 'How API routes work — define JSON endpoints with Mochi.api(), tested live against the running server.',
     category: 'endpoints',
   },
   {
@@ -225,7 +225,7 @@ export const demos: Demo[] = [
     slug: 'rate-limit',
     files: rateLimit,
     title: 'Rate Limiting',
-    hook: 'A rateLimit config on the route — 5 requests per minute per IP; reload past the limit to hit the 429 error page.',
+    hook: 'How rate limiting works — a rateLimit config on the route caps requests per IP per minute and serves the 429 error page past the limit.',
     category: 'endpoints',
   },
   {
@@ -233,7 +233,7 @@ export const demos: Demo[] = [
     slug: 'file',
     files: file,
     title: 'File Routes',
-    hook: 'Serve a file from disk with Mochi.file() — static path or a per-request resolver.',
+    hook: 'How file routes work — serve a file from disk with Mochi.file(), as a static path or a per-request resolver.',
     category: 'endpoints',
   },
   {
@@ -241,7 +241,7 @@ export const demos: Demo[] = [
     slug: 'shared-state',
     files: sharedState,
     title: 'Shared State',
-    hook: 'Two separate islands sharing the same reactive $state.',
+    hook: 'How shared state across islands works — two separate islands driving the same reactive $state.',
     category: 'hydration',
   },
   {
@@ -249,7 +249,7 @@ export const demos: Demo[] = [
     slug: 'streams',
     files: streams,
     title: 'Real-time Streams',
-    hook: 'WebSocket and SSE clocks, lazily hydrated via mochi:hydrate:visible.',
+    hook: 'How server-sent events and WebSocket streaming work — live SSE and WebSocket clocks, lazily hydrated via mochi:hydrate:visible.',
     category: 'endpoints',
   },
   {
@@ -257,7 +257,7 @@ export const demos: Demo[] = [
     slug: 'queue',
     files: queue,
     title: 'Background jobs with queues',
-    hook: 'Offload work to a Mochi.queue() with an embedded worker — no Redis.',
+    hook: 'How background job queues work — offload work to a Mochi.queue() with an embedded worker, no Redis.',
     category: 'endpoints',
   },
   {
@@ -265,7 +265,7 @@ export const demos: Demo[] = [
     slug: 'server-island',
     files: serverIsland,
     title: 'Server Islands',
-    hook: 'Components marked mochi:defer render server-side on demand after the initial page is delivered.',
+    hook: 'How server islands work — components marked mochi:defer render server-side on demand after the initial page is delivered.',
     category: 'hydration',
   },
   {
@@ -273,7 +273,7 @@ export const demos: Demo[] = [
     slug: 'island-props',
     files: islandProps,
     title: 'Crossing the server-client boundary with props',
-    hook: 'How props travel from a server-rendered parent into a hydrated island — Date, Map, Set, BigInt, URL, typed arrays, and even cyclic refs survive devalue’s round-trip.',
+    hook: "How props cross the server-client boundary — Date, Map, Set, BigInt, URL, typed arrays, and even cyclic refs survive devalue's round-trip into a hydrated island.",
     category: 'hydration',
   },
   {
@@ -281,7 +281,7 @@ export const demos: Demo[] = [
     slug: 'client-only',
     files: clientOnly,
     title: 'Client-only Islands',
-    hook: 'Components marked mochi:clientOnly skip SSR entirely and mount in the browser — a fallback snippet fills in until then.',
+    hook: 'How client-only islands work — components marked mochi:clientOnly skip SSR and mount in the browser, with a fallback snippet until then.',
     category: 'hydration',
   },
   {
@@ -289,7 +289,7 @@ export const demos: Demo[] = [
     slug: 'lazy',
     files: lazy,
     title: 'Lazy Islands',
-    hook: 'Islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view.',
+    hook: 'How lazy hydration works — islands marked mochi:hydrate:visible hydrate and load their CSS only when scrolled into view.',
     category: 'hydration',
   },
   {
@@ -297,7 +297,7 @@ export const demos: Demo[] = [
     slug: 'lazy-server-island',
     files: lazyServerIsland,
     title: 'Lazy Server Islands',
-    hook: 'Server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view.',
+    hook: 'How lazy server islands work — server islands marked mochi:defer:visible only fetch when the wrapper scrolls into view.',
     category: 'hydration',
   },
   {
@@ -305,7 +305,7 @@ export const demos: Demo[] = [
     slug: 'font-loading',
     files: fontLoading,
     title: 'Font loading',
-    hook: 'Ship fonts via @fontsource packages or standalone .woff2 files — automatically bundled and linked from the page head.',
+    hook: 'How font loading works — ship fonts via @fontsource packages or standalone .woff2 files, automatically bundled and linked from the page head.',
     category: 'hydration',
   },
   {
@@ -313,7 +313,7 @@ export const demos: Demo[] = [
     slug: 'mdsvex',
     files: mdsvex,
     title: 'MdSvex',
-    hook: 'A .md file compiled through mdsvex and rendered as a Svelte component, with an embedded <script> block.',
+    hook: 'How mdsvex works — a .md file compiled through mdsvex and rendered as a Svelte component, embedded <script> and all.',
     category: 'hydration',
   },
   {
@@ -321,7 +321,7 @@ export const demos: Demo[] = [
     slug: 'nested-components',
     files: nestedComponents,
     title: 'Nested Components',
-    hook: 'A five-level recursive tree — hydrating the root carries the whole subtree in one island.',
+    hook: 'How whole-subtree hydration works — a five-level recursive tree where hydrating the root carries the entire subtree in one island.',
     category: 'hydration',
   },
   {
@@ -329,7 +329,7 @@ export const demos: Demo[] = [
     slug: 'nested-islands',
     files: nestedIslands,
     title: 'Nested Islands',
-    hook: 'Islands inside islands — a mochi:defer server island wrapping mochi:hydrate components, and a server island nesting both a deferred and a deferred-hydrated server island.',
+    hook: 'How nested islands work — a mochi:defer server island wrapping mochi:hydrate components, and server islands nesting more server islands.',
     category: 'hydration',
   },
   {
@@ -337,7 +337,7 @@ export const demos: Demo[] = [
     slug: 'island-depth',
     files: islandDepth,
     title: 'Nested Island Max Depth',
-    hook: 'A chain of mochi:defer server islands nested four levels deep — each fetches the next on demand, and the prebuild precompiles the whole chain.',
+    hook: 'How deeply nested server islands work — a four-level mochi:defer chain where each level fetches the next on demand and the prebuild precompiles the whole chain.',
     category: 'hydration',
   },
   {
@@ -345,7 +345,7 @@ export const demos: Demo[] = [
     slug: 'prop-dedup',
     files: propDedup,
     title: 'Shared Props',
-    hook: 'Nine islands, three unique payloads — each set serialized once and referenced via props-ref.',
+    hook: 'How island prop deduplication works — nine islands share three unique payloads, each serialized once and referenced via props-ref.',
     category: 'hydration',
   },
   {
@@ -353,7 +353,7 @@ export const demos: Demo[] = [
     slug: 'props-id',
     files: propsId,
     title: 'Unique IDs',
-    hook: "Svelte's native $props.id() inside islands — SSR-consistent, unique per instance, namespaced in server islands.",
+    hook: "How stable island IDs work — Svelte's native $props.id() gives SSR-consistent, per-instance ids, namespaced inside server islands.",
     category: 'hydration',
   },
   {
@@ -361,7 +361,7 @@ export const demos: Demo[] = [
     slug: 'login',
     files: login,
     title: 'Form Actions',
-    hook: 'A login form rendered twice — plain HTML POST and intercepted with {@attach enhance(...)}.',
+    hook: 'How form actions work — a form rendered twice, as a plain HTML POST and intercepted with {@attach enhance(...)}.',
     category: 'forms',
   },
   {
@@ -369,7 +369,7 @@ export const demos: Demo[] = [
     slug: 'email',
     files: email,
     title: 'Send Email',
-    hook: 'Send a pre-written email through Mochi.email() and read it back in the /_mochi/email dev outbox.',
+    hook: 'How sending email works — dispatch through Mochi.email() and read it back in the /_mochi/email dev outbox.',
     category: 'forms',
   },
   {
@@ -377,7 +377,7 @@ export const demos: Demo[] = [
     slug: 'form-return-data',
     files: formReturnData,
     title: 'Using form return data',
-    hook: 'An action returns data via success({...}); {@attach enhance(...)} updates the UI in place, plain HTML re-renders the page.',
+    hook: 'How form action return data works — an action returns success({...}); {@attach enhance(...)} updates the UI in place, plain HTML re-renders.',
     category: 'forms',
   },
   {
@@ -385,7 +385,7 @@ export const demos: Demo[] = [
     slug: 'form-errors',
     files: formErrors,
     title: 'Form Errors',
-    hook: 'A thrown action error shown inline via {@attach enhance(...)}, or as the Mochi error page on plain submit.',
+    hook: 'How form action errors work — a thrown action error shows inline via {@attach enhance(...)}, or as the Mochi error page on a plain submit.',
     category: 'forms',
   },
   {
@@ -393,7 +393,7 @@ export const demos: Demo[] = [
     slug: 'form-redirects',
     files: formRedirects,
     title: 'Form Redirects',
-    hook: 'redirect(303, …) intercepted as a JSON envelope by {@attach enhance(...)}, or followed natively by the browser.',
+    hook: 'How form action redirects work — redirect(303, …) is intercepted as a JSON envelope by {@attach enhance(...)} or followed natively by the browser.',
     category: 'forms',
   },
   {
@@ -401,7 +401,7 @@ export const demos: Demo[] = [
     slug: 'file-upload',
     files: fileUpload,
     title: 'File Uploads via form actions',
-    hook: 'multipart/form-data submission, validated with fail() and success(), shown enhanced and plain.',
+    hook: 'How file uploads through form actions work — multipart/form-data validated with fail() and success(), shown enhanced and plain.',
     category: 'forms',
   },
   {
@@ -409,7 +409,7 @@ export const demos: Demo[] = [
     slug: 'reload-form-data',
     files: reloadFormData,
     title: 'Reloading associated form data',
-    hook: 'After a successful submit, refetch the related list inside enhance() — or rely on the post-POST re-render.',
+    hook: 'How reloading associated data works — after a successful submit, refetch the related list inside enhance(), or rely on the post-POST re-render.',
     category: 'forms',
   },
   {
@@ -417,7 +417,7 @@ export const demos: Demo[] = [
     slug: 'captcha',
     files: captcha,
     title: 'Captcha',
-    hook: 'Slide-to-verify with a hash chain and proof-of-work — no third party, no tracking.',
+    hook: 'How the captcha works — slide-to-verify backed by a hash chain and proof-of-work, with no third party and no tracking.',
     category: 'forms',
   },
   {
@@ -425,7 +425,7 @@ export const demos: Demo[] = [
     slug: 'captcha-styling',
     files: captchaStyling,
     title: 'Captcha Styling',
-    hook: 'The same captcha four ways — every colour is a CSS custom property with a built-in fallback.',
+    hook: 'How captcha theming works — the same captcha four ways, every colour a CSS custom property with a built-in fallback.',
     category: 'forms',
   },
   {
@@ -433,7 +433,7 @@ export const demos: Demo[] = [
     slug: 'form-cancel',
     files: formCancel,
     title: 'Cancelling form submissions',
-    hook: 'cancel() prevents the fetch from firing; controller.abort() stops one mid-flight.',
+    hook: 'How cancelling form submissions works — cancel() stops the fetch before it fires; controller.abort() stops one mid-flight.',
     category: 'forms',
   },
   {
@@ -441,7 +441,7 @@ export const demos: Demo[] = [
     slug: 'error',
     files: error,
     title: 'Error Handling',
-    hook: 'Catch render errors and unmatched routes via Mochi.serve()’s errorPage option and the handleError hook.',
+    hook: "How error handling works — catch render errors and unmatched routes via Mochi.serve()'s errorPage option and the handleError hook.",
     category: 'errors',
   },
   {
@@ -449,7 +449,7 @@ export const demos: Demo[] = [
     slug: 'error-boundaries',
     files: errorBoundaries,
     title: 'Error Boundaries',
-    hook: 'Contain island failures with <svelte:boundary> so one broken component does not crash the page.',
+    hook: "How error boundaries work — contain island failures with <svelte:boundary> so one broken component doesn't crash the page.",
     category: 'errors',
   },
   {
@@ -475,7 +475,7 @@ export const demos: Demo[] = [
     slug: 'entity-props',
     files: entityProps,
     title: 'HTML Entities in Props',
-    hook: 'HTML entities in a static island prop (label="Tom &amp; Jerry") decode to their characters — identical on the server and after hydration.',
+    hook: 'How HTML entities in island props work — an entity in a static prop (label="Tom &amp; Jerry") decodes identically on the server and after hydration.',
     category: 'hydration',
   },
 ];


### PR DESCRIPTION
## What

Reword every demo `hook:` tagline from **what the demo practically does** to **the concept it teaches** — led by the mechanism and packed with searchable keywords.

Before → after example:

> **Data Loading** — ~~Server-side fetch from PokéAPI cached via MochiCache and rendered at request time.~~ → *How server-side data loading works — fetch on the server, cache with MochiCache, and render at request time.*

## Why

The `hook` field isn't just a card subtitle — it's the text the **demo search** matches against (`packages/site/src/lib/toc.ts`), and it's reused as the section-index and `llms.txt` description (`packages/site/src/lib/docs.ts`). Concept-led, keyword-rich text improves discovery and search.

## Scope

- **`packages/site/src/lib/demos.ts`** — the canonical registry (49 hooks reworded).
- **`packages/docs/*.md`** — the hand-duplicated inline copies inside `<SeeItInAction demos={[…]}>` blocks, kept byte-consistent with the registry.
- **Unchanged:** the three demo-*site* entries (Hacker News, admin panel, Tailwind todo) — whole apps rather than single concepts.

The request-cache demo's own hook is reworded on its feature branch (that demo doesn't exist on `main` yet), so it isn't part of this PR.

## Verification

- `lint:fix` + `format` + `typecheck` pass.
- Docs `<SeeItInAction>` hooks verified byte-identical to their `demos.ts` counterparts.
- SSR spot-check: the reworded hooks render on `/docs/*` "See it in action" cards and the demos index.