### PR TITLE
chore(deps): update svelte-check to 4.7.4

### DIFF
--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -9,7 +9,7 @@
     {
       "label": "Pin svelte-check across the workspace",
       "dependencies": ["svelte-check"],
-      "pinVersion": "4.7.3"
+      "pinVersion": "4.7.4"
     },
     {
       "label": "Peer dependencies are intentionally wide — don't sync them",

--- a/bun.lock
+++ b/bun.lock
@@ -54,7 +54,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
-        "svelte-check": "4.7.3",
+        "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
     },
@@ -76,7 +76,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
-        "svelte-check": "4.7.3",
+        "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
     },
@@ -89,7 +89,7 @@
       "devDependencies": {
         "@mochi-framework/rsvelte": "workspace:*",
         "@types/bun": "1.3.14",
-        "svelte-check": "4.7.3",
+        "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
     },
@@ -126,7 +126,7 @@
         "fast-check": "4.9.0",
         "smtp-server": "3.19.2",
         "svelte": "^5.56.7",
-        "svelte-check": "4.7.3",
+        "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
@@ -203,7 +203,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
-        "svelte-check": "4.7.3",
+        "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
     },
@@ -218,7 +218,7 @@
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
-        "svelte-check": "4.7.3",
+        "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
     },
@@ -239,7 +239,7 @@
     },
   },
   "patchedDependencies": {
-    "svelte-check@4.7.3": "packages/mochi/patches/svelte-check@4.7.3.patch",
+    "svelte-check@4.7.4": "packages/mochi/patches/svelte-check@4.7.4.patch",
   },
   "overrides": {
     "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*",
@@ -407,7 +407,7 @@
 
     "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.10", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-4WfKk68eTih+MiJD4fSbxN7E8kVBmTMPWHUPYjvl2N0rMs53YLTT8/YjKU5Dtnz5LqDjl7LEw4U7lXR2W3J5WA=="],
 
-    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.0", "", {}, "sha512-1LgZ/qUqSoq+QorD83lk2hka79Px0wXNW2q5V1nZlxGhQgw1jrsIbVz5YiCeucVLo4XvFLjXukUaQjIiqowkcg=="],
+    "@sveltejs/load-config": ["@sveltejs/load-config@0.2.1", "", {}, "sha512-5m3B2cbqQ4TbwW6Xkh66Ntw6dD7gNc77cCxABTTesWcq9jxIzMgTk97pZx5vEtvQx8iokgi7GIphqZe+PGwcZA=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.3.3", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.24.1", "jiti": "^2.7.0", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.3.3" } }, "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg=="],
 
@@ -1231,7 +1231,7 @@
 
     "svelte": ["svelte@5.56.7", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "@types/trusted-types": "^2.0.7", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-5qERUZX80oQj6XrDMUmD2Uhd/cIpCPDWWKBK3ZHmyRUC9apPyamWM8xMo31mbWsIQxwG2hVoSnOJ/EcnhVkkzQ=="],
 
-    "svelte-check": ["svelte-check@4.7.3", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.0", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": ">=5.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-DHdTCGX62R0fCxBEaT+USdASAnoaRBaaNczkRJl0K7o3WyoCeVUbVxo6fKqpOll/B+WMWCsiFK0eFrJSNBKZIg=="],
+    "svelte-check": ["svelte-check@4.7.4", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.25", "@sveltejs/load-config": "^0.2.1", "chokidar": "^4.0.1", "fdir": "^6.2.0", "picocolors": "^1.0.0", "sade": "^1.7.4" }, "peerDependencies": { "svelte": "^4.0.0 || ^5.0.0-next.0", "typescript": "^5.0.0 || ^6.0.0" }, "bin": { "svelte-check": "bin/svelte-check" } }, "sha512-IW9ot9YqAoyv8FvyN+eb4ZTe8zgcKZrJLNYU6dzSKkGwEBsSPc4K7lmQ8bKn8W2YMXM6WDfZSSVOaGtekyUfOQ=="],
 
     "svelte-eslint-parser": ["svelte-eslint-parser@1.8.0", "", { "dependencies": { "eslint-scope": "^8.2.0", "eslint-visitor-keys": "^4.0.0", "espree": "^10.0.0", "postcss": "^8.4.49", "postcss-scss": "^4.0.9", "postcss-selector-parser": "^7.0.0", "semver": "^7.7.2" }, "peerDependencies": { "svelte": "^3.37.0 || ^4.0.0 || ^5.0.0" }, "optionalPeers": ["svelte"] }, "sha512-mikR1qwIVy3t5WthUoAXkMwxkXvabZP9FJgdx35Ei7EbGWmctva1Pih16Koeor/bdNNq8NXHlwKGS6NkYTawLg=="],
 

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "typescript-eslint": "^8.65.0"
   },
   "patchedDependencies": {
-    "svelte-check@4.7.3": "packages/mochi/patches/svelte-check@4.7.3.patch"
+    "svelte-check@4.7.4": "packages/mochi/patches/svelte-check@4.7.4.patch"
   },
   "overrides": {
     "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*"

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -83,6 +83,7 @@ describe('transformPackageJson', () => {
       'svelte-check@4.6.0': 'patches/svelte-check@4.6.0.patch',
       'svelte-check@4.7.1': 'patches/svelte-check@4.7.1.patch',
       'svelte-check@4.7.3': 'patches/svelte-check@4.7.3.patch',
+      'svelte-check@4.7.4': 'patches/svelte-check@4.7.4.patch',
     });
   });
 });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -106,6 +106,7 @@ export function transformPackageJson(contents: string, opts: PackageJsonTransfor
     'svelte-check@4.6.0': 'patches/svelte-check@4.6.0.patch',
     'svelte-check@4.7.1': 'patches/svelte-check@4.7.1.patch',
     'svelte-check@4.7.3': 'patches/svelte-check@4.7.3.patch',
+    'svelte-check@4.7.4': 'patches/svelte-check@4.7.4.patch',
   };
 
   return JSON.stringify(pkg, null, 2) + '\n';

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -27,7 +27,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
-    "svelte-check": "4.7.3",
+    "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   },
   "overrides": {

--- a/packages/demos/patches/svelte-check@4.7.4.patch
+++ b/packages/demos/patches/svelte-check@4.7.4.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/src/index.js b/dist/src/index.js
-index a2e8d95a456f37fda1adf30d6e5db18abfb8f76a..f958710d8131b9d3e4d6c6dc231b7aa374261daf 100644
+index 1efd1f365acd4e61e506459041caa9a7321cafcc..5741eb48aec77aeb2ff362674cde201787b8167d 100644
 --- a/dist/src/index.js
 +++ b/dist/src/index.js
 @@ -91170,6 +91170,13 @@ function handleAttribute(str, attr, parent, preserveCase, svelte5Plus, element)

--- a/packages/minimal-rsvelte/package.json
+++ b/packages/minimal-rsvelte/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@mochi-framework/rsvelte": "workspace:*",
     "@types/bun": "1.3.14",
-    "svelte-check": "4.7.3",
+    "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   },
   "overrides": {

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
-    "svelte-check": "4.7.3",
+    "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   },
   "overrides": {

--- a/packages/minimal/patches/svelte-check@4.7.4.patch
+++ b/packages/minimal/patches/svelte-check@4.7.4.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/src/index.js b/dist/src/index.js
+index 1efd1f365acd4e61e506459041caa9a7321cafcc..5741eb48aec77aeb2ff362674cde201787b8167d 100644
+--- a/dist/src/index.js
++++ b/dist/src/index.js
+@@ -91170,6 +91170,13 @@ function handleAttribute(str, attr, parent, preserveCase, svelte5Plus, element)
+                 }
+                 value.push('})');
+             }
++            else if (attr.name.startsWith('mochi:')) {
++                name.unshift('...__sveltets_2_empty({');
++                if (!value) {
++                    value = ['__sveltets_2_any()'];
++                }
++                value.push('})');
++            }
+             element.addProp(name, value);
+         };
+     const transformAttributeCase = (name) => {

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -124,7 +124,7 @@
     "fast-check": "4.9.0",
     "smtp-server": "3.19.2",
     "svelte": "^5.56.7",
-    "svelte-check": "4.7.3",
+    "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/mochi/patches/svelte-check@4.7.4.patch
+++ b/packages/mochi/patches/svelte-check@4.7.4.patch
@@ -1,0 +1,18 @@
+diff --git a/dist/src/index.js b/dist/src/index.js
+index 1efd1f365acd4e61e506459041caa9a7321cafcc..5741eb48aec77aeb2ff362674cde201787b8167d 100644
+--- a/dist/src/index.js
++++ b/dist/src/index.js
+@@ -91170,6 +91170,13 @@ function handleAttribute(str, attr, parent, preserveCase, svelte5Plus, element)
+                 }
+                 value.push('})');
+             }
++            else if (attr.name.startsWith('mochi:')) {
++                name.unshift('...__sveltets_2_empty({');
++                if (!value) {
++                    value = ['__sveltets_2_any()'];
++                }
++                value.push('})');
++            }
+             element.addProp(name, value);
+         };
+     const transformAttributeCase = (name) => {

--- a/packages/mochi/src/patches.test.ts
+++ b/packages/mochi/src/patches.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-const PATCH = 'svelte-check@4.7.3.patch';
+const PATCH = 'svelte-check@4.7.4.patch';
 const CANONICAL = join(import.meta.dir, '..', 'patches', PATCH);
 const TEMPLATE_COPIES = [join(import.meta.dir, '..', '..', 'minimal', 'patches', PATCH), join(import.meta.dir, '..', '..', 'demos', 'patches', PATCH)];
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -37,7 +37,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
-    "svelte-check": "4.7.3",
+    "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/bun": "1.3.14",
-    "svelte-check": "4.7.3",
+    "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   },
   "overrides": {


### PR DESCRIPTION
Bumps `svelte-check` from **4.7.3 → 4.7.4** and re-rolls the `mochi:` attribute patch against it.

`svelte-check` is exact-pinned on purpose because the patch key is version-exact, so the version has to move in four coupled places at once: root `patchedDependencies` (key *and* filename), `.syncpackrc.json`'s `pinVersion`, the `svelte-check` devDependency in all six workspaces, and `packages/mochi/src/patches.test.ts`'s `PATCH` constant.

## The patch

`mochi:` handling is still absent upstream in 4.7.4, so the patch is still required. It was regenerated with `bun patch` (not hand-edited), and the result is **byte-identical to the 4.7.3 patch apart from the blob hashes** — same hunk, same offset, still chained onto the `--` cssProp branch in `handleAttribute`:

```js
else if (attr.name.startsWith('mochi:')) {
    name.unshift('...__sveltets_2_empty({');
    if (!value) {
        value = ['__sveltets_2_any()'];
    }
    value.push('})');
}
```

Per the existing convention, `packages/mochi/patches/` carries only the current version, while the `minimal` / `demos` template copies accumulate (`4.4.7`, `4.6.0`, `4.7.1`, `4.7.3`, and now `4.7.4`) — the CLI deliberately references every shipped version so a generated project survives drift. All three copies are byte-identical, which `patches.test.ts` enforces.

## Why the `fix(cli):` commit is separate

Templates are downloaded from `main` at scaffold time (`giget`, default branch), but `create-mochi` is published independently — and **published `create-mochi@0.3.0` tops out at the `4.7.3` entry** (verified by unpacking it from npm).

So without the CLI change, the moment this merges: `npm create mochi` fetches a template pinned to `svelte-check@4.7.4`, the published CLI writes no matching `patchedDependencies` entry, the patch silently doesn't apply, and the scaffolded project's `bun run typecheck` fails on `mochi:hydrate`. That's exactly the drift the "reference every shipped version" design in `utils.ts` guards against — but the guard only works if the CLI ships the new entry.

Splitting it means release-please offers a **create-mochi patch release** while leaving `mochi-framework` unreleased, which is correct: only a devDependency moved, nothing in the published framework's dependency or peer graph changed.

## Verification

- **`bun run syncpack`** — ✅ no issues; the pin group agrees across all six workspaces.
- **`bun run checks`** — ✅ all four stages. Typecheck 0 errors everywhere (`mochi-framework` 1258 files, `mochi-site` 946 files). Tests: `mochi-framework` 142/142 files, `create-mochi` 16/16, `@mochi-framework/rsvelte` 64/64, `mochi-demos` 31/31, `mochi-site` 9/9, `mochi-support` 2/2, `mochi-minimal` 1/1, `mochi-minimal-rsvelte` 2/2. No `mochi:` diagnostic, no "Unknown attribute", no "not assignable to type 'never'".
- **`bun run cli-test`** — ✅ pass (scaffold, install, test, typecheck).
- **Clean-install proof** — `rm -rf node_modules && bun install` from the repo-convention patch path, then confirmed `attr.name.startsWith('mochi:')` is present in the installed `node_modules/svelte-check/dist/src/index.js`. The patch applies from scratch, not just incrementally.
- **Negative control** — the patch is load-bearing, not vestigial. With `patchedDependencies` temporarily removed and a reinstall, `svelte-check` on `packages/minimal` fails on `<Leaves mochi:hydrate />`:

  ```
  ERROR "src/HelloWorld.svelte" 18:9 "Type 'true' is not assignable to type 'never'."
  ```

  Restoring the patch and reinstalling returns `COMPLETED 466 FILES 0 ERRORS 0 WARNINGS`.

## Note

`bun.lock` also moves `@sveltejs/load-config` 0.2.0 → 0.2.1 as a `svelte-check` transitive. Otherwise the lockfile diff is `svelte-check` only.
