### PR TITLE
feat: warn at boot when publicDir was non-empty at build time but empty at serve

### DIFF
--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -37,7 +37,7 @@ Mochi.serve({ manifest: '/srv/app/build/manifest.json' });
 Four things still anchor a prebuilt app to its project:
 
 - **Build and serve from the same working directory.** Components are keyed relative to the project root, which both `mochi-framework build` and `Mochi.serve()` take to be the current working directory — so run both from the project root. How a route spells its component (`'./src/Site.svelte'` or an absolute path) doesn't have to match. A component the manifest doesn't cover is compiled from source instead, and says so loudly at startup.
-- **Ship your `public/` directory.** Static files are never copied into the build — the runtime scans `publicDir` (default `./public`) at startup, in production exactly as in development. A deploy that ships only `.mochi/` and `src/` 404s every static file. In exchange, swapping a `robots.txt` needs a restart, not a rebuild.
+- **Ship your `public/` directory.** Static files are never copied into the build — the runtime scans `publicDir` (default `./public`) at startup, in production exactly as in development. A deploy that ships only `.mochi/` and `src/` 404s every static file; the build records how many files it saw, so a server that boots with none of them warns rather than failing silently. In exchange, swapping a `robots.txt` needs a restart, not a rebuild.
 - **Keep the out-dir in the project tree.** The compiled SSR modules resolve `node_modules` from the out-dir's location.
 - **On-demand server islands need sources.** Islands missing from the manifest are compiled at request time from source paths recorded at build. Prebuilt islands — the normal case — don't, and relocate fine.
 

--- a/packages/docs/185-docker.md
+++ b/packages/docs/185-docker.md
@@ -52,7 +52,12 @@ node_modules
 .env*
 ```
 
-Don't add `public` to that list. Unlike `.mochi`, it isn't regenerated inside the image — the runtime reads it from disk on every boot.
+Don't add `public` to that list. Unlike `.mochi`, it isn't regenerated inside the image — the runtime reads it from disk on every boot. If it doesn't make it in, the server says so at startup instead of quietly 404ing:
+
+```
+[mochi] publicDir "public" is missing or empty, but the build found 12 file(s) there —
+every static file will 404.
+```
 
 ### `--production` and devDeps
 

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -40,7 +40,7 @@ import { applyFilter, initExtensions, runHook } from './extensions';
 import { escapeHtmlAttr } from './utils/htmlEscape';
 import { buildPublicUrl } from './runtime/proxy';
 import { realpath } from 'node:fs/promises';
-import { apiError, collectHeaderPairs, cssLinkTag, headResponse, isHtmlResponse, MochiHttpError, toPosixPath, withHead } from './utils';
+import { apiError, collectHeaderPairs, cssLinkTag, headResponse, isHtmlResponse, MochiHttpError, relForDisplay, toPosixPath, withHead } from './utils';
 import type { MochiEvent, MochiEventKind, MochiResolveOptions } from './runtime/hooks';
 import { applyResolveOptions } from './runtime/hooks';
 import { alternateSlashPattern, trailingSlashRedirect } from './runtime/trailingSlash';
@@ -1575,6 +1575,19 @@ export class Mochi {
     // route is only added when no user route claims the path. The dev-watcher
     // reload rebuilds these the same way via the same helpers.
     const initialPublicFiles = await resolvePublicFiles({ publicDir, development });
+    // Since the build copies nothing, a deploy that ships the build output and
+    // forgets publicDir looks identical on disk to an app that never had static
+    // files — except to the build-time count, the only witness they existed.
+    // Warn rather than throw: dropping the directory on purpose is legitimate,
+    // and static files are not worth refusing to boot over.
+    if (!development && registry.loadedFromManifest && registry.publicFileCountAtBuild > 0 && initialPublicFiles.size === 0) {
+      logger.warn(
+        `publicDir "${relForDisplay(publicDir)}" is missing or empty, but the build found ${registry.publicFileCountAtBuild} file(s) there — every static file will 404. ` +
+          `The build never copies publicDir; the runtime reads it on every boot, so that directory has to ship with your deploy ` +
+          `(in Docker, a COPY for it in the final stage — and check .dockerignore). ` +
+          `If it moved, point \`publicDir\` at the new location; if the files are gone on purpose, re-run \`mochi-framework build\` to clear this.`,
+      );
+    }
     registerPublicRoutes(bunRoutes, initialPublicFiles);
 
     const userFetch = options.fetch;

