### PR TITLE
feat(site): render the changelog as a page at /docs/changelog/

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -187,6 +187,7 @@
         "@lucide/svelte": "^1.25.0",
         "@tmcp/adapter-valibot": "0.1.6",
         "@tmcp/transport-http": "0.8.6",
+        "hast-util-to-html": "^9.0.5",
         "mdsvex": "^0.12.8",
         "mochi-framework": "workspace:*",
         "mochi-shared": "workspace:*",
@@ -466,7 +467,7 @@
 
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
-    "@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+    "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
 
@@ -1402,19 +1403,15 @@
 
     "@tmcp/adapter-valibot/valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 
-    "@types/hast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
-    "@types/mdast/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "chrome-remote-interface/commander": ["commander@2.11.0", "", {}, "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="],
 
     "happy-dom/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
-    "hast-util-to-html/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
-
     "mdast-util-to-hast/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
+
+    "mdsvex/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
@@ -1442,21 +1439,21 @@
 
     "tmcp/valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
 
-    "unist-util-position/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+    "unist-util-stringify-position/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "vfile/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+    "unist-util-visit/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "unist-util-visit-parents/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "vfile/vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
-    "woff2sfnt-sfnt2woff/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+    "vfile-message/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "mdast-util-to-hast/unist-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+    "woff2sfnt-sfnt2woff/pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
     "mdast-util-to-hast/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 
     "mdast-util-to-hast/unist-util-visit/unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
-
-    "rehype-slug/unist-util-visit/@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "rehype-slug/unist-util-visit/unist-util-is": ["unist-util-is@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g=="],
 

--- a/packages/docs/190-docs-for-llms.md
+++ b/packages/docs/190-docs-for-llms.md
@@ -165,7 +165,7 @@ Each individual doc is reachable as plain text at `/docs/<slug>/llms.txt`:
 
 The "Copy as llms.txt" button on each doc page emits just that page — use it to give the model focused context without the rest of the framework.
 
-The changelog is served the same way at [`/docs/changelog/llms.txt`](/docs/changelog/llms.txt) — the record of what changed in each `mochi-framework` version. It's fetched from GitHub, so it returns `503` (not `404`) if that fetch is ever unavailable.
+The changelog is served the same way at [`/docs/changelog/llms.txt`](/docs/changelog/llms.txt) — the record of what changed in each `mochi-framework` version, also readable as a page at [`/docs/changelog/`](/docs/changelog/). It's fetched from GitHub, so both return `503` (not `404`) if that fetch is ever unavailable.
 
 #### Per-post text
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -21,6 +21,7 @@
     "@lucide/svelte": "^1.25.0",
     "@tmcp/adapter-valibot": "0.1.6",
     "@tmcp/transport-http": "0.8.6",
+    "hast-util-to-html": "^9.0.5",
     "mdsvex": "^0.12.8",
     "mochi-framework": "workspace:*",
     "mochi-shared": "workspace:*",

--- a/packages/site/src/Docs.svelte
+++ b/packages/site/src/Docs.svelte
@@ -14,6 +14,7 @@
     description,
     docsNav,
     toc,
+    html,
     prev,
     next,
   }: {
@@ -22,6 +23,8 @@
     description?: string;
     docsNav: TocEntry[];
     toc: TocEntry[];
+    /** Pre-rendered markup for synthetic docs (the changelog) that have no barrel component. */
+    html?: string;
     prev: DocNeighbor | null;
     next: DocNeighbor | null;
   } = $props();
