### PR TITLE
feat(site): add a CI status dashboard at /ci/

### DIFF
--- a/packages/site/public/robots.txt
+++ b/packages/site/public/robots.txt
@@ -1,5 +1,4 @@
 User-Agent: *
 Allow: /
-Disallow: /og/
-Disallow: /ci/
-Disallow: /ci/dashboard/
+Disallow: /og
+Disallow: /ci/data/

--- a/packages/site/public/robots.txt
+++ b/packages/site/public/robots.txt
@@ -1,3 +1,4 @@
 User-Agent: *
 Allow: /
 Disallow: /og
+Disallow: /ci

--- a/packages/site/public/robots.txt
+++ b/packages/site/public/robots.txt
@@ -1,4 +1,5 @@
 User-Agent: *
 Allow: /
-Disallow: /og
-Disallow: /ci
+Disallow: /og/
+Disallow: /ci/
+Disallow: /ci/dashboard/

--- a/packages/site/src/ci/CiDashboard.svelte
+++ b/packages/site/src/ci/CiDashboard.svelte
@@ -1,0 +1,201 @@
+<script lang="ts">
+  import RefreshCw from '@lucide/svelte/icons/refresh-cw';
+  import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
+  import type { CiDashboardData, CiRateLimit } from '../lib/ci';
+  import { createCiBoard } from './board.svelte';
+  import { CI_ACTIONS_URL } from './repo';
+  import WorkflowCard from './WorkflowCard.svelte';
+  import { formatRelative, formatUntil } from './status';
+
+  let {
+    dashboard,
+    rateLimit,
+    serverNow,
+  }: {
+    dashboard: CiDashboardData | null;
+    rateLimit: CiRateLimit | null;
+    serverNow: number;
+  } = $props();
+
+  // The seed is deliberately a one-time snapshot: the board owns these values from
+  // here on and refreshes them itself.
+  // svelte-ignore state_referenced_locally
+  const ci = createCiBoard({ dashboard, rateLimit, serverNow });
+
+  const board = $derived(ci.dashboard);
+  const limit = $derived(ci.rateLimit);
+  const now = $derived(ci.now);
+
+  $effect(() => ci.start());
+</script>
+
+<div class="toolbar">
+  <p class="checked">
+    {#if board}
+      Checked {formatRelative(board.fetchedAt, now)}
+    {:else}
+      Not loaded
+    {/if}
+    {#if ci.failed}
+      <span class="chip">refresh failed</span>
+    {/if}
+  </p>
+
+  <div class="toolbar-right">
+    {#if limit}
+      <span class="quota">{limit.remaining}/{limit.limit} API calls left · resets {formatUntil(limit.resetAt, now)}</span>
+    {/if}
+    <button type="button" onclick={() => void ci.refresh()} disabled={ci.polling} aria-label="Refresh now">
+      <span class="spin" class:spinning={ci.polling}><RefreshCw size={14} aria-hidden="true" /></span>
+      Refresh
+    </button>
+  </div>
+</div>
+
+{#if !board}
+  <div class="notice">
+    <p class="notice-title"><TriangleAlert size={16} aria-hidden="true" /> Couldn't load the CI status</p>
+    {#if limit && limit.remaining === 0}
+      <p>GitHub's unauthenticated API allowance ({limit.limit} requests/hour) is used up. It resets {formatUntil(limit.resetAt, now)}.</p>
+    {:else}
+      <p>The GitHub API didn't respond. This page will retry on its own.</p>
+    {/if}
+    <p><a href={CI_ACTIONS_URL} target="_blank" rel="noreferrer">Open the Actions tab on GitHub →</a></p>
+  </div>
+{:else}
+  {#if board.partial}
+    <p class="warn"><TriangleAlert size={14} aria-hidden="true" /> Some workflows couldn't be loaded — the rest are up to date.</p>
+  {/if}
+
+  <div class="grid">
+    {#each board.workflows as workflow (workflow.id)}
+      <WorkflowCard {workflow} branch={board.branch} {now} />
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .toolbar-right {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .checked {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .quota {
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .chip {
+    margin-left: 0.4rem;
+    padding: 0.1em 0.5em;
+    border-radius: 999px;
+    background: var(--badge-warning-bg);
+    color: var(--badge-warning-text);
+    font-size: 0.7rem;
+  }
+
+  button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.35rem 0.7rem;
+    font: inherit;
+    font-size: 0.8rem;
+    color: var(--text);
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+  }
+
+  button:hover:not(:disabled) {
+    background: var(--surface-muted);
+    border-color: var(--border-strong);
+  }
+
+  button:disabled {
+    cursor: default;
+    color: var(--text-subtle);
+  }
+
+  .spin {
+    display: inline-flex;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .spin.spinning {
+      animation: rotate 0.9s linear infinite;
+    }
+  }
+
+  @keyframes rotate {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: 1rem;
+  }
+
+  .notice {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+    padding: 1.25rem 1.5rem;
+    color: var(--text-muted);
+  }
+
+  .notice p {
+    margin: 0 0 0.5rem;
+  }
+
+  .notice p:last-child {
+    margin-bottom: 0;
+  }
+
+  .notice-title {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-weight: 600;
+    color: var(--text);
+  }
+
+  .warn {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0 0 1rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: var(--radius-md);
+    background: var(--badge-warning-bg);
+    color: var(--badge-warning-text);
+    font-size: 0.85rem;
+  }
+
+  @media (max-width: 768px) {
+    .grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/site/src/ci/CiPage.svelte
+++ b/packages/site/src/ci/CiPage.svelte
@@ -1,0 +1,134 @@
+<script lang="ts">
+  import Footer from '../components/Footer.svelte';
+  import PageShell from '../components/PageShell.svelte';
+  import type { CiDashboardData, CiRateLimit } from '../lib/ci';
+  import type { TocEntry } from '../lib/toc';
+  import CiDashboard from './CiDashboard.svelte';
+  import { CI_BRANCH, CI_REPO } from './repo';
+
+  let {
+    docsNav,
+    dashboard,
+    rateLimit,
+    serverNow,
+  }: {
+    docsNav: TocEntry[];
+    dashboard: CiDashboardData | null;
+    rateLimit: CiRateLimit | null;
+    serverNow: number;
+  } = $props();
+</script>
+
+<svelte:head>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+</svelte:head>
+
+<PageShell
+  {docsNav}
+  metaTags={{
+    title: 'CI Status',
+    description: `GitHub Actions status for ${CI_REPO}.`,
+    canonical: 'https://mochi.fast/ci/',
+    robots: 'noindex, nofollow',
+  }}
+>
+  <header class="hero-minimal">
+    <div class="hero-inner">
+      <a class="logo" href="/">🍡 mochi</a>
+      <p class="tagline">SSR framework for Svelte 5 + Bun with islands-based selective hydration</p>
+    </div>
+  </header>
+
+  <main class="body">
+    <h1>CI Status</h1>
+    <p class="lede">GitHub Actions on <code>{CI_REPO}</code>, branch <code>{CI_BRANCH}</code>.</p>
+
+    <CiDashboard mochi:hydrate {dashboard} {rateLimit} {serverNow} />
+  </main>
+
+  <Footer />
+</PageShell>
+
+<style>
+  .hero-minimal {
+    padding: 1.5rem 1.5rem;
+  }
+
+  .hero-inner {
+    position: relative;
+    max-width: 600px;
+    margin: 0 auto;
+  }
+
+  .logo {
+    display: inline-block;
+    font-family: var(--font-serif);
+    font-size: 3.25rem;
+    font-weight: 400;
+    font-variation-settings:
+      'opsz' 144,
+      'SOFT' 50;
+    color: #fff;
+    letter-spacing: -0.015em;
+    margin-bottom: 0.5rem;
+    text-decoration: none;
+  }
+
+  .tagline {
+    font-family: var(--font-serif);
+    font-weight: 300;
+    color: #d8e4dc;
+    font-size: 1.05rem;
+    line-height: 1.5;
+    letter-spacing: 0.005em;
+    margin-bottom: 0;
+  }
+
+  .body {
+    max-width: 1100px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 2rem 1.5rem;
+    flex: 1;
+    color: var(--text);
+  }
+
+  h1 {
+    font-family: var(--font-serif);
+    font-size: 2.25rem;
+    font-weight: 400;
+    /* Fraunces' low optical size is the plain (non-decorated) cut of the face. */
+    font-variation-settings: 'opsz' 9;
+    margin: 0 0 0.35rem;
+    letter-spacing: -0.01em;
+  }
+
+  .lede {
+    margin: 0 0 1.5rem;
+    color: var(--text-muted);
+  }
+
+  .lede code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+  }
+
+  @media (max-width: 768px) {
+    .hero-minimal {
+      padding: 1rem 1.25rem;
+    }
+
+    .logo {
+      font-size: 2.2rem;
+    }
+
+    .body {
+      max-width: none;
+      background: var(--surface);
+    }
+
+    h1 {
+      font-size: 1.875rem;
+    }
+  }
+</style>

--- a/packages/site/src/ci/CompactBoard.svelte
+++ b/packages/site/src/ci/CompactBoard.svelte
@@ -32,7 +32,7 @@
       <span class="status">Couldn't reach the GitHub API</span>
     </div>
   {:else}
-    <div class="grid" style="--count: {board.workflows.length}">
+    <div class="grid">
       {#each board.workflows as wf (wf.id)}
         {@const latest = wf.runs[0]}
         {@const rate = successRate(wf.runs)}

--- a/packages/site/src/ci/CompactBoard.svelte
+++ b/packages/site/src/ci/CompactBoard.svelte
@@ -81,14 +81,13 @@
   }
 
   .tile {
-    /* Each tile carries its own tint, so the strip is drawn from currentColor rather
-       than the global tone tokens — a green success bar would vanish on a green tile.
-       Failures read as the solid marks; passes recede. */
-    --dot-success: color-mix(in srgb, currentColor 30%, transparent);
-    --dot-failure: currentColor;
-    --dot-running: color-mix(in srgb, currentColor 60%, transparent);
-    --dot-neutral: color-mix(in srgb, currentColor 15%, transparent);
-    --dot-ring: transparent;
+    /* Same semantic colours as the full board — a failed run is red wherever it shows
+       up. The tile itself stays neutral so those squares are the loudest thing on it. */
+    --dot-success: var(--badge-success-text);
+    --dot-failure: var(--badge-danger-text);
+    --dot-running: var(--badge-info-text);
+    --dot-neutral: var(--text-subtle);
+    --tone: var(--text-muted);
     --strip-gap: clamp(2px, 0.6vmin, 5px);
     --bar-size: clamp(9px, 3.1vmin, 24px);
     --bar-radius: clamp(3px, 0.9vmin, 6px);
@@ -101,8 +100,8 @@
     border-radius: var(--radius-lg);
     text-decoration: none;
     overflow: hidden;
-    background: var(--badge-default-bg);
-    color: var(--badge-default-text);
+    background: var(--surface);
+    color: var(--text);
   }
 
   .tile :global(.strip) {
@@ -116,23 +115,23 @@
   }
 
   .tile.tone-success {
-    background: var(--badge-success-bg);
-    color: var(--badge-success-text);
-  }
-
-  .tile.tone-failure {
-    background: var(--badge-danger-bg);
-    color: var(--badge-danger-text);
+    --tone: var(--badge-success-text);
   }
 
   .tile.tone-running {
-    background: var(--badge-info-bg);
-    color: var(--badge-info-text);
+    --tone: var(--badge-info-text);
+  }
+
+  /* A break is the one thing worth spotting from across the room, so the failing tile
+     gets an outline as well as red type — the status word alone is easy to miss. */
+  .tile.tone-failure {
+    --tone: var(--badge-danger-text);
+    box-shadow: inset 0 0 0 2px var(--badge-danger-text);
   }
 
   .name {
     font-family: var(--font-serif);
-    font-size: clamp(1rem, 3.4vmin, 2.1rem);
+    font-size: clamp(1.2rem, 4.4vmin, 3rem);
     font-weight: 500;
     line-height: 1.15;
     overflow: hidden;
@@ -141,22 +140,23 @@
   }
 
   .status {
-    font-size: clamp(0.7rem, 2.1vmin, 1.15rem);
-    font-weight: 600;
+    font-size: clamp(0.85rem, 2.8vmin, 1.6rem);
+    font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.06em;
+    color: var(--tone);
   }
 
   .sub {
-    font-size: clamp(0.62rem, 1.6vmin, 0.95rem);
-    opacity: 0.75;
+    font-size: clamp(0.75rem, 2.1vmin, 1.25rem);
+    color: var(--text-subtle);
   }
 
   .foot {
     margin: 0;
     flex-shrink: 0;
     text-align: center;
-    font-size: clamp(0.6rem, 1.5vmin, 0.85rem);
+    font-size: clamp(0.7rem, 1.9vmin, 1.05rem);
     color: var(--text-subtle);
   }
 

--- a/packages/site/src/ci/CompactBoard.svelte
+++ b/packages/site/src/ci/CompactBoard.svelte
@@ -36,7 +36,7 @@
       {#each board.workflows as wf (wf.id)}
         {@const latest = wf.runs[0]}
         {@const rate = successRate(wf.runs)}
-        <a class="tile tone-{wf.error ? 'failure' : latest ? runTone(latest) : 'neutral'}" href={wf.runsUrl} target="_blank" rel="noreferrer">
+        <a class="tile tone-{wf.error ? 'error' : latest ? runTone(latest) : 'neutral'}" href={wf.runsUrl} target="_blank" rel="noreferrer">
           <span class="name">{wf.name}</span>
           <span class="status">{wf.error ? 'unavailable' : latest ? runLabel(latest) : 'no runs'}</span>
           {#if latest && !wf.error}
@@ -88,6 +88,8 @@
     --dot-running: var(--badge-info-text);
     --dot-neutral: var(--text-subtle);
     --tone: var(--text-muted);
+    --tile-bg: var(--surface);
+    --dot-ring: var(--tile-bg);
     --strip-gap: clamp(2px, 0.6vmin, 5px);
     --bar-size: clamp(9px, 3.1vmin, 24px);
     --bar-radius: clamp(3px, 0.9vmin, 6px);
@@ -100,7 +102,7 @@
     border-radius: var(--radius-lg);
     text-decoration: none;
     overflow: hidden;
-    background: var(--surface);
+    background: var(--tile-bg);
     color: var(--text);
   }
 
@@ -122,11 +124,19 @@
     --tone: var(--badge-info-text);
   }
 
-  /* A break is the one thing worth spotting from across the room, so the failing tile
-     gets an outline as well as red type — the status word alone is easy to miss. */
+  /* A currently-broken workflow turns the whole tile red — the point of a wall display
+     is spotting that from across the room. The tint alone is muted by design, so the
+     bright ring carries the rest of the alarm. */
   .tile.tone-failure {
     --tone: var(--badge-danger-text);
+    --tile-bg: var(--badge-danger-bg);
     box-shadow: inset 0 0 0 2px var(--badge-danger-text);
+  }
+
+  /* "We couldn't ask GitHub" is not "the build is broken" — amber, not red. */
+  .tile.tone-error {
+    --tone: var(--badge-warning-text);
+    --tile-bg: var(--badge-warning-bg);
   }
 
   .name {

--- a/packages/site/src/ci/CompactBoard.svelte
+++ b/packages/site/src/ci/CompactBoard.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  import type { CiDashboardData, CiRateLimit } from '../lib/ci';
+  import { createCiBoard } from './board.svelte';
+  import RunStrip from './RunStrip.svelte';
+  import { formatRelative, runLabel, runTone, successRate } from './status';
+
+  let {
+    dashboard,
+    rateLimit,
+    serverNow,
+  }: {
+    dashboard: CiDashboardData | null;
+    rateLimit: CiRateLimit | null;
+    serverNow: number;
+  } = $props();
+
+  // The seed is deliberately a one-time snapshot: the board owns these values from
+  // here on and refreshes them itself.
+  // svelte-ignore state_referenced_locally
+  const ci = createCiBoard({ dashboard, rateLimit, serverNow });
+
+  const board = $derived(ci.dashboard);
+  const now = $derived(ci.now);
+
+  $effect(() => ci.start());
+</script>
+
+<div class="wall">
+  {#if !board}
+    <div class="tile tone-failure solo">
+      <span class="name">CI unavailable</span>
+      <span class="status">Couldn't reach the GitHub API</span>
+    </div>
+  {:else}
+    <div class="grid" style="--count: {board.workflows.length}">
+      {#each board.workflows as wf (wf.id)}
+        {@const latest = wf.runs[0]}
+        {@const rate = successRate(wf.runs)}
+        <a class="tile tone-{wf.error ? 'failure' : latest ? runTone(latest) : 'neutral'}" href={wf.runsUrl} target="_blank" rel="noreferrer">
+          <span class="name">{wf.name}</span>
+          <span class="status">{wf.error ? 'unavailable' : latest ? runLabel(latest) : 'no runs'}</span>
+          {#if latest && !wf.error}
+            <span class="sub">{[formatRelative(latest.createdAt, now), rate && `${rate.passed}/${rate.total}`].filter(Boolean).join(' · ')}</span>
+            <RunStrip runs={wf.runs} {now} interactive={false} />
+          {/if}
+        </a>
+      {/each}
+    </div>
+
+    <p class="foot">
+      {board.repo} · {board.branch} · checked {formatRelative(board.fetchedAt, now)}
+      {#if ci.failed}<span class="stale">· refresh failed</span>{/if}
+    </p>
+  {/if}
+</div>
+
+<style>
+  .wall {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5vmin;
+    height: 100dvh;
+    padding: 1.2vmin;
+    box-sizing: border-box;
+    background: var(--bg);
+    color: var(--text);
+  }
+
+  /* Tracks and type both scale off the viewport, so the same markup reads on a 480px
+     panel and a wall-mounted display without a single hard-coded breakpoint. The 28%
+     floor caps the grid at three columns however wide it gets — otherwise a desktop
+     window flattens every tile into one row of stretched slivers — while the 14rem
+     floor takes over on narrow screens and steps down to two columns, then one. */
+  .grid {
+    flex: 1;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, max(14rem, 28%)), 1fr));
+    grid-auto-rows: 1fr;
+    gap: 1.2vmin;
+    min-height: 0;
+  }
+
+  .tile {
+    /* Each tile carries its own tint, so the strip is drawn from currentColor rather
+       than the global tone tokens — a green success bar would vanish on a green tile.
+       Failures read as the solid marks; passes recede. */
+    --dot-success: color-mix(in srgb, currentColor 30%, transparent);
+    --dot-failure: currentColor;
+    --dot-running: color-mix(in srgb, currentColor 60%, transparent);
+    --dot-neutral: color-mix(in srgb, currentColor 15%, transparent);
+    --dot-ring: transparent;
+    --strip-gap: clamp(2px, 0.6vmin, 5px);
+    --bar-size: clamp(9px, 3.1vmin, 24px);
+    --bar-radius: clamp(3px, 0.9vmin, 6px);
+
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 0.3vmin;
+    padding: 1.5vmin 2vmin;
+    border-radius: var(--radius-lg);
+    text-decoration: none;
+    overflow: hidden;
+    background: var(--badge-default-bg);
+    color: var(--badge-default-text);
+  }
+
+  .tile :global(.strip) {
+    margin-top: 0.8vmin;
+  }
+
+  .tile.solo {
+    flex: 1;
+    align-items: center;
+    text-align: center;
+  }
+
+  .tile.tone-success {
+    background: var(--badge-success-bg);
+    color: var(--badge-success-text);
+  }
+
+  .tile.tone-failure {
+    background: var(--badge-danger-bg);
+    color: var(--badge-danger-text);
+  }
+
+  .tile.tone-running {
+    background: var(--badge-info-bg);
+    color: var(--badge-info-text);
+  }
+
+  .name {
+    font-family: var(--font-serif);
+    font-size: clamp(1rem, 3.4vmin, 2.1rem);
+    font-weight: 500;
+    line-height: 1.15;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .status {
+    font-size: clamp(0.7rem, 2.1vmin, 1.15rem);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+  }
+
+  .sub {
+    font-size: clamp(0.62rem, 1.6vmin, 0.95rem);
+    opacity: 0.75;
+  }
+
+  .foot {
+    margin: 0;
+    flex-shrink: 0;
+    text-align: center;
+    font-size: clamp(0.6rem, 1.5vmin, 0.85rem);
+    color: var(--text-subtle);
+  }
+
+  .stale {
+    color: var(--badge-warning-text);
+  }
+</style>

--- a/packages/site/src/ci/DashboardPage.svelte
+++ b/packages/site/src/ci/DashboardPage.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import '@fontsource/public-sans';
+  import '@fontsource-variable/fraunces/full.css';
+  import type { CiDashboardData, CiRateLimit } from '../lib/ci';
+  import CompactBoard from './CompactBoard.svelte';
+  import { CI_REPO } from './repo';
+
+  let {
+    dashboard,
+    rateLimit,
+    serverNow,
+  }: {
+    dashboard: CiDashboardData | null;
+    rateLimit: CiRateLimit | null;
+    serverNow: number;
+  } = $props();
+</script>
+
+<svelte:head>
+  <title>CI — {CI_REPO}</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <!-- No PageShell here, so svelte-meta-tags never runs and this is the only robots tag. -->
+  <meta name="robots" content="noindex, nofollow" />
+</svelte:head>
+
+<CompactBoard mochi:hydrate {dashboard} {rateLimit} {serverNow} />
+
+<style>
+  :global(body) {
+    margin: 0;
+    overflow: hidden;
+    font-family: var(--font-sans);
+  }
+</style>

--- a/packages/site/src/ci/RunStrip.svelte
+++ b/packages/site/src/ci/RunStrip.svelte
@@ -69,8 +69,9 @@
   }
 
   /* An inset notch so a failure is distinguishable from a pass without relying on hue.
-     The compact board sets --dot-ring transparent: there, solid-vs-faded already
-     separates the two and a ring at that size would just muddy the bar. */
+     It has to match whatever the bar sits on, so the host overrides --dot-ring: the
+     compact board's failed tiles are tinted, where the --surface default would read as
+     a stray light square. */
   .bar.tone-failure {
     background: var(--dot-failure);
     box-shadow: inset 0 0 0 2px var(--dot-ring, var(--surface));

--- a/packages/site/src/ci/RunStrip.svelte
+++ b/packages/site/src/ci/RunStrip.svelte
@@ -1,0 +1,90 @@
+<script lang="ts">
+  import type { CiRun } from '../lib/ci';
+  import { formatRelative, runLabel, runTone } from './status';
+
+  // `interactive: false` renders spans instead of links — the compact board wraps each
+  // whole tile in an <a>, and nesting anchors is invalid HTML.
+  let { runs, now, interactive = true }: { runs: CiRun[]; now: number; interactive?: boolean } = $props();
+
+  // Runs arrive newest-first; read left-to-right as oldest-to-newest.
+  const ordered = $derived([...runs].reverse());
+</script>
+
+<div class="strip">
+  {#each ordered as run (run.id)}
+    {@const label = `#${run.runNumber} · ${runLabel(run)} · ${formatRelative(run.createdAt, now)}`}
+    <svelte:element
+      this={interactive ? 'a' : 'span'}
+      class="bar tone-{runTone(run)}"
+      class:live={run.status !== 'completed'}
+      href={interactive ? run.htmlUrl : undefined}
+      target={interactive ? '_blank' : undefined}
+      rel={interactive ? 'noreferrer' : undefined}
+      role={interactive ? undefined : 'img'}
+      title={label}
+      aria-label={label}
+    ></svelte:element>
+  {/each}
+</div>
+
+<style>
+  /* Squares at a fixed size rather than blobs that stretch to fill: a workflow with
+     seven runs would otherwise draw visibly fatter squares than one with ten, which
+     reads as meaning something it doesn't. Now a short history is just a short strip. */
+  .strip {
+    display: flex;
+    align-items: center;
+    gap: var(--strip-gap, 4px);
+    overflow: hidden;
+  }
+
+  .bar {
+    /* Shrinkable rather than fixed: in a tall, narrow column the full-size strip would
+       overrun its tile and `overflow: hidden` would quietly eat the newest runs. Losing
+       a few pixels per square is honest; losing squares is not. aspect-ratio keeps them
+       square at whatever width they settle on. */
+    flex: 0 1 auto;
+    width: var(--bar-size, 22px);
+    min-width: 3px;
+    aspect-ratio: 1;
+    border-radius: var(--bar-radius, 5px);
+    background: var(--dot-neutral);
+    text-decoration: none;
+    transition: transform 0.12s ease;
+  }
+
+  a.bar:hover,
+  a.bar:focus-visible {
+    transform: scale(1.12);
+    outline: none;
+    box-shadow: var(--focus-ring);
+  }
+
+  .bar.tone-success {
+    background: var(--dot-success);
+  }
+
+  .bar.tone-running {
+    background: var(--dot-running);
+  }
+
+  /* An inset notch so a failure is distinguishable from a pass without relying on hue.
+     The compact board sets --dot-ring transparent: there, solid-vs-faded already
+     separates the two and a ring at that size would just muddy the bar. */
+  .bar.tone-failure {
+    background: var(--dot-failure);
+    box-shadow: inset 0 0 0 2px var(--dot-ring, var(--surface));
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    .bar.live {
+      animation: pulse 1.4s ease-in-out infinite;
+    }
+  }
+
+  @keyframes pulse {
+    50% {
+      opacity: 0.4;
+    }
+  }
+</style>

--- a/packages/site/src/ci/WorkflowCard.svelte
+++ b/packages/site/src/ci/WorkflowCard.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+  import TriangleAlert from '@lucide/svelte/icons/triangle-alert';
+  import Badge from '../components/Badge.svelte';
+  import type { CiWorkflow } from '../lib/ci';
+  import RunStrip from './RunStrip.svelte';
+  import { formatRelative, runLabel, runTone, successRate, toneToBadge } from './status';
+
+  let { workflow, branch, now }: { workflow: CiWorkflow; branch: string; now: number } = $props();
+
+  const latest = $derived(workflow.runs[0]);
+  const rate = $derived(successRate(workflow.runs));
+</script>
+
+<article class="card">
+  <header>
+    <a class="name" href={workflow.runsUrl} target="_blank" rel="noreferrer">{workflow.name}</a>
+    {#if workflow.error}
+      <Badge kind="warning">Unavailable</Badge>
+    {:else if latest}
+      <Badge kind={toneToBadge[runTone(latest)]}>{runLabel(latest)}</Badge>
+    {/if}
+  </header>
+  <p class="path">{workflow.path}</p>
+
+  {#if workflow.error}
+    <p class="empty"><TriangleAlert size={14} aria-hidden="true" /> Couldn't load runs for this workflow.</p>
+  {:else if latest}
+    <a class="latest" href={latest.htmlUrl} target="_blank" rel="noreferrer">
+      <span class="title">{latest.title}</span>
+      <span class="meta">
+        <span class="num">#{latest.runNumber}</span>
+        <span class="sha">{latest.sha}</span>
+        <span>{latest.event}</span>
+        <span>{formatRelative(latest.createdAt, now)}</span>
+      </span>
+    </a>
+
+    <RunStrip runs={workflow.runs} {now} />
+    {#if rate}
+      <p class="rate">{rate.passed}/{rate.total} passing on {branch}</p>
+    {/if}
+  {/if}
+</article>
+
+<style>
+  .card {
+    /* Map tones once here. The --badge-*-bg fills are too pale to read as a bar on
+       --surface, but the matching *-text tokens carry contrast in both themes. */
+    --dot-success: var(--badge-success-text);
+    --dot-failure: var(--badge-danger-text);
+    --dot-running: var(--badge-info-text);
+    --dot-neutral: var(--text-subtle);
+
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-sm);
+    padding: 1rem 1.15rem 1.1rem;
+    color: var(--text);
+  }
+
+  header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .name {
+    font-family: var(--font-serif);
+    font-size: 1.15rem;
+    font-weight: 500;
+    color: var(--text);
+    text-decoration: none;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .name:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
+    text-underline-offset: 3px;
+  }
+
+  .path {
+    margin: -0.35rem 0 0.15rem;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-subtle);
+  }
+
+  .latest {
+    display: block;
+    padding: 0.5rem 0.6rem;
+    margin: 0 -0.15rem;
+    border-radius: var(--radius-md);
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .latest:hover {
+    background: var(--surface-muted);
+  }
+
+  .title {
+    display: block;
+    font-size: 0.9rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    margin-top: 0.2rem;
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .num,
+  .sha {
+    font-family: var(--font-mono);
+  }
+
+  .rate {
+    margin: 0;
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .empty {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin: 0.15rem 0 0;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+</style>

--- a/packages/site/src/ci/board.svelte.ts
+++ b/packages/site/src/ci/board.svelte.ts
@@ -1,0 +1,92 @@
+import type { CiDashboardData, CiRateLimit } from '../lib/ci';
+
+export interface BoardSeed {
+  dashboard: CiDashboardData | null;
+  rateLimit: CiRateLimit | null;
+  serverNow: number;
+}
+
+// The server cache only turns over hourly; the poll just governs how quickly the page
+// notices. Visibility-gated, so a background tab or an idle wall display costs nothing.
+const POLL_MS = 300_000;
+const TICK_MS = 15_000;
+
+/**
+ * Live CI board state, shared by the full page and the compact dashboard.
+ * `now` is seeded from the server: a bare Date.now() would run during SSR *and* again
+ * on hydration, so every relative timestamp would mismatch.
+ */
+export function createCiBoard(seed: BoardSeed) {
+  let dashboard = $state(seed.dashboard);
+  let rateLimit = $state(seed.rateLimit);
+  let now = $state(seed.serverNow);
+  let polling = $state(false);
+  let failed = $state(false);
+
+  async function refresh() {
+    if (polling) {
+      return;
+    }
+    polling = true;
+    try {
+      const res = await fetch('/ci/data/', { headers: { Accept: 'application/json' } });
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+      const next = await res.json();
+      dashboard = next.dashboard;
+      rateLimit = next.rateLimit;
+      now = Date.now();
+      failed = false;
+    } catch {
+      // Keep the board we already have on screen; the caller surfaces `failed`.
+      failed = true;
+    } finally {
+      polling = false;
+    }
+  }
+
+  /** Call from an `$effect`; returns the teardown. */
+  function start(): () => void {
+    const tick = setInterval(() => {
+      now = Date.now();
+    }, TICK_MS);
+    const poll = setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        void refresh();
+      }
+    }, POLL_MS);
+    const onVisible = () => {
+      if (document.visibilityState === 'visible') {
+        now = Date.now();
+        void refresh();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisible);
+    return () => {
+      clearInterval(tick);
+      clearInterval(poll);
+      document.removeEventListener('visibilitychange', onVisible);
+    };
+  }
+
+  return {
+    get dashboard() {
+      return dashboard;
+    },
+    get rateLimit() {
+      return rateLimit;
+    },
+    get now() {
+      return now;
+    },
+    get polling() {
+      return polling;
+    },
+    get failed() {
+      return failed;
+    },
+    refresh,
+    start,
+  };
+}

--- a/packages/site/src/ci/repo.ts
+++ b/packages/site/src/ci/repo.ts
@@ -1,0 +1,6 @@
+// Client-safe constants. The island needs these, and `lib/ci.ts` can't supply them —
+// importing a value from it would pull node:path and FileStorage into the browser bundle.
+
+export const CI_REPO = 'khromov/mochi';
+export const CI_BRANCH = 'main';
+export const CI_ACTIONS_URL = `https://github.com/${CI_REPO}/actions`;

--- a/packages/site/src/ci/routes.ts
+++ b/packages/site/src/ci/routes.ts
@@ -1,0 +1,35 @@
+import { Mochi } from 'mochi-framework';
+import type { MochiRouteValue } from 'mochi-framework';
+import { getCiDashboard, getLastRateLimit } from '../lib/ci';
+import { buildDocsNav } from '../lib/docs';
+
+export const routes: Record<string, MochiRouteValue> = {
+  '/ci': Mochi.page('./src/ci/CiPage.svelte', {
+    serverProps: async () => {
+      const dashboard = await getCiDashboard();
+      return {
+        docsNav: await buildDocsNav(),
+        dashboard,
+        rateLimit: dashboard?.rateLimit ?? getLastRateLimit(),
+        // The island seeds its clock from this so SSR and hydration agree.
+        serverNow: Date.now(),
+      };
+    },
+  }),
+
+  // Chrome-free variant for a small always-on display — same data, no nav or hero.
+  '/ci/dashboard': Mochi.page('./src/ci/DashboardPage.svelte', {
+    serverProps: async () => {
+      const dashboard = await getCiDashboard();
+      return { dashboard, rateLimit: dashboard?.rateLimit ?? getLastRateLimit(), serverNow: Date.now() };
+    },
+  }),
+
+  // Always 200, even when GitHub is unreachable: a null `dashboard` lets the island
+  // tell "GitHub is down" (render the degraded card) apart from "our route broke"
+  // (keep the last board and flag the failed refresh). A 503 collapses the two.
+  '/ci/data': Mochi.api(async () => {
+    const dashboard = await getCiDashboard();
+    return Response.json({ dashboard, rateLimit: dashboard?.rateLimit ?? getLastRateLimit(), serverNow: Date.now() }, { headers: { 'Cache-Control': 'no-store' } });
+  }),
+};

--- a/packages/site/src/ci/status.ts
+++ b/packages/site/src/ci/status.ts
@@ -1,0 +1,98 @@
+// Pure helpers — this module ships to the browser inside the CI island, so it must
+// stay free of any server-only import.
+
+export type Tone = 'success' | 'failure' | 'running' | 'neutral';
+
+export type BadgeKind = 'default' | 'info' | 'success' | 'warning' | 'danger';
+
+interface RunLike {
+  status: string;
+  conclusion: string | null;
+}
+
+/**
+ * `conclusion` is null while a run is in flight, so status has to be checked first —
+ * switching on conclusion alone silently labels every running job as unknown.
+ */
+export function runTone(run: RunLike): Tone {
+  if (run.status !== 'completed') {
+    return 'running';
+  }
+  switch (run.conclusion) {
+    case 'success':
+      return 'success';
+    case 'failure':
+    case 'timed_out':
+    case 'startup_failure':
+      return 'failure';
+    default:
+      // cancelled / skipped / action_required / neutral — not a build break.
+      return 'neutral';
+  }
+}
+
+export function runLabel(run: RunLike): string {
+  if (run.status === 'queued' || run.status === 'requested' || run.status === 'waiting' || run.status === 'pending') {
+    return 'Queued';
+  }
+  if (run.status !== 'completed') {
+    return 'Running';
+  }
+  return (run.conclusion ?? 'unknown').replace(/_/g, ' ');
+}
+
+export const toneToBadge: Record<Tone, BadgeKind> = {
+  success: 'success',
+  failure: 'danger',
+  running: 'info',
+  neutral: 'default',
+};
+
+const MINUTE = 60_000;
+const HOUR = 3_600_000;
+const DAY = 86_400_000;
+
+/** Coarse relative time. Clock skew between our `now` and GitHub's timestamps can put
+ * an event slightly in the future, which must read as "just now", never "-3m ago". */
+export function formatRelative(iso: string | number, now: number): string {
+  const then = typeof iso === 'number' ? iso : Date.parse(iso);
+  if (!Number.isFinite(then)) {
+    return 'unknown';
+  }
+  const delta = now - then;
+  if (delta < MINUTE) {
+    return 'just now';
+  }
+  if (delta < HOUR) {
+    return `${Math.floor(delta / MINUTE)}m ago`;
+  }
+  if (delta < DAY) {
+    return `${Math.floor(delta / HOUR)}h ago`;
+  }
+  return `${Math.floor(delta / DAY)}d ago`;
+}
+
+/** Same scale, phrased forwards — for a rate-limit reset that lies ahead. */
+export function formatUntil(iso: string | number, now: number): string {
+  const then = typeof iso === 'number' ? iso : Date.parse(iso);
+  if (!Number.isFinite(then)) {
+    return 'unknown';
+  }
+  const delta = then - now;
+  if (delta < MINUTE) {
+    return 'any moment';
+  }
+  if (delta < HOUR) {
+    return `in ${Math.floor(delta / MINUTE)}m`;
+  }
+  return `in ${Math.floor(delta / HOUR)}h`;
+}
+
+/** Passing share of the completed runs, or null when none have completed. */
+export function successRate(runs: RunLike[]): { passed: number; total: number } | null {
+  const completed = runs.filter((r) => r.status === 'completed');
+  if (completed.length === 0) {
+    return null;
+  }
+  return { passed: completed.filter((r) => runTone(r) === 'success').length, total: completed.length };
+}

--- a/packages/site/src/components/MobileNav.svelte
+++ b/packages/site/src/components/MobileNav.svelte
@@ -101,6 +101,9 @@
         <li class="toc-item level-2">
           <a href="/docs/changelog/" onclick={close}>Changelog</a>
         </li>
+        <li class="toc-item level-2">
+          <a href="/ci/" onclick={close}>CI Status</a>
+        </li>
       </ul>
 
       {#if filteredDocs.length > 0}

--- a/packages/site/src/components/Sidebar.svelte
+++ b/packages/site/src/components/Sidebar.svelte
@@ -138,6 +138,9 @@
       <li class="toc-item level-2">
         <a href="/docs/changelog/">Changelog</a>
       </li>
+      <li class="toc-item level-2">
+        <a href="/ci/">CI Status</a>
+      </li>
     </ul>
 
     {#if filteredDocs.length > 0}

--- a/packages/site/src/lib/ci.ts
+++ b/packages/site/src/lib/ci.ts
@@ -1,0 +1,226 @@
+import path from 'node:path';
+import { FileStorage, MochiCache, logger } from 'mochi-framework';
+import { CI_ACTIONS_URL, CI_BRANCH, CI_REPO } from '../ci/repo';
+import { SITE_ROOT } from './siteRoot';
+
+// Reads the public GitHub Actions API unauthenticated, which is capped at 60
+// requests/hour per source IP. Set GITHUB_TOKEN (Bun auto-loads .env) to raise
+// that to 5000/hour — entirely optional, the dashboard works without it.
+
+export const CI_API_BASE = 'https://api.github.com';
+
+const RUNS_PER_WORKFLOW = 10;
+const DEVELOPMENT = process.env.MODE === 'development';
+
+export interface CiRun {
+  id: number;
+  runNumber: number;
+  status: string;
+  /** `null` while the run is still in flight — always check `status` first. */
+  conclusion: string | null;
+  event: string;
+  title: string;
+  sha: string;
+  htmlUrl: string;
+  createdAt: string;
+  attempt: number;
+}
+
+export interface CiWorkflow {
+  id: number;
+  name: string;
+  path: string;
+  runsUrl: string;
+  /** Newest first. Empty is legitimate — a PR-only workflow never runs on main. */
+  runs: CiRun[];
+  /** Set when this one workflow's runs could not be fetched. */
+  error?: string;
+}
+
+export interface CiRateLimit {
+  limit: number;
+  remaining: number;
+  resetAt: string;
+}
+
+export interface CiDashboardData {
+  repo: string;
+  branch: string;
+  fetchedAt: string;
+  workflows: CiWorkflow[];
+  rateLimit: CiRateLimit | null;
+  /** At least one workflow failed to load but the rest of the board is usable. */
+  partial: boolean;
+}
+
+const ciCache = new MochiCache({
+  minTimeToStale: 3_600_000, // 1h — after this, serve stale and refresh in the background
+  maxTimeToLive: 21_600_000, // 6h — keep serving the last-good board through a GitHub outage
+  // Warmup hits every static page pattern on boot, so each dev restart spends 8 of the
+  // 60 hourly calls before anyone visits. Persisting to disk makes restarts free. Prod is
+  // long-lived so it gains nothing, and FileStorage mkdirs synchronously at construction —
+  // under `bun test` MODE is unset, which keeps tests off the filesystem entirely.
+  ...(DEVELOPMENT
+    ? {
+        storage: new FileStorage({
+          directory: path.join(SITE_ROOT, '.mochi', 'ci'),
+          maxAge: 21_600_000,
+        }),
+      }
+    : {}),
+});
+
+// Written on every response, read even after the cache callback throws — that's what
+// lets a cold-cache 403 render "resets in 34m" instead of a bare failure.
+let lastRateLimit: CiRateLimit | null = null;
+
+export function getLastRateLimit(): CiRateLimit | null {
+  return lastRateLimit;
+}
+
+// `Number(null)` is 0, so read the raw header and bail on a miss rather than
+// letting an absent header masquerade as "0 requests left".
+function headerInt(headers: Headers, name: string): number | null {
+  const raw = headers.get(name);
+  if (raw === null) {
+    return null;
+  }
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : null;
+}
+
+function recordRateLimit(headers: Headers): void {
+  const limit = headerInt(headers, 'x-ratelimit-limit');
+  const remaining = headerInt(headers, 'x-ratelimit-remaining');
+  const reset = headerInt(headers, 'x-ratelimit-reset');
+  if (limit === null || remaining === null || reset === null) {
+    return;
+  }
+  lastRateLimit = { limit, remaining, resetAt: new Date(reset * 1000).toISOString() };
+}
+
+async function ghFetch(pathname: string): Promise<unknown> {
+  const token = process.env.GITHUB_TOKEN;
+  const res = await fetch(`${CI_API_BASE}${pathname}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'mochi.fast-ci-dashboard',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    // A hung GitHub must never stall an SSR render.
+    signal: AbortSignal.timeout(10_000),
+  });
+  recordRateLimit(res.headers);
+  // Throw rather than return, so a 403 rate-limit body or a 5xx HTML page is never cached.
+  if (!res.ok) {
+    throw new Error(`GitHub ${pathname} failed: ${res.status} ${res.statusText}`);
+  }
+  return await res.json();
+}
+
+interface RawWorkflow {
+  id: number;
+  name: string;
+  path: string;
+  state: string;
+}
+
+interface RawRun {
+  id: number;
+  run_number: number;
+  status: string;
+  conclusion: string | null;
+  event: string;
+  display_title: string;
+  head_sha: string;
+  html_url: string;
+  created_at: string;
+  run_attempt: number;
+}
+
+// The list response's `html_url` points at the workflow's YAML file, not its runs.
+function workflowRunsUrl(workflowPath: string): string {
+  const file = workflowPath.split('/').pop() ?? workflowPath;
+  return `${CI_ACTIONS_URL}/workflows/${file}?query=branch%3A${CI_BRANCH}`;
+}
+
+function normalizeRun(raw: RawRun): CiRun {
+  return {
+    id: raw.id,
+    runNumber: raw.run_number,
+    status: raw.status,
+    conclusion: raw.conclusion,
+    event: raw.event,
+    title: raw.display_title,
+    sha: (raw.head_sha ?? '').slice(0, 7),
+    htmlUrl: raw.html_url,
+    createdAt: raw.created_at,
+    attempt: raw.run_attempt,
+  };
+}
+
+async function fetchWorkflowList(): Promise<RawWorkflow[]> {
+  const body = (await ghFetch(`/repos/${CI_REPO}/actions/workflows?per_page=100`)) as { workflows?: RawWorkflow[] };
+  // A deleted workflow lingers in the list as `deleted_workflow_state`; dropping the
+  // non-active ones means the board prunes itself with no code change.
+  return (body.workflows ?? []).filter((w) => w.state === 'active');
+}
+
+async function fetchRuns(workflowId: number): Promise<CiRun[]> {
+  const body = (await ghFetch(`/repos/${CI_REPO}/actions/workflows/${workflowId}/runs?per_page=${RUNS_PER_WORKFLOW}&branch=${CI_BRANCH}`)) as {
+    workflow_runs?: RawRun[];
+  };
+  return (body.workflow_runs ?? []).map(normalizeRun);
+}
+
+function buildDashboard(list: RawWorkflow[], settled: PromiseSettledResult<CiRun[]>[]): CiDashboardData {
+  const workflows: CiWorkflow[] = list
+    .map((raw, i): CiWorkflow => {
+      const result = settled[i];
+      const base = { id: raw.id, name: raw.name, path: raw.path, runsUrl: workflowRunsUrl(raw.path) };
+      return result?.status === 'fulfilled' ? { ...base, runs: result.value } : { ...base, runs: [], error: String(result?.reason ?? 'unknown error') };
+    })
+    // A pull_request-only workflow never runs on this branch, so it has no status to
+    // report — drop it rather than show a permanently blank card. Keyed off the empty
+    // result, not a workflow name, so it holds for any future PR-only workflow. A
+    // fetch failure is different: that one keeps its card and says so.
+    .filter((w) => w.runs.length > 0 || w.error !== undefined);
+
+  // Most-recently-active first.
+  workflows.sort((a, b) => (b.runs[0]?.createdAt ?? '').localeCompare(a.runs[0]?.createdAt ?? ''));
+
+  return {
+    repo: CI_REPO,
+    branch: CI_BRANCH,
+    fetchedAt: new Date().toISOString(),
+    workflows,
+    rateLimit: lastRateLimit,
+    partial: workflows.some((w) => w.error !== undefined),
+  };
+}
+
+const CACHE_KEY = 'ci:dashboard';
+
+/** The CI board, or null when GitHub can't be reached and nothing is cached. */
+export async function getCiDashboard(): Promise<CiDashboardData | null> {
+  try {
+    return await ciCache.fetch(CACHE_KEY, async () => {
+      // The workflow list is the spine — without it there is nothing to render.
+      const list = await fetchWorkflowList();
+      const settled = await Promise.allSettled(list.map((w) => fetchRuns(w.id)));
+
+      // A rejection is a failure; an empty array is not. Caching an all-rejected board
+      // would show a convincing "nothing has ever run" for the next hour.
+      if (settled.length > 0 && settled.every((r) => r.status === 'rejected')) {
+        throw new Error('every workflow runs fetch failed');
+      }
+      return buildDashboard(list, settled);
+    });
+  } catch (err) {
+    // GitHub being unreachable must never break the page — the route renders the
+    // degraded state, explained by getLastRateLimit() when we were rate limited.
+    logger.warn('[ci] fetch failed:', err);
+    return null;
+  }
+}

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -24,6 +24,7 @@ import { routes as cacheEventsRoutes } from './demos/cache-events/routes';
 import { routes as captchaRoutes } from './demos/captcha/routes';
 import { routes as captchaStylingRoutes } from './demos/captcha-styling/routes';
 import { routes as chatRoutes } from './demos/chat/routes';
+import { routes as ciRoutes } from './ci/routes';
 import { routes as clientOnlyRoutes } from './demos/client-only/routes';
 import { routes as cookieVaryTestRoutes } from './demos/cookie-vary-test/routes';
 import { routes as cookiesRoutes } from './demos/cookies/routes';
@@ -293,6 +294,7 @@ export const routes: Record<string, MochiRouteValue> = {
   ...captchaRoutes,
   ...captchaStylingRoutes,
   ...chatRoutes,
+  ...ciRoutes,
   ...clientOnlyRoutes,
   ...cookieVaryTestRoutes,
   ...cookiesRoutes,


### PR DESCRIPTION
A small self-hosted dashboard for how the repo's GitHub Actions are doing, so it's not a trip to the Actions tab or waiting for a red email.

Data comes from the **public GitHub REST API, unauthenticated** — no secret needed to run this.

## Two views, one data source

| Route | What it is |
|---|---|
| `/ci/` | Full page with the site chrome. One card per workflow: latest run (title, number, sha, event, age) plus a strip of the last 10 runs and a pass count. |
| `/ci/dashboard/` | Chrome-free tiles for a small always-on display. No nav, no hero, no footer. |

The compact view has no hardcoded breakpoints — grid tracks and type scale off the viewport, so it reads at 480×320, at the ~700×480 target, and on a large screen. The column count is capped intrinsically (a `28%` track floor) so a wide window can't flatten every tile into one row of slivers.

## Refresh

Both views hydrate an island that polls `/ci/data/` and ticks its relative timestamps. Polling is visibility-gated, so a background tab or an idle wall display costs nothing, and becoming visible refreshes immediately.

The GitHub calls sit behind a 1h `MochiCache` (6h TTL for stale-while-revalidate), so the **60 requests/hour** anonymous budget is spent once an hour regardless of traffic — 8 calls per refresh (1 workflow list + 7 run lists). Setting `GITHUB_TOKEN` raises the limit to 5000/hour, but it is optional and never required.

In dev the cache is backed by `FileStorage` under `.mochi/`, because warmup hits every static page pattern on boot — without it, roughly seven dev restarts would exhaust the hourly budget. Prod stays in memory.

## Degradation

Failure modes are kept distinct rather than collapsed into one error:

- **GitHub unreachable, cold cache** → explicit notice; if we were rate limited it says so and when the limit resets, read from a module-scope record that survives the throw.
- **GitHub unreachable, warm cache** → last-good board served stale; nobody notices.
- **One workflow's runs fail** → that card says "unavailable", the rest are untouched, board marked partial.
- **Every runs fetch fails** → nothing is cached, so a fake "nothing has ever run" board can't stick for an hour.
- **Poll fails** → previous board stays on screen with a small "refresh failed" chip.

A `pull_request`-only workflow (currently `Review`) has no status to report on `main`, so it's dropped rather than shown as a permanently blank card. That's keyed off the empty result, not a workflow name.

## Visibility

Linked from the sidebar and mobile nav, but `noindex` plus `Disallow: /ci` in robots.txt and deliberately **not** in `sitemap.xml` — it's a dashboard, not marketing surface.

## Notes

- No new dependencies. Colours come entirely from the existing `--badge-*` design tokens, so light and dark both work; contrast was measured at 4.7–11.5:1 across every status tone in both themes.
- Status is never conveyed by colour alone — every square carries an `aria-label`, the pill states the condition in text, and failures get an inset ring so they separate in grayscale.
- Per the review comment on this branch: no dedicated tests, this is a simple feature.

## Verification

Smoke-tested against the live API on a dev server: SSR HTML, the JSON route, the trailing-slash redirect, robots.txt, and `sitemap.xml` exclusion. Driven in a real browser to confirm clean hydration (no mismatch on the relative timestamps — the island seeds its clock from the server), no fetch on load, exactly one request per poll, and correct rendering in both themes at 480×320, 700×480, 700×1200 and 1600×900.

`bun run checks` passes.