### PR TITLE
chore(deps): update svelte to 5.56.8

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -48,7 +48,7 @@
         "@tailwindcss/oxide": "^4.3.3",
         "html-entities": "^2.6.0",
         "mochi-framework": "workspace:*",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
         "svelte-meta-tags": "^5.0.2",
         "tailwindcss": "^4.3.3",
       },
@@ -64,7 +64,7 @@
       "dependencies": {
         "@lucide/svelte": "^1.25.0",
         "mochi-framework": "workspace:*",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
         "uqr": "^0.1.3",
       },
     },
@@ -72,7 +72,7 @@
       "name": "mochi-minimal",
       "dependencies": {
         "mochi-framework": "workspace:*",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -84,7 +84,7 @@
       "name": "mochi-minimal-rsvelte",
       "dependencies": {
         "mochi-framework": "workspace:*",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
       },
       "devDependencies": {
         "@mochi-framework/rsvelte": "workspace:*",
@@ -125,7 +125,7 @@
         "@types/smtp-server": "3.5.13",
         "fast-check": "4.9.0",
         "smtp-server": "3.19.2",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
         "svelte-check": "4.7.3",
         "typescript": "^6.0.3",
       },
@@ -150,7 +150,7 @@
       "devDependencies": {
         "@types/bun": "1.3.14",
         "mochi-framework": "workspace:*",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
@@ -194,7 +194,7 @@
         "rehype-slug": "^6.0.0",
         "shiki": "^4.3.1",
         "slugify": "^1.6.9",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
         "svelte-french-toast": "2.0.0-alpha.0",
         "svelte-meta-tags": "^5.0.2",
         "svelte-youtube-lite": "^1.3.0",
@@ -214,7 +214,7 @@
         "@fontsource/public-sans": "^5.3.0",
         "mochi-framework": "workspace:*",
         "mochi-shared": "workspace:*",
-        "svelte": "^5.56.7",
+        "svelte": "^5.56.8",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -1229,7 +1229,7 @@
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
-    "svelte": ["svelte@5.56.7", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-5qERUZX80oQj6XrDMUmD2Uhd/cIpCPDWWKBK3ZHmyRUC9apPyamWM8xMo31mbWsIQxwG2hVoSnOJ/EcnhVkkzQ=="],
+    "svelte": ["svelte@5.56.8", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-PY8LOw7xP6c8IOiVqdo0sbbZVYhXRSfklOQLAUyGBKqjTX0wx/z4l/9J+PmBpmlLnxzEb1NqltxQ5/wZme/Cmg=="],
 
     "svelte-check": ["svelte-check@4.7.3", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg=="],
 
@@ -1424,8 +1424,6 @@
     "puppeteer-core/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 
     "rehype-slug/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
-
-    "svelte/devalue": ["devalue@5.8.1", "", {}, "sha512-4CXDYRBGqN+57wVJkuXBYmpAVUSg3L6JAQa/DFqm238G73E1wuyc/JhGQJzN7vUf/CMphYau2zXbfWzDR5aTEw=="],
 
     "svelte/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -21,7 +21,7 @@
     "@tailwindcss/oxide": "^4.3.3",
     "html-entities": "^2.6.0",
     "mochi-framework": "workspace:*",
-    "svelte": "^5.56.7",
+    "svelte": "^5.56.8",
     "svelte-meta-tags": "^5.0.2",
     "tailwindcss": "^4.3.3"
   },

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "@lucide/svelte": "^1.25.0",
     "mochi-framework": "workspace:*",
-    "svelte": "^5.56.7",
+    "svelte": "^5.56.8",
     "uqr": "^0.1.3"
   }
 }

--- a/packages/minimal-rsvelte/package.json
+++ b/packages/minimal-rsvelte/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "mochi-framework": "workspace:*",
-    "svelte": "^5.56.7"
+    "svelte": "^5.56.8"
   },
   "devDependencies": {
     "@mochi-framework/rsvelte": "workspace:*",

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "mochi-framework": "workspace:*",
-    "svelte": "^5.56.7"
+    "svelte": "^5.56.8"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/packages/mochi-rsvelte/package.json
+++ b/packages/mochi-rsvelte/package.json
@@ -60,7 +60,7 @@
   "devDependencies": {
     "@types/bun": "1.3.14",
     "mochi-framework": "workspace:*",
-    "svelte": "^5.56.7",
+    "svelte": "^5.56.8",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -123,7 +123,7 @@
     "@types/smtp-server": "3.5.13",
     "fast-check": "4.9.0",
     "smtp-server": "3.19.2",
-    "svelte": "^5.56.7",
+    "svelte": "^5.56.8",
     "svelte-check": "4.7.3",
     "typescript": "^6.0.3"
   }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -28,7 +28,7 @@
     "rehype-slug": "^6.0.0",
     "shiki": "^4.3.1",
     "slugify": "^1.6.9",
-    "svelte": "^5.56.7",
+    "svelte": "^5.56.8",
     "svelte-french-toast": "2.0.0-alpha.0",
     "svelte-meta-tags": "^5.0.2",
     "svelte-youtube-lite": "^1.3.0",

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -18,7 +18,7 @@
     "@fontsource/public-sans": "^5.3.0",
     "mochi-framework": "workspace:*",
     "mochi-shared": "workspace:*",
-    "svelte": "^5.56.7"
+    "svelte": "^5.56.8"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",


### PR DESCRIPTION
Bumps Svelte from **5.56.7 → 5.56.8** across every workspace.

## Upstream changes

Patch release, two fixes — the first lands directly on a Mochi code path, since the preprocessor auto-wraps every `mochi:hydrate*` island in a `<svelte:boundary>`:

- fix: call `onerror` and provide a working `reset` when hydrating a failed boundary ([sveltejs/svelte#18556](https://github.com/sveltejs/svelte/pull/18556))
- fix: preserve select selection when spread attributes omit value ([sveltejs/svelte#18561](https://github.com/sveltejs/svelte/pull/18561))

## Bump table

| Workspace | Field | From | To |
| --- | --- | --- | --- |
| `packages/mochi` | devDependencies | `^5.56.7` | `^5.56.8` |
| `packages/mochi-rsvelte` | devDependencies | `^5.56.7` | `^5.56.8` |
| `packages/site` | dependencies | `^5.56.7` | `^5.56.8` |
| `packages/demos` | dependencies | `^5.56.7` | `^5.56.8` |
| `packages/docs` | dependencies | `^5.56.7` | `^5.56.8` |
| `packages/minimal` | dependencies | `^5.56.7` | `^5.56.8` |
| `packages/minimal-rsvelte` | dependencies | `^5.56.7` | `^5.56.8` |
| `packages/support` | dependencies | `^5.56.7` | `^5.56.8` |

## Deliberately not changed

- **`packages/mochi` `peerDependencies.svelte` stays at `^5.56.6`.** It's a floor for published consumers and already admits 5.56.8; raising it would force an upgrade for no API reason. Since published `mochi-framework` carries Svelte only as a devDependency plus this unchanged peer range, nothing consumer-visible moved — hence `chore(deps):` rather than `fix(deps):`, and no release is warranted.
- Scope is Svelte only, not a full dependency sweep. Also currently outdated and left alone: `@lucide/svelte` (1.25.0 → 1.27.0), `@rsvelte/vite-plugin-svelte-native` (0.2.8 → 0.3.1), `svelte-check` (4.7.3 → 4.7.4, exact-pinned because it carries a patch keyed on the version), `typescript` (6.0.3 → 7.0.2).

The `bun.lock` diff is Svelte-only; the one removed `svelte/devalue` entry is a dedupe artifact (devalue is now satisfied from the root).

## Verification

- **`bun run syncpack`** — ✅ no issues; cross-workspace agreement holds, including the unchanged peer range.
- **`bun run checks`** (lint:fix + format + typecheck + test) — ✅ all four stages green. Typecheck 0 errors across all workspaces; tests 142/142 mochi-framework files, 9/9 site, 2/2 support, demos/minimal/minimal-rsvelte all green, 0 failures.
- **Clean reinstall + dedupe** — `rm -rf node_modules packages/*/node_modules && bun install`. `packages/*/node_modules/svelte` is empty and `node_modules/.bun` is absent, so there is exactly one hoisted `svelte@5.56.8`. (Duplicate copies mean two context maps and break `getContext` across the island boundary — invisible to CI.)
- **`bun run build`** — ✅ output byte-identical to the pre-bump baseline apart from timings. No optimization skipped, no shake fallback:

  | | before | after |
  | --- | --- | --- |
  | `svelte-shaker` (site) | slimmed 33 of 163 | slimmed 33 of 163 |
  | site | 65 pages · 245 client files · 12 public · 7 image assets · 2 email templates | identical |
  | demos | 10 pages · 32 client files | identical |
  | support | 2 pages · 19 client files · 1 email template | identical |
  | minimal / minimal-rsvelte | 1 page · 10 client files each | identical |

  Per-file bundle sizes in the build listing are unchanged too.

- **Browser smoke test** (`PORT=4444 bun run dev:site`, driven via chrome-devtools):
  - `/` — no console errors/warnings.
  - `/docs/queues/` — no console errors/warnings.
  - `/demos/error-boundaries/` — the demo most relevant to #18556. All five scenarios render their expected fallbacks (user-written boundary, `mochi:hydrate` SSR throw, `mochi:hydrate` client throw, `mochi:defer` server-island throw, healthy server island with an inner throwing `mochi:hydrate` child). All 22 requests 200, including both `/_mochi/island/*` fetches. The only console output is the demo's intentional `ThrowOnClient` failure. Debug bar reports **Svelte 5.56.8**.
  - `/demos/nested-islands/` — clean console, all four `/_mochi/island/*` fetches 200.
  - `/demos/is-hydratable/` — clean console, both island fetches 200. This is the canary for the duplicate-copy failure mode (`isHydratable()` is its first casualty), so it independently confirms the dedupe.
- **`bun run cli-test`** — ✅ pass (scaffold, install, test, typecheck). `minimal` and `demos` both moved and double as `create-mochi` template sources.