@@ -55,6 +58,9 @@
       <DocsToc {toc} />
       {#if DocComponent}
         <DocComponent />
+      {:else if html}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -- first-party markdown (our own CHANGELOG.md), rendered server-side -->
+        {@html html}
       {:else}
         <p>Doc not found.</p>
       {/if}

--- a/packages/site/src/components/MobileNav.svelte
+++ b/packages/site/src/components/MobileNav.svelte
@@ -98,6 +98,9 @@
         <li class="toc-item level-2">
           <a href="/support/" onclick={close}>Support</a>
         </li>
+        <li class="toc-item level-2">
+          <a href="/docs/changelog/" onclick={close}>Changelog</a>
+        </li>
       </ul>
 
       {#if filteredDocs.length > 0}

--- a/packages/site/src/components/Sidebar.svelte
+++ b/packages/site/src/components/Sidebar.svelte
@@ -135,6 +135,9 @@
       <li class="toc-item level-2">
         <a href="/support/">Support</a>
       </li>
+      <li class="toc-item level-2">
+        <a href="/docs/changelog/">Changelog</a>
+      </li>
     </ul>
 
     {#if filteredDocs.length > 0}

--- a/packages/site/src/demoLlms.test.ts
+++ b/packages/site/src/demoLlms.test.ts
@@ -17,7 +17,9 @@ describe('per-demo llms.txt routes', () => {
 
   const realBunImage = Bun.Image;
   const realFetch = globalThis.fetch;
-  const CHANGELOG_BODY = '# Changelog\n\n## [0.8.0] mochi-framework\n\n### Features\n\n- something\n';
+  // Shaped like real release-please output — the linked version heading is what the
+  // page's external-link handling is asserted against.
+  const CHANGELOG_BODY = '# Changelog\n\n## [0.8.0](https://github.com/khromov/mochi/releases/tag/v0.8.0) (2026-07-21)\n\n### Features\n\n- something\n';
 
   beforeAll(async () => {
     // /llms-full.txt and /docs/changelog/llms.txt fetch the changelog from GitHub.
@@ -211,6 +213,26 @@ describe('per-demo llms.txt routes', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('content-type')).toContain('text/plain');
     expect(await res.text()).toContain('# Changelog');
+  });
+
+  // Slashless: this harness doesn't set the site's `trailingSlash: 'always'` (that lives
+  // in index.ts), so the canonical path here is the bare one.
+  test('/docs/changelog renders the changelog as a page', async () => {
+    const res = await fetch(`${base}/docs/changelog`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const html = await res.text();
+    // Rendered markup, not the raw markdown the llms.txt route serves.
+    expect(html).toContain('<h3 id="features">Features</h3>');
+    expect(html).not.toContain('### Features');
+    // Reachable from the nav, and carrying the same llms.txt affordance as a real doc.
+    expect(html).toContain('href="/docs/changelog/"');
+    expect(html).toContain('href="/docs/changelog/llms.txt"');
+  });
+
+  test('/docs/changelog opens outbound links in a new tab', async () => {
+    const html = await fetch(`${base}/docs/changelog`).then((r) => r.text());
+    expect(html).toContain('<a href="https://github.com/khromov/mochi/releases/tag/v0.8.0" rel="noopener noreferrer nofollow" target="_blank">');
   });
 
   test('/llms-recommended.txt serves the concatenated docs', async () => {

--- a/packages/site/src/lib/changelog.ts
+++ b/packages/site/src/lib/changelog.ts
@@ -1,4 +1,5 @@
 import { MochiCache, logger } from 'mochi-framework';
+import { renderMarkdown } from './markdown';
 
 export const CHANGELOG_URL = 'https://raw.githubusercontent.com/khromov/mochi/refs/heads/main/packages/mochi/CHANGELOG.md';
 export const CHANGELOG_SLUG = 'changelog';
@@ -27,4 +28,22 @@ export async function getChangelogTxt(): Promise<string | null> {
     logger.warn('[changelog] fetch failed:', err);
     return null;
   }
+}
+
+// Re-rendering ~24k of markdown on every request is pure waste when the upstream text
+// only moves on the cache's 4h refresh, so memoize against the exact source it came from.
+let rendered: { source: string; html: string } | null = null;
+
+/** The changelog as HTML for its page, or null when the upstream fetch failed. */
+export async function getChangelogHtml(): Promise<string | null> {
+  const source = await getChangelogTxt();
+  if (source === null) {
+    return null;
+  }
+  if (rendered?.source === source) {
+    return rendered.html;
+  }
+  const html = await renderMarkdown(source);
+  rendered = { source, html };
+  return html;
 }

--- a/packages/site/src/lib/docs.ts
+++ b/packages/site/src/lib/docs.ts
@@ -8,9 +8,8 @@ import { loadPosts, getPost } from './blog';
 import { CHANGELOG_SLUG, CHANGELOG_TITLE, CHANGELOG_DESCRIPTION, getChangelogTxt } from './changelog';
 import { demos, type Demo } from './demos';
 import { isDemoIndex, stripImageConfig, type SourceSpec } from '../components/utils.ts';
+import { collectHeadings, type HastNode, type MdsvexRehypePlugin } from './markdown';
 import type { TocEntry } from './toc';
-
-type MdsvexRehypePlugin = NonNullable<NonNullable<Parameters<typeof mdsvexCompile>[1]>['rehypePlugins']>[number];
 
 export const DOCS_DIR = path.resolve(SITE_ROOT, '../docs');
 // Internal demos are keyed by their folder name (`slug`) and carry their own `files`
@@ -293,6 +292,7 @@ export async function buildSitemapXml(): Promise<string> {
   const urls: string[] = [
     `  <url><loc>${SITE_BASE}/</loc></url>`,
     ...docs.map((d) => `  <url><loc>${SITE_BASE}/docs/${d.slug}/</loc></url>`),
+    `  <url><loc>${SITE_BASE}/docs/${CHANGELOG_SLUG}/</loc></url>`,
     `  <url><loc>${SITE_BASE}/blog/</loc></url>`,
     ...posts.map((p) => `  <url><loc>${SITE_BASE}/blog/${p.slug}/</loc></url>`),
     // Demo hrefs already carry a trailing slash; trailingSlashIt normalizes to
@@ -433,44 +433,13 @@ export async function buildLlmsIndexTxt(origin: string): Promise<string> {
   return lines.join('\n');
 }
 
-type HastNode = {
-  type: string;
-  tagName?: string;
-  value?: string;
-  properties?: Record<string, unknown>;
-  children?: HastNode[];
-};
-
-function hastText(node: HastNode): string {
-  if (node.type === 'text') {
-    return node.value ?? '';
-  }
-  if (!node.children) {
-    return '';
-  }
-  return node.children.map(hastText).join('');
-}
-
 async function parseDoc(markdown: string): Promise<{
   metadata: Partial<DocMetadata>;
   toc: TocEntry[];
 }> {
-  const toc: TocEntry[] = [];
+  let toc: TocEntry[] = [];
   const capture = () => (tree: HastNode) => {
-    for (const node of tree.children ?? []) {
-      if (node.type !== 'element' || !node.tagName) {
-        continue;
-      }
-      const match = /^h([1-6])$/.exec(node.tagName);
-      if (!match) {
-        continue;
-      }
-      toc.push({
-        level: Number(match[1]),
-        text: hastText(node),
-        slug: String(node.properties?.id ?? ''),
-      });
-    }
+    toc = collectHeadings(tree);
   };
   const result = await mdsvexCompile(markdown, {
     extensions: ['.md', '.svx'],

--- a/packages/site/src/lib/markdown.ts
+++ b/packages/site/src/lib/markdown.ts
@@ -1,0 +1,67 @@
+import { compile as mdsvexCompile } from 'mdsvex';
+import { toHtml } from 'hast-util-to-html';
+import rehypeSlug from 'rehype-slug';
+import rehypeExternalLinks from './rehypeExternalLinks';
+import type { TocEntry } from './toc';
+
+export type MdsvexRehypePlugin = NonNullable<NonNullable<Parameters<typeof mdsvexCompile>[1]>['rehypePlugins']>[number];
+
+export type HastNode = {
+  type: string;
+  tagName?: string;
+  value?: string;
+  properties?: Record<string, unknown>;
+  children?: HastNode[];
+};
+
+export function hastText(node: HastNode): string {
+  if (node.type === 'text') {
+    return node.value ?? '';
+  }
+  if (!node.children) {
+    return '';
+  }
+  return node.children.map(hastText).join('');
+}
+
+/** Top-level headings of a hast tree, carrying the ids rehype-slug assigned. */
+export function collectHeadings(tree: HastNode): TocEntry[] {
+  const toc: TocEntry[] = [];
+  for (const node of tree.children ?? []) {
+    if (node.type !== 'element' || !node.tagName) {
+      continue;
+    }
+    const match = /^h([1-6])$/.exec(node.tagName);
+    if (!match) {
+      continue;
+    }
+    toc.push({
+      level: Number(match[1]),
+      text: hastText(node),
+      slug: String(node.properties?.id ?? ''),
+    });
+  }
+  return toc;
+}
+
+/**
+ * Markdown to plain HTML, for content that arrives at runtime and so can't go through
+ * the build-time `.md` → Svelte component barrel. Runs the same mdsvex + rehype pipeline
+ * the docs use, then stringifies the hast tree instead of letting mdsvex emit Svelte source.
+ */
+export async function renderMarkdown(markdown: string): Promise<string> {
+  let html = '';
+  // Stringify inside the plugin: mdsvex keeps transforming the tree afterwards on its
+  // way to Svelte source, so a reference captured here is stale by the time it resolves.
+  const capture = () => (tree: HastNode) => {
+    html = toHtml(tree as Parameters<typeof toHtml>[0]);
+  };
+  await mdsvexCompile(markdown, {
+    extensions: ['.md', '.svx'],
+    // Same pair (and order) the authored docs are built with in index.ts, so runtime
+    // markdown gets the same heading ids and the same new-tab treatment on outbound links.
+    rehypePlugins: [rehypeSlug as unknown as MdsvexRehypePlugin, rehypeExternalLinks as unknown as MdsvexRehypePlugin, capture as unknown as MdsvexRehypePlugin],
+    highlight: false,
+  });
+  return html;
+}

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -16,7 +16,7 @@ import {
   loadDocs,
 } from './lib/docs';
 import { loadPosts, getPost } from './lib/blog';
-import { getChangelogTxt } from './lib/changelog';
+import { CHANGELOG_SLUG, CHANGELOG_TITLE, CHANGELOG_DESCRIPTION, getChangelogHtml, getChangelogTxt } from './lib/changelog';
 import { respondMcp } from './lib/mcp';
 import { profilerEnabled, startProfiler, stopProfiler } from './lib/profiler';
 import { routes as apiRoutes } from './demos/api/routes';
@@ -131,6 +131,29 @@ export const routes: Record<string, MochiRouteValue> = {
       return {
         docsNav: await buildDocsNav(),
         firstDocSlug: docs[0]?.slug ?? 'intro',
+      };
+    },
+  }),
+  // Static, so it outranks /docs/:slug below. The changelog is a synthetic doc rendered
+  // from markdown fetched at runtime — it can't ride the build-time docComponents barrel,
+  // so it hands Docs.svelte pre-rendered HTML instead of a component.
+  '/docs/changelog': Mochi.page('./src/Docs.svelte', {
+    serverProps: async () => {
+      const html = await getChangelogHtml();
+      if (html === null) {
+        error(503, 'Changelog is temporarily unavailable');
+      }
+      return {
+        slug: CHANGELOG_SLUG,
+        title: CHANGELOG_TITLE,
+        description: CHANGELOG_DESCRIPTION,
+        docsNav: await buildDocsNav(),
+        // No on-page TOC: it would just be a second copy of the version list the page
+        // already is. No pager either — the changelog sits outside the docs sequence.
+        toc: [],
+        html,
+        prev: null,
+        next: null,
       };
     },
   }),


### PR DESCRIPTION
## What

`/docs/changelog/` 404'd. #209 wired the changelog into the LLM/MCP surfaces (`/docs/changelog/llms.txt`, `/llms-full.txt`, `get_section`) but never added an HTML page — there was no route behind it, so `/docs/:slug` fell through to `getDoc('changelog')` → `null` → 404.

(For the record, #215 is the CapRover deploy serialization PR — the changelog work landed in #209.)

## How

The changelog can't ride the build-time `docComponents` barrel: that barrel imports `.md` files off disk at build time, and this markdown is fetched from GitHub at runtime. So it renders to HTML per request and `Docs.svelte` gains an `html` prop it falls back to when a slug has no barrel component. Everything else about the page — shell, prose styling, meta tags, the `llms.txt` copy pill — is the existing docs page, unchanged.

Rendering runs the **same** pipeline the authored docs use (`index.ts`'s `rehypePlugins: [rehypeSlug, rehypeExternalLinks]`), just stringified via `hast-util-to-html` instead of letting mdsvex emit Svelte source. That means heading ids match what an authored doc would get, and outbound links pick up `target="_blank" rel="noopener noreferrer nofollow"` from the plugin that already exists for this. The shared plumbing moved into `lib/markdown.ts`; `parseDoc` now reuses its heading walk instead of carrying a second copy.

Placement, per review feedback while building:

- The nav link sits under **Support** in the top nav (both `Sidebar` and `MobileNav`) rather than buried at the end of the docs list.
- **No "On this page"** — the TOC would just restate the version list the page already is.
- **No doc pager** — the changelog sits outside the docs sequence, so `getDocNeighbors` is left alone and `mochi-vs-sveltekit` keeps its original no-next ending.
- Added to `sitemap.xml`.

Rendered HTML is memoized against the exact source string it came from, so the ~24k of markdown isn't re-rendered per request — it only re-renders when the existing 4h `MochiCache` refresh actually returns new text. A failed upstream fetch returns `503`, matching what the `llms.txt` route already does.

`hast-util-to-html@^9.0.5` is a new explicit dependency of `packages/site`. It was already present transitively (via mdsvex's rehype stack) and pinned to the same version `bun info` reports as latest. It's used only in server-side route code, so it never reaches the SSR bundle's `external` list.

## Tests

Two new cases in `packages/site/src/demoLlms.test.ts`, which boots the real site routes:

- `/docs/changelog` returns 200 `text/html` containing `<h3 id="features">Features</h3>` and *not* the raw `### Features`, plus the nav link and the `llms.txt` link.
- outbound links render as `rel="noopener noreferrer nofollow" target="_blank"`.

The stubbed changelog body now mirrors real release-please output (a linked version heading) so the second assertion has something to bite on. Note these hit the slashless path — the test harness doesn't set the site's `trailingSlash: 'always'`, which lives in `index.ts`.

`bun run checks` passes (lint, format, typecheck, tests across all 10 workspaces).

Verified in a browser against a dev server: page renders with correct docs styling, sidebar entry under Support, no TOC, no pager, and a clean console with no hydration errors.
