### PR TITLE
ci: serialize CapRover deploys within and across runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,19 @@ permissions:
   contents: read
   packages: write
 
+# max-parallel below only orders legs *within* one run, so two merges landing
+# back-to-back would otherwise deploy on top of each other. This queues whole
+# runs per branch instead: run 2 stays pending until run 1 is completely done.
+# It also keeps the :main tag honest — nothing can overwrite the image between
+# run 1's push and run 1's deploy, because run 2 hasn't started building yet.
+#
+# cancel-in-progress: false is the entire point; don't flip it. Note that only
+# one run can sit pending per group, so a third merge arriving while run 2 is
+# still queued cancels run 2 — the newest commit supersedes it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -186,6 +199,37 @@ jobs:
         run: |
           printf '%s\n' "${{ steps.meta.outputs.tags }}" | xargs -n1 docker push
 
+  # Deploys are serialized (max-parallel: 1) because the CapRover server
+  # reconciles one app at a time — concurrent deploys contend for it. Builds
+  # above stay fully parallel; only this job is one-at-a-time. fail-fast stays
+  # off so a hiccup on one app still lets the others deploy: their images are
+  # already built, smoke-tested and pushed by the time we get here.
+  #
+  # The matrix here only carries the deploy targets. Keep the three entries in
+  # sync with the build matrix above when adding/renaming an app.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        include:
+          - name: site
+            image: ghcr.io/khromov/mochi
+            caprover_app: mochi
+            caprover_token_secret: APP_TOKEN_S1
+          - name: demos
+            image: ghcr.io/khromov/mochi-demos
+            caprover_app: mochi-demos
+            caprover_token_secret: APP_TOKEN_DEMOS_S1
+          - name: support
+            image: ghcr.io/khromov/mochi-support
+            caprover_app: mochi-support
+            caprover_token_secret: APP_TOKEN_SUPPORT_S1
+
+    steps:
       - name: Deploy on CapRover
         uses: caprover/deploy-from-github@v1.2.0
         with:


### PR DESCRIPTION
## What

`Deploy on CapRover` could run three-wide inside a single run, and nothing at all stopped two runs from deploying simultaneously when merges landed back-to-back. Now deploys are serialized on both axes.

## How

**Within a run** — `Deploy on CapRover` moves out of the build matrix into its own `deploy` job with `max-parallel: 1`, so one app deploys at a time. `needs: build` means every image is built, smoke-tested and pushed before any deploy starts. Builds stay fully parallel; only this job is one-at-a-time. `fail-fast: false` so a hiccup on one app still lets the others deploy — their images are already pushed by then.

The deploy matrix carries only the three deploy targets (`image`, `caprover_app`, `caprover_token_secret`). These duplicate fields from the build matrix and must be kept in sync when adding or renaming an app; there's a comment on the job saying so. Single-sourcing them would mean a `setup` job emitting the matrix as JSON, which costs the inline comments the build matrix currently carries.

**Across runs** — workflow-level `concurrency` keyed on `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: false` queues whole runs per branch, so run 2 stays pending until run 1 is completely done.

That also closes a pre-existing tag race. Both runs push the same `:main` tag and CapRover deploys `<image>:main`, so run 2's push could overwrite the tag between run 1's push and run 1's deploy — run 1 would "deploy" run 2's image. With whole-run queuing, run 2 hasn't started building when run 1 deploys.

## Trade-offs

- **Gates on completion, not success.** If run 1 goes red, run 2 still deploys once it stops waiting. There's no native Actions primitive for "previous run on this branch must be green" — it takes a step querying the API for the prior run's conclusion, which would freeze all deploys until someone fixes a red `main`. Left out deliberately; easy to add if that's wanted.
- **The whole run queues, builds included**, so run 2 gets no CI feedback until run 1 finishes.
- **Only one run pends per concurrency group.** A third merge arriving while run 2 is still queued cancels run 2, so that commit never builds at its exact SHA (its code is still built as part of the next commit). The alternative — job-level `concurrency` on `deploy` only, so every commit always builds — reopens the `:main` overwrite race above, so it wasn't chosen.

## Tests

None — CI config isn't unit-testable here. Verified by parsing the YAML: two jobs, `deploy` has `needs: build` + `max-parallel: 1`, workflow `concurrency` has `cancel-in-progress: false`, and the deploy matrix's `image` / `caprover_app` / `caprover_token_secret` match the build matrix leg-for-leg. `prettier --check` clean. The real validation is this PR's own run plus the first push to `main`.