--- a/packages/mochi/src/cli/build.ts
+++ b/packages/mochi/src/cli/build.ts
@@ -276,6 +276,10 @@ export async function build(options: MochiBuildOptions): Promise<void> {
     // Write manifest
     const manifestPath = path.join(outDir, 'manifest.json');
     const manifest = registry.toManifest();
+    // Recorded here rather than in toManifest() because the registry no longer
+    // holds public files at all — this is the build's own count, and the only
+    // evidence at boot that static files existed when the build ran.
+    manifest.publicFileCount = publicFileCount;
     await Bun.write(manifestPath, JSON.stringify(manifest, null, 2));
 
     const clientFileCount = Object.keys(manifest.clientFiles).length;

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -463,6 +463,8 @@ export class ComponentRegistry {
   readonly development: boolean;
   /** Set by `fromManifest()`; distinguishes a prebuilt-manifest boot from a live, compile-on-demand one. */
   loadedFromManifest = false;
+  /** Files `publicDir` held when this manifest was built; see `MochiManifest.publicFileCount`. 0 when not loaded from one. */
+  publicFileCountAtBuild = 0;
   readonly debugBarEnabled: boolean;
   readonly outDir: string;
   readonly assetPrefix: string;
@@ -2231,6 +2233,7 @@ export class ComponentRegistry {
       assetPrefix: manifest.assetPrefix,
     });
     registry.loadedFromManifest = true;
+    registry.publicFileCountAtBuild = manifest.publicFileCount ?? 0;
 
     registry.islandBootstrapUrl = manifest.bootstrapUrl;
     registry.clientStats = manifest.stats;

--- a/packages/mochi/src/runtime/publicDirMissingWarning.test.ts
+++ b/packages/mochi/src/runtime/publicDirMissingWarning.test.ts
@@ -1,0 +1,76 @@
+// The build copies no static files, so on disk a deploy that shipped `public/`
+// and one that forgot it are indistinguishable — the shape a Docker final stage
+// hits when it copies `.mochi/` and `src/` selectively. The manifest's
+// build-time count is the only witness the files ever existed; this is the boot
+// check that reads it. Its own Mochi.serve() file because only one is allowed
+// per process (see publicDirProduction.test.ts for the healthy-boot side).
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { build } from '../cli/build';
+import { Mochi } from '../Mochi';
+import { logger } from '../utils/log';
+import type { MochiManifest } from '../types';
+
+const RM_OPTS = { recursive: true, force: true, maxRetries: 5, retryDelay: 100 } as const;
+
+const tempDir = (prefix: string) => mkdtempSync(path.join(import.meta.dir, '..', '..', prefix));
+
+describe('a deploy that left publicDir behind warns at boot', () => {
+  const routes = { '/ping': Mochi.api(() => new Response('pong')) };
+  let publicDir: string;
+  let outDir: string;
+  let manifest: MochiManifest;
+  let server: Server<undefined> | undefined;
+  let warnings: string[];
+
+  beforeAll(async () => {
+    publicDir = tempDir('.mochi-public-missing-src-');
+    outDir = tempDir('.mochi-public-missing-out-');
+    writeFileSync(path.join(publicDir, 'robots.txt'), 'User-agent: *\nDisallow:\n');
+    writeFileSync(path.join(publicDir, 'favicon.ico'), 'x');
+
+    await build({ routes, development: false, outDir, publicDir });
+    manifest = JSON.parse(await Bun.file(path.join(outDir, 'manifest.json')).text());
+
+    // The deploy: the build output travels, the static files don't. Removing the
+    // directory outright rather than emptying it is the truer reproduction — a
+    // Dockerfile that never COPYs it leaves nothing behind, not an empty dir.
+    rmSync(publicDir, RM_OPTS);
+
+    warnings = [];
+    const originalWarn = logger.warn;
+    logger.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    };
+    try {
+      server = await Mochi.serve({ port: 0, development: false, warmup: false, logger: { enabled: false }, outDir, publicDir, routes });
+    } finally {
+      logger.warn = originalWarn;
+    }
+  });
+
+  afterAll(() => {
+    server?.stop(true);
+    rmSync(publicDir, RM_OPTS);
+    rmSync(outDir, RM_OPTS);
+  });
+
+  test('the build records how many static files it saw', () => {
+    expect(manifest.publicFileCount).toBe(2);
+  });
+
+  test('boot warns once, with the count and something to do about it', () => {
+    const hits = warnings.filter((w) => w.includes('every static file will 404'));
+    expect(hits).toHaveLength(1);
+    expect(hits[0]).toContain('2 file(s)');
+    expect(hits[0]).toContain('COPY');
+  });
+
+  test('it warns rather than refusing to boot', async () => {
+    const res = await fetch(`http://localhost:${server!.port}/ping`);
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe('pong');
+  });
+});

