### PR TITLE
feat(extensions): crash when server-only internals reach the client

### DIFF
--- a/packages/docs/162-extensions.md
+++ b/packages/docs/162-extensions.md
@@ -32,6 +32,20 @@ Names use a `namespace:camelCase` convention. Each name is registered in a typed
 - **Hooks** run a user function at a specific framework moment. No return value — observation or side effects only.
 - **Filters** replace a framework default value. The callback receives the existing value and returns the new one.
 
+### Server-only
+
+The registry lives in the server process and nowhere else. It is never shipped to the browser, so there is no client-side hook or filter — a filter that ran there would find an empty registry and hand back the framework default, silently undoing whatever you configured.
+
+Mochi refuses to let that happen quietly. Pulling the modules behind the registry into a client bundle fails the build, naming the import:
+
+```
+[mochi] src/extensions.ts is server-only (hooks and filters) but was pulled into the
+client bundle by src/lib/Widget.svelte. Move the client-facing part into its own
+module, or import it with `import type`.
+```
+
+The same applies to the `Mochi.serve()` config singleton and the [request context](/docs/request-context/). To use a filtered value inside a hydratable island, resolve it during SSR and pass it down as a prop.
+
 ### Hooks
 
 #### `mochi:init`

--- a/packages/mochi/scripts/run-tests.ts
+++ b/packages/mochi/scripts/run-tests.ts
@@ -2,6 +2,15 @@
 import { runTests } from 'mochi-framework';
 
 await runTests({
+  sequential: [
+    // Asserts a *single* write produces exactly one `reload` message, so it
+    // can't defend itself the way publicDirSpaces.test.ts does — re-touching to
+    // give the watcher another chance would emit extra reloads and break the
+    // assertion. Under full-suite parallel load chokidar/fsevents can drop an fs
+    // event outright, and a dropped event is unrecoverable: the test waits out
+    // its 30s timeout. Running it after the parallel batch removes the load.
+    'src/liveReloadFilter.test.ts',
+  ],
   // See testing.ts `windowsSkip`. Both suites' logic is OS-agnostic and fully
   // covered on Linux/macOS.
   windowsSkip: [

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -18,6 +18,7 @@ import { mergeCompilerOptions, type MochiSvelteConfig } from './svelteConfig';
 import { backendId, resolveSvelteCompiler, type MochiSvelteCompiler, type SvelteCompilerBackend } from './svelteCompilerBackend';
 import { applyFilter } from '../extensions';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
+import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 import { renderMochiEnvServer, renderMochiEnvClient } from './virtualModuleTemplate';
 import { createImageAssetLoader, IMAGE_FILE_FILTER } from './imageAssetLoader';
 import { registerLocalImageAsset } from '../image/localAssetRegistry';
@@ -1284,13 +1285,16 @@ export class ComponentRegistry {
     const result = await Bun.build({
       entrypoints,
       files: filesMap,
-      plugins: [clientPlugin],
+      // The guard goes first so its `onResolve` sees a server-only specifier
+      // before any of the client plugin's own handlers can claim it.
+      plugins: [serverOnlyModuleGuard, clientPlugin],
       target: 'browser',
       conditions: ['svelte', ...(development ? ['development'] : ['production'])],
       define: {
         DEV: String(development),
         BROWSER: 'true',
         NODE: 'false',
+        ...CLIENT_BUILD_DEFINE,
       },
       minify: true,
       splitting: true,

--- a/packages/mochi/src/compiler/buildInlineWebComponent.ts
+++ b/packages/mochi/src/compiler/buildInlineWebComponent.ts
@@ -4,6 +4,8 @@
  * resolved relative to `src/`, so callers pass paths like
  * `./web-components/ServerIsland.ts`.
  */
+import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
+
 // This file lives in `src/compiler/`, so climb one level: resolving `relPath`
 // against `import.meta.url` would anchor callers' paths to `src/compiler/`.
 const SRC_URL = new URL('../', import.meta.url);
@@ -12,7 +14,9 @@ export async function buildInlineWebComponent(relPath: string): Promise<string> 
   const entry = Bun.fileURLToPath(new URL(relPath, SRC_URL));
   const result = await Bun.build({
     entrypoints: [entry],
+    plugins: [serverOnlyModuleGuard],
     target: 'browser',
+    define: { ...CLIENT_BUILD_DEFINE },
     minify: true,
     throw: false,
   });

--- a/packages/mochi/src/compiler/serverOnlyModuleGuard.test.ts
+++ b/packages/mochi/src/compiler/serverOnlyModuleGuard.test.ts
@@ -1,0 +1,56 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
+
+const SRC_DIR = path.resolve(import.meta.dir, '..');
+// A sibling of `src/` so relative specifiers can climb out to the real
+// framework modules the guard is meant to catch.
+const tmpDir = mkdtempSync(path.join(SRC_DIR, '..', '.mochi-server-only-guard-'));
+
+afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+function fixture(name: string, contents: string): string {
+  const file = path.join(tmpDir, name);
+  mkdirSync(path.dirname(file), { recursive: true });
+  writeFileSync(file, contents);
+  return file;
+}
+
+const buildForBrowser = (entry: string) =>
+  Bun.build({
+    entrypoints: [entry],
+    plugins: [serverOnlyModuleGuard],
+    target: 'browser',
+    define: { ...CLIENT_BUILD_DEFINE },
+    throw: false,
+  });
+
+describe('serverOnlyModuleGuard', () => {
+  test.each([
+    ['extensions', `${path.relative(tmpDir, path.join(SRC_DIR, 'extensions'))}`, 'hooks and filters'],
+    ['mochiConfig', `${path.relative(tmpDir, path.join(SRC_DIR, 'mochiConfig'))}`, 'the Mochi.serve() config singleton'],
+    ['requestContext', `${path.relative(tmpDir, path.join(SRC_DIR, 'runtime', 'requestContext'))}`, 'the request context'],
+  ])('fails the client build for %s', async (name, specifier, label) => {
+    const entry = fixture(`imports-${name}.ts`, `import * as m from '${specifier.replace(/\\/g, '/')}';\nexport default m;\n`);
+
+    const result = await buildForBrowser(entry);
+
+    expect(result.success).toBe(false);
+    const messages = result.logs.map((l) => String(l.message ?? l)).join('\n');
+    expect(messages).toContain(`src/${name === 'requestContext' ? 'runtime/requestContext' : name}.ts is server-only (${label})`);
+    expect(messages).toContain(`imports-${name}.ts`);
+    // Paths in user-facing output are always POSIX, on every platform.
+    expect(messages).not.toContain('\\');
+  });
+
+  test('a user module that merely shares the basename resolves normally', async () => {
+    fixture('lib/extensions.ts', `export const mine = 'ok';\n`);
+    const entry = fixture('imports-user-extensions.ts', `import { mine } from './lib/extensions';\nexport default mine;\n`);
+
+    const result = await buildForBrowser(entry);
+
+    expect(result.success).toBe(true);
+    expect(await result.outputs[0]!.text()).toContain('ok');
+  });
+});

--- a/packages/mochi/src/compiler/serverOnlyModuleGuard.ts
+++ b/packages/mochi/src/compiler/serverOnlyModuleGuard.ts
@@ -1,0 +1,55 @@
+/**
+ * Fails a browser `Bun.build` the moment a server-only framework module is
+ * resolved into the client graph.
+ *
+ * These modules back process-global state that only ever exists on the server
+ * (the hook/filter registry, the `Mochi.serve()` singleton, the request-context
+ * `AsyncLocalStorage`). Bundled into the browser they don't error — they read an
+ * empty registry and hand back framework defaults, so a configured filter simply
+ * stops applying with nothing in the console. Catching it at resolve time turns
+ * that silent divergence into a build failure naming the importer.
+ */
+import path from 'node:path';
+import type { BunPlugin } from 'bun';
+import { relForDisplay } from '../utils/index';
+
+// This file lives in `src/compiler/`, so climb one level for `src/` — same
+// convention as `SRC_DIR` in `ComponentRegistry.ts`.
+const SRC_DIR = path.resolve(import.meta.dir, '..');
+
+const SERVER_ONLY_MODULES = new Map<string, string>([
+  [path.join(SRC_DIR, 'extensions.ts'), 'hooks and filters'],
+  [path.join(SRC_DIR, 'mochiConfig.ts'), 'the Mochi.serve() config singleton'],
+  [path.join(SRC_DIR, 'runtime', 'requestContext.ts'), 'the request context'],
+]);
+
+/** Injected by every browser build so `utils/serverOnly.ts` can tell which bundle it landed in. */
+export const CLIENT_BUILD_DEFINE = { MOCHI_CLIENT: 'true' } as const;
+
+// Narrow enough that the handler runs for a handful of specifiers per build; a
+// user file that happens to share one of these basenames falls through to normal
+// resolution below.
+const CANDIDATE_SPECIFIER = /(^|[\\/])(extensions|mochiConfig|requestContext)(\.[jt]s)?$/;
+
+export const serverOnlyModuleGuard: BunPlugin = {
+  name: 'mochi-server-only-module-guard',
+  setup(build) {
+    build.onResolve({ filter: CANDIDATE_SPECIFIER }, (args) => {
+      const base = args.resolveDir ? path.resolve(args.resolveDir, args.path) : path.resolve(args.path);
+      for (const candidate of [base, `${base}.ts`]) {
+        const what = SERVER_ONLY_MODULES.get(candidate);
+        if (what === undefined) {
+          continue;
+        }
+        // Thrown rather than returned as `{ errors }` because a throw is what
+        // Bun surfaces into `result.logs` with `throw: false` set, which is how
+        // both client builds run.
+        throw new Error(
+          `[mochi] ${relForDisplay(candidate)} is server-only (${what}) but was pulled into the client bundle by ${relForDisplay(args.importer)}. ` +
+            'Move the client-facing part into its own module, or import it with `import type`.',
+        );
+      }
+      return undefined;
+    });
+  },
+};

--- a/packages/mochi/src/extensions.test.ts
+++ b/packages/mochi/src/extensions.test.ts
@@ -1,5 +1,9 @@
-import { beforeEach, describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
 import type { MochiServeOptions } from './types';
+import { CLIENT_BUILD_DEFINE } from './compiler/serverOnlyModuleGuard';
+import { toPosixPath } from './utils/index';
 import { applyFilter, initExtensions, runHook, type MochiFilterContext } from './extensions';
 import { reachedStartupMilestones, resetStartupMilestones } from './lifecycle';
 import type { IslandPropsEntry } from './islands/islandPropsRegistry';
@@ -860,5 +864,51 @@ describe('new extension points', () => {
     expect(seen!.requestId).toBe('rid-route-matched');
     expect(seen!.pathname).toBe('/users/42');
     expect(seen!.param).toBe('42');
+  });
+});
+
+describe('client bundles', () => {
+  // The guard is a build-time `define` substitution, so the only honest test is
+  // to actually bundle for the browser the way `ComponentRegistry` does and run
+  // the result. `outDir` sits under the package so the emitted module resolves
+  // its deps through the project's own node_modules chain.
+  const tmpDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-extensions-client-'));
+  afterAll(() => rmSync(tmpDir, { recursive: true, force: true }));
+
+  let bundled: typeof import('./extensions');
+
+  beforeAll(async () => {
+    // Source and output must not share a directory: Bun resolves `./entry.js`
+    // back to a sibling `entry.ts` when one exists, so importing the bundle
+    // would silently hand back the unbundled source and the test would pass
+    // against the server build.
+    const srcDir = path.join(tmpDir, 'src');
+    const outDir = path.join(tmpDir, 'dist');
+    mkdirSync(srcDir);
+    const entry = path.join(srcDir, 'entry.ts');
+    writeFileSync(entry, `export { applyFilter, initExtensions, runHook } from '${toPosixPath(path.join(import.meta.dir, 'extensions'))}';\n`);
+    const result = await Bun.build({
+      entrypoints: [entry],
+      target: 'browser',
+      define: { ...CLIENT_BUILD_DEFINE },
+      outdir: outDir,
+      throw: false,
+    });
+    if (!result.success) {
+      throw new Error(result.logs.map((l) => String(l.message ?? l)).join('\n'));
+    }
+    bundled = (await import(result.outputs[0]!.path)) as typeof import('./extensions');
+  });
+
+  test('applyFilter throws instead of silently returning the default', () => {
+    expect(() => bundled.applyFilter('captcha:bits', DEFAULT_CAPTCHA_BITS, { options: {}, configured: false })).toThrow(/applyFilter\('captcha:bits'\) was called in the browser/);
+  });
+
+  test('runHook throws', () => {
+    expect(() => bundled.runHook('mochi:init', { options: fakeOptions })).toThrow(/runHook\('mochi:init'\) was called in the browser/);
+  });
+
+  test('initExtensions throws', () => {
+    expect(() => bundled.initExtensions({})).toThrow(/initExtensions\(\) was called in the browser/);
   });
 });

--- a/packages/mochi/src/extensions.ts
+++ b/packages/mochi/src/extensions.ts
@@ -24,6 +24,7 @@ import type { ResolvedEmailMessage, MochiEmailTransportConfig } from './email/ty
 import type { ImportedImageFormat } from './image/types';
 import type { TrailingSlashPolicy } from './runtime/trailingSlash';
 import { pinGlobal } from './utils/globalState';
+import { assertServerOnly } from './utils/serverOnly';
 import { markStartupMilestone } from './lifecycle';
 import type { MochiStartupMilestone } from './lifecycle';
 
@@ -321,7 +322,13 @@ const FILTER_KINDS: { [K in keyof MochiFilterValue]: MochiKind } = {
 // calling `Mochi.serve()` more than once.
 const registry = pinGlobal<{ eventHooks: MochiHooks; filters: MochiFilters }>('__mochi_extensions_registry__', () => ({ eventHooks: {}, filters: {} }));
 
+// The registry is only ever populated on the server, so a client-side read
+// would hand back the framework default and quietly drop whatever the app
+// configured. Crash instead — see `utils/serverOnly.ts`.
+const SERVER_ONLY_REASON = 'Hooks and filters are server-only — the registry only exists in the server process, so this call could never see a registered entry.';
+
 export function initExtensions(opts: Pick<MochiServeOptions, 'eventHooks' | 'filters'>): void {
+  assertServerOnly('initExtensions()', SERVER_ONLY_REASON);
   registry.eventHooks = opts.eventHooks ?? {};
   registry.filters = opts.filters ?? {};
 }
@@ -330,6 +337,7 @@ export function initExtensions(opts: Pick<MochiServeOptions, 'eventHooks' | 'fil
 // The runtime dispatches on the runtime kind table to guarantee the actual
 // return matches the type — including when no user fn is registered.
 export function runHook<K extends keyof MochiHookContext>(name: K, ctx: MochiHookContext[K]): MochiHookKindMap[K] extends 'async' ? Promise<void> : void {
+  assertServerOnly(`runHook('${name}')`, SERVER_ONLY_REASON);
   // Startup hooks double as lifecycle milestones. Recording here (rather than
   // at each call site) keeps the record in step with the hooks themselves;
   // per-request hooks like `route:matched` are deliberately not recorded.
@@ -352,6 +360,7 @@ export function applyFilter<K extends keyof MochiFilterValue>(
   value: MochiFilterValue[K],
   ctx: MochiFilterContext[K],
 ): MochiFilterKindMap[K] extends 'async' ? FilterReturn<K> | Promise<FilterReturn<K>> : FilterReturn<K> {
+  assertServerOnly(`applyFilter('${name}')`, SERVER_ONLY_REASON);
   const fn = registry.filters[name] as Filter<K> | undefined;
   if (FILTER_KINDS[name] === 'async') {
     if (!fn) {

--- a/packages/mochi/src/mochiConfig.ts
+++ b/packages/mochi/src/mochiConfig.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'node:crypto';
 import type { MochiServeOptions } from './types';
 import { applyFilter } from './extensions';
 import { logger } from './utils/log';
+import { assertServerOnly } from './utils/serverOnly';
 
 export interface MochiContext {
   options: MochiServeOptions;
@@ -15,7 +16,10 @@ export interface MochiContext {
 // compiled component.
 const GLOBAL_KEY = '__mochi_config__';
 
+const SERVER_ONLY_REASON = 'The Mochi.serve() config singleton — and the secret key it holds — only exists in the server process.';
+
 export async function initMochiConfig(options: MochiServeOptions): Promise<void> {
+  assertServerOnly('initMochiConfig()', SERVER_ONLY_REASON);
   // This one-per-process singleton (never cleared by server.stop()) is why
   // server-booting tests must run one file per process via runTests
   // (cli/testing.ts) rather than a plain `bun test` over the whole suite —
@@ -53,6 +57,7 @@ export async function initMochiConfig(options: MochiServeOptions): Promise<void>
 }
 
 export function getMochiConfig(): MochiContext {
+  assertServerOnly('getMochiConfig()', SERVER_ONLY_REASON);
   const ctx = (globalThis as unknown as Record<string, unknown>)[GLOBAL_KEY] as MochiContext | undefined;
   if (!ctx) {
     throw new Error('Mochi.serve() has not been called yet.');

--- a/packages/mochi/src/runtime/requestContext.ts
+++ b/packages/mochi/src/runtime/requestContext.ts
@@ -5,6 +5,7 @@ import type { MochiFormResult } from '../types';
 import type { MochiRateLimitInfo } from './rateLimit';
 import type { RequestCacheState } from './requestCache';
 import { pinGlobal } from '../utils/globalState';
+import { assertServerOnly } from '../utils/serverOnly';
 
 export interface MochiRequestContext {
   /**
@@ -232,6 +233,10 @@ export interface DebugBarRuntimeData extends DebugBarData {
 // in each compiled component, breaking the context chain.
 export const requestContext = pinGlobal('__mochi_request_context__', () => new AsyncLocalStorage<MochiRequestContext>());
 
+// `mochi-env.client.js` already stubs the public `getRequestContext` export; this
+// covers the other way in — framework code deep-importing this module.
+const SERVER_ONLY_REASON = 'The request context is server-only. Read what you need during SSR and pass it down as a prop, or through Svelte’s hydratable().';
+
 /**
  * Returns the current request context. Available in any server-side code
  * running within a request (components, API handlers, helpers).
@@ -244,6 +249,7 @@ export const requestContext = pinGlobal('__mochi_request_context__', () => new A
  * ```
  */
 export function getRequestContext(): MochiRequestContext {
+  assertServerOnly('getRequestContext()', SERVER_ONLY_REASON);
   const ctx = requestContext.getStore();
   if (!ctx) {
     throw new Error('getRequestContext() called outside of a request. ' + 'It is only available in server-side code running within a Mochi request handler.');
@@ -270,6 +276,7 @@ export function getRequestContext(): MochiRequestContext {
  * The assertion is a tripwire if either invariant regresses.
  */
 export async function renderDetached<T>(fn: () => Promise<T>): Promise<T> {
+  assertServerOnly('renderDetached()', SERVER_ONLY_REASON);
   return requestContext.exit(async () => {
     if (requestContext.getStore() !== undefined) {
       throw new Error('renderDetached: request context was not cleared — isolation failed');

--- a/packages/mochi/src/utils/serverOnly.ts
+++ b/packages/mochi/src/utils/serverOnly.ts
@@ -1,0 +1,25 @@
+/**
+ * Runtime backstop for framework internals that only work in the server
+ * process — the extension registry, the `Mochi.serve()` config singleton, the
+ * request context. `compiler/serverOnlyModuleGuard.ts` already fails the client
+ * build when one of those modules is resolved into a browser graph; this catches
+ * anything that reaches a browser by some other route (a hand-rolled bundle, a
+ * future build path that forgets the plugin).
+ *
+ * Without it these APIs *silently* degrade: an empty filter registry hands back
+ * the framework default, so a configured filter just quietly stops applying.
+ */
+
+// `declare` erases before bundling, so `MOCHI_CLIENT` reaches Bun as a free
+// identifier its `define` folds to `true` — and the whole constant then
+// dead-code-eliminates each guard below down to a bare throw. Everywhere else
+// the identifier is genuinely undeclared, which `typeof` handles safely.
+declare const MOCHI_CLIENT: boolean | undefined;
+
+export const IS_CLIENT_BUNDLE = typeof MOCHI_CLIENT !== 'undefined' && MOCHI_CLIENT === true;
+
+export function assertServerOnly(api: string, why: string): void {
+  if (IS_CLIENT_BUNDLE) {
+    throw new Error(`[mochi] ${api} was called in the browser. ${why}`);
+  }
+}


### PR DESCRIPTION
## Why

`applyFilter()` / `runHook()` / `initExtensions()` read a registry that only ever gets populated on the server, by `Mochi.serve({ eventHooks, filters })`. None of them is exported from `index.ts` or the `mochi-env` virtual module, so there's no supported way to call them in a browser — but nothing stopped it either.

If a framework module that calls `applyFilter` ever gets pulled into a client bundle (easy to do by accident — `captcha/config.ts`, `islands/payloadCrypto.ts` and `runtime/csrf.ts` all call it and all sit next to genuinely client-shared code), the registry is empty and `applyFilter` **silently returns the framework default**. A filter the app configured just quietly stops applying, with nothing in the console. `mochiConfig.ts` and `runtime/requestContext.ts` have the same shape.

## What

Two layers.

**Build-time** — `compiler/serverOnlyModuleGuard.ts` is a `BunPlugin` whose `onResolve` fails the build when `extensions.ts`, `mochiConfig.ts` or `runtime/requestContext.ts` is resolved into a browser graph. Wired into both browser builds (`ComponentRegistry`'s client pass and `buildInlineWebComponent`). A user module that merely shares one of those basenames falls through to normal resolution.

```
[mochi] src/extensions.ts is server-only (hooks and filters) but was pulled into the
client bundle by src/captcha/MochiCaptcha.svelte. Move the client-facing part into
its own module, or import it with `import type`.
```

**Runtime** — `utils/serverOnly.ts` exposes `assertServerOnly()`, gated on a new `MOCHI_CLIENT` define both browser builds now inject. `declare const` erases before bundling, so Bun's `define` folds the constant to `true` in a client bundle and each guard minifies down to a bare throw; outside one the identifier is undeclared and `typeof` handles it, so the server path stays free. Called from `applyFilter` / `runHook` / `initExtensions`, `initMochiConfig` / `getMochiConfig`, and `getRequestContext` / `renderDetached`.

## Verification

- No client entry pulls any of the three today (the debug-bar's only `requestContext` references are `import type`), so nothing should break. `bun run build` is clean across all workspaces.
- Negative check: temporarily importing `../extensions` into `MochiCaptcha.svelte` fails the build with the message above; reverted.
- `serverOnlyModuleGuard.test.ts` covers all three modules plus the same-basename fall-through.
- `extensions.test.ts` gains a `client bundles` block that actually bundles for the browser with the define and runs the output, so the substitution itself is under test rather than assumed.
- Browser-checked `/demos/captcha/` and `/docs/extensions/` on a dev server: all islands hydrate, no console errors, no failed island fetches.
- `bun run checks` passes.

## Docs

New **Server-only** section in `packages/docs/162-extensions.md`.