--- a/packages/mochi/src/runtime/publicDirProduction.test.ts
+++ b/packages/mochi/src/runtime/publicDirProduction.test.ts
@@ -8,6 +8,7 @@ import path from 'node:path';
 import type { Server } from 'bun';
 import { build } from '../cli/build';
 import { Mochi } from '../Mochi';
+import { logger } from '../utils/log';
 import type { MochiManifest } from '../types';
 
 const RM_OPTS = { recursive: true, force: true, maxRetries: 5, retryDelay: 100 } as const;
@@ -22,6 +23,7 @@ describe('production serves static files from publicDir', () => {
   let outDir: string;
   let manifest: MochiManifest;
   let server: Server<undefined> | undefined;
+  let warnings: string[];
 
   beforeAll(async () => {
     publicDir = tempDir('.mochi-public-prod-src-');
@@ -39,7 +41,16 @@ describe('production serves static files from publicDir', () => {
     writeFileSync(path.join(publicDir, 'late.txt'), LATE_TXT);
     writeFileSync(path.join(publicDir, 'shadowed.txt'), 'FROM_THE_FILE');
 
-    server = await Mochi.serve({ port: 0, development: false, warmup: false, logger: { enabled: false }, outDir, publicDir, routes });
+    warnings = [];
+    const originalWarn = logger.warn;
+    logger.warn = (...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    };
+    try {
+      server = await Mochi.serve({ port: 0, development: false, warmup: false, logger: { enabled: false }, outDir, publicDir, routes });
+    } finally {
+      logger.warn = originalWarn;
+    }
   });
 
   afterAll(() => {
@@ -51,6 +62,14 @@ describe('production serves static files from publicDir', () => {
   test('the build copies nothing and names no static file in the manifest', () => {
     expect(existsSync(path.join(outDir, 'public'))).toBe(false);
     expect(Object.keys(manifest)).not.toContain('publicFiles');
+    // A count, not a list — enough for the missing-publicDir check at boot.
+    expect(manifest.publicFileCount).toBe(1);
+  });
+
+  test('a publicDir that did ship draws no warning', () => {
+    // The other half of publicDirMissingWarning.test.ts: the check has to stay
+    // silent on a healthy boot, or it trains people to ignore it.
+    expect(warnings.filter((w) => w.includes('every static file will 404'))).toEqual([]);
   });
 
   test('a file present at build time serves', async () => {

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -372,7 +372,7 @@ export interface MochiManifestComponent {
 export interface MochiManifest {
   /**
    * Schema version of the on-disk build output. The runtime loads only the exact
-   * version it writes (currently 3) and throws on anything else — build and serve
+   * version it writes (currently 2) and throws on anything else — build and serve
    * with the same `mochi-framework` version. Typed as `number` rather than a
    * literal because it is parsed from JSON any version may have written; the
    * check is what narrows it.
@@ -395,7 +395,7 @@ export interface MochiManifest {
    *
    * Static files are deliberately not a family here: the build never copies
    * `publicDir`, so the runtime scans it at startup in every mode and a manifest
-   * never names one.
+   * never names one — only counts them, see `publicFileCount`.
    */
   version: number;
   /** URL prefix under which framework client assets and the server island endpoint are served. */
@@ -433,6 +433,14 @@ export interface MochiManifest {
    * at startup.
    */
   serverIslandScript?: string;
+  /**
+   * How many files `publicDir` held at build time. A count, not a path family —
+   * nothing resolves it, and it stays machine-independent. It exists because the
+   * build copies no static files: nothing in the out-dir would otherwise reveal a
+   * deploy that shipped the build output and left `publicDir` behind, so
+   * `Mochi.serve()` compares this against its own startup scan.
+   */
+  publicFileCount?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #170 (relocatable build output / manifest v2). These changes were left uncommitted in the `feat/relocatable-manifest` worktree after that PR merged.

- The build never copies `publicDir`; the runtime scans it fresh on every boot. On disk, a deploy that shipped `public/` and one that forgot it are indistinguishable — so the build now records how many files it saw (`manifest.publicFileCount`), and the runtime compares that against its own startup scan.
- When the build recorded files but none show up at boot, `Mochi.serve()` now warns (with the file count and a suggestion) instead of silently 404ing every static asset.
- Docs (`184-deployment.md`, `185-docker.md`) updated to mention the new warning.
- Fixes a stale manifest version docstring in `types.ts` (said "currently 3"; the actual constant is 2).

## Test plan

- [x] `bun run checks` (lint:fix + format + typecheck + test) passes across all workspaces
- [x] New test `publicDirMissingWarning.test.ts`: build records file count, boot warns once with count + remediation hint, server still boots (200 on other routes)
- [x] Updated `publicDirProduction.test.ts`: healthy boot (files present) draws no warning, manifest records the count