### PR TITLE
fix(cache): run one FileStorage sweeper per directory

### DIFF
--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -114,6 +114,8 @@ Binary fields (`Uint8Array` / `Buffer`) anywhere in a value round-trip transpare
 | `maxAge`        | `600_000` (10min) | Files older than this are deleted by the sweep.                            |
 | `offloadBinary` | `false`           | Offload binary fields to per-key blob files, read back as lazy `BlobRef`s. |
 
+Only one background sweeper runs per cache directory per process. Constructing another `FileStorage` on the same directory transfers the sweep to the newest instance (and with it that instance's `maxAge`), so a dev-server reload that re-runs your module never stacks up duplicate sweepers.
+
 <Callout type="warning">
 
 **Keep `maxAge` at or above `maxTimeToLive`.** The sweep deletes files past `maxAge` — set it lower and the sweeper would remove entries the cache still wants to serve stale, turning a fast stale read into a blocking recompute. Values must be JSON-serializable (no `Date`, `Map`, `BigInt`, or `undefined` round-trip).

--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -114,7 +114,7 @@ Binary fields (`Uint8Array` / `Buffer`) anywhere in a value round-trip transpare
 | `maxAge`        | `600_000` (10min) | Files older than this are deleted by the sweep.                            |
 | `offloadBinary` | `false`           | Offload binary fields to per-key blob files, read back as lazy `BlobRef`s. |
 
-Only one background sweeper runs per cache directory per process. Constructing another `FileStorage` on the same directory transfers the sweep to the newest instance (and with it that instance's `maxAge`), so a dev-server reload that re-runs your module never stacks up duplicate sweepers.
+Only one background sweeper runs per cache directory per process. Constructing another `FileStorage` on the same directory transfers the sweep to the newest instance (and with it that instance's `maxAge`), so a dev-server reload that re-runs your module never stacks up duplicate sweepers. Ownership never moves back: `dispose()` on the newest instance ends the sweep for that directory even if an older instance is still in use.
 
 <Callout type="warning">
 

--- a/packages/mochi/src/cache/cache-storage-file.test.ts
+++ b/packages/mochi/src/cache/cache-storage-file.test.ts
@@ -164,8 +164,8 @@ describe('FileStorage', () => {
     }
     expect(ticks).toBeGreaterThanOrEqual(1);
 
-    // Disposing the owner must silence the directory outright: a surviving sweeper on `first` would keep ticking. This
-    // is asserted instead of counting events over a window, which flakes when CI load starves the 20ms interval.
+    // Asserts silence after disposing the owner rather than counting events over a window, which flakes when CI load
+    // starves the 20ms interval.
     second.dispose();
     const settled = ticks;
     await wait(200);

--- a/packages/mochi/src/cache/cache-storage-file.test.ts
+++ b/packages/mochi/src/cache/cache-storage-file.test.ts
@@ -149,6 +149,45 @@ describe('FileStorage', () => {
     expect(events.length).toBeGreaterThanOrEqual(1);
   });
 
+  test('a second store on the same directory takes the sweeper over instead of adding one', async () => {
+    let ticks = 0;
+    mochiEvents.on('cache:sweep', () => ticks++);
+
+    const dir = makeDir();
+    const first = new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 });
+    created.push(first);
+    const second = new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 });
+    created.push(second);
+
+    for (let i = 0; i < 200 && ticks === 0; i++) {
+      await wait(10);
+    }
+    expect(ticks).toBeGreaterThanOrEqual(1);
+
+    // Disposing the owner must silence the directory outright: a surviving sweeper on `first` would keep ticking. This
+    // is asserted instead of counting events over a window, which flakes when CI load starves the 20ms interval.
+    second.dispose();
+    const settled = ticks;
+    await wait(200);
+    expect(ticks).toBe(settled);
+  });
+
+  test('disposing a superseded store leaves the newest one sweeping', async () => {
+    let ticks = 0;
+    mochiEvents.on('cache:sweep', () => ticks++);
+
+    const dir = makeDir();
+    const first = new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 });
+    created.push(first);
+    created.push(new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 }));
+
+    first.dispose();
+    for (let i = 0; i < 200 && ticks === 0; i++) {
+      await wait(10);
+    }
+    expect(ticks).toBeGreaterThanOrEqual(1);
+  });
+
   test('sweep reports the plaintext keys it removed when asked', async () => {
     const storage = makeStorage({ maxAge: 50 });
     await storage.setItem('alpha', { value: 1, createdAt: 0 });

--- a/packages/mochi/src/cache/cache-storage-file.test.ts
+++ b/packages/mochi/src/cache/cache-storage-file.test.ts
@@ -153,11 +153,12 @@ describe('FileStorage', () => {
     let ticks = 0;
     mochiEvents.on('cache:sweep', () => ticks++);
 
+    // Three deep so a take-over that only ever displaces the immediately preceding store is caught too.
     const dir = makeDir();
-    const first = new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 });
-    created.push(first);
-    const second = new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 });
-    created.push(second);
+    created.push(new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 }));
+    created.push(new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 }));
+    const newest = new FileStorage({ directory: dir, maxAge: 5, purgeInterval: 20 });
+    created.push(newest);
 
     for (let i = 0; i < 200 && ticks === 0; i++) {
       await wait(10);
@@ -165,13 +166,15 @@ describe('FileStorage', () => {
     expect(ticks).toBeGreaterThanOrEqual(1);
 
     // Asserts silence after disposing the owner rather than counting events over a window, which flakes when CI load
-    // starves the 20ms interval.
-    second.dispose();
+    // starves the 20ms interval. The wait before snapshotting lets a sweep already in flight at dispose() land first.
+    newest.dispose();
+    await wait(50);
     const settled = ticks;
     await wait(200);
     expect(ticks).toBe(settled);
   });
 
+  // Guards the ownership check in `dispose()`: a superseded store must not clear the live owner's registry entry.
   test('disposing a superseded store leaves the newest one sweeping', async () => {
     let ticks = 0;
     mochiEvents.on('cache:sweep', () => ticks++);

--- a/packages/mochi/src/cache/cache-storage.ts
+++ b/packages/mochi/src/cache/cache-storage.ts
@@ -6,8 +6,10 @@ import { mochiEvents } from '../events';
 import { pinGlobal } from '../utils/globalState';
 import { logger } from '../utils/log';
 
+// A closure rather than the instance, so taking a sweeper over needs no public method on `FileStorage` — the registry
+// may hold an entry from a different bundled copy of this class.
 interface SweeperOwner {
-  stopSweepTimers(): void;
+  stop(): void;
 }
 
 // Dev HMR rebuilds a module-scope FileStorage on every reload while the previous copy becomes unreachable, so nobody
@@ -255,6 +257,7 @@ export class FileStorage implements Storage {
   private initialTimer?: ReturnType<typeof setTimeout>;
   private intervalTimer?: ReturnType<typeof setInterval>;
   private sweepKey?: string;
+  private sweepOwner?: SweeperOwner;
 
   constructor(options: FileStorageOptions) {
     this.directory = options.directory;
@@ -462,9 +465,7 @@ export class FileStorage implements Storage {
     return options.reportKeys ? { removed, removedKeys } : { removed };
   }
 
-  // @internal Public only so `FileStorage` structurally satisfies `SweeperOwner` — the registry may hold an instance
-  // from a different bundled copy of this class.
-  stopSweepTimers(): void {
+  private stopSweepTimers(): void {
     if (this.initialTimer) {
       clearTimeout(this.initialTimer);
     }
@@ -479,10 +480,11 @@ export class FileStorage implements Storage {
   dispose(): void {
     this.stopSweepTimers();
     // A newer instance may have taken the directory over and must keep sweeping it.
-    if (this.sweepKey !== undefined && sweeperOwners.get(this.sweepKey) === this) {
+    if (this.sweepKey !== undefined && sweeperOwners.get(this.sweepKey) === this.sweepOwner) {
       sweeperOwners.delete(this.sweepKey);
     }
     this.sweepKey = undefined;
+    this.sweepOwner = undefined;
   }
 
   // The plaintext key stored in a file's envelope, or null if it can't be recovered
@@ -577,8 +579,9 @@ export class FileStorage implements Storage {
     // Newest wins: an older instance is usually a dead HMR copy, and first-wins would pin the sweep to one that
     // `dispose()` can never reach.
     const key = resolve(this.directory);
-    sweeperOwners.get(key)?.stopSweepTimers();
+    sweeperOwners.get(key)?.stop();
     this.sweepKey = key;
+    this.sweepOwner = { stop: () => this.stopSweepTimers() };
 
     // An initial pass shortly after boot reclaims accrued cruft and makes the
     // sweeper visible right away; both timers are unref'd so they never keep the
@@ -587,6 +590,6 @@ export class FileStorage implements Storage {
     this.intervalTimer = setInterval(run, intervalMs);
     this.initialTimer.unref?.();
     this.intervalTimer.unref?.();
-    sweeperOwners.set(key, this);
+    sweeperOwners.set(key, this.sweepOwner);
   }
 }

--- a/packages/mochi/src/cache/cache-storage.ts
+++ b/packages/mochi/src/cache/cache-storage.ts
@@ -1,9 +1,21 @@
 import { mkdirSync, rmSync, type Dirent } from 'node:fs';
 import { mkdir, open, readdir, rename, rm, stat, unlink, type FileHandle } from 'node:fs/promises';
-import { join, relative } from 'node:path';
+import { join, relative, resolve } from 'node:path';
 import type { Storage, SweepOptions, SweepResult } from './cache';
 import { mochiEvents } from '../events';
+import { pinGlobal } from '../utils/globalState';
 import { logger } from '../utils/log';
+
+/** A store that can be told to drop its sweep timers when another takes its directory over. */
+interface SweeperOwner {
+  stopSweepTimers(): void;
+}
+
+// Dev HMR re-executes a site's module graph in a fresh copy on every reload, so a module-scope FileStorage is rebuilt
+// each time while the previous copy becomes unreachable — nobody is left to dispose() it and its unref'd interval keeps
+// sweeping forever. Keyed on the resolved directory because a sweep deletes files by mtime, making it a property of the
+// directory rather than of any one instance. Pinned so duplicate bundled framework copies share one registry.
+const sweeperOwners = pinGlobal('__mochi_cache_sweeper_owners__', () => new Map<string, SweeperOwner>());
 
 /**
  * On-disk sentinel written in place of a binary field: a pointer (relative to the
@@ -244,6 +256,7 @@ export class FileStorage implements Storage {
   private offloadBinary: boolean;
   private initialTimer?: ReturnType<typeof setTimeout>;
   private intervalTimer?: ReturnType<typeof setInterval>;
+  private sweepKey?: string;
 
   constructor(options: FileStorageOptions) {
     this.directory = options.directory;
@@ -451,8 +464,11 @@ export class FileStorage implements Storage {
     return options.reportKeys ? { removed, removedKeys } : { removed };
   }
 
-  /** Stop the background sweep. Call when the cache is no longer needed (e.g. in tests). */
-  dispose(): void {
+  /**
+   * @internal Drop the sweep timers without releasing directory ownership. Public only so `FileStorage` structurally
+   * satisfies the registry's `SweeperOwner`, which may hold an instance from a different bundled copy of this class.
+   */
+  stopSweepTimers(): void {
     if (this.initialTimer) {
       clearTimeout(this.initialTimer);
     }
@@ -461,6 +477,17 @@ export class FileStorage implements Storage {
     }
     this.initialTimer = undefined;
     this.intervalTimer = undefined;
+  }
+
+  /** Stop the background sweep. Call when the cache is no longer needed (e.g. in tests). */
+  dispose(): void {
+    this.stopSweepTimers();
+    // Only relinquish ownership while it is still ours — a newer instance may have taken the directory over and must
+    // keep sweeping it.
+    if (this.sweepKey !== undefined && sweeperOwners.get(this.sweepKey) === this) {
+      sweeperOwners.delete(this.sweepKey);
+    }
+    this.sweepKey = undefined;
   }
 
   // The plaintext key stored in a file's envelope, or null if it can't be recovered
@@ -552,6 +579,12 @@ export class FileStorage implements Storage {
         logger.warn(`Cache sweep failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     };
+    // Newest instance wins the directory: an older one is usually a dead HMR module copy, and if it is instead a live
+    // store that later gets disposed, first-wins would leave the directory unswept.
+    const key = resolve(this.directory);
+    sweeperOwners.get(key)?.stopSweepTimers();
+    this.sweepKey = key;
+
     // An initial pass shortly after boot reclaims accrued cruft and makes the
     // sweeper visible right away; both timers are unref'd so they never keep the
     // process alive.
@@ -559,5 +592,6 @@ export class FileStorage implements Storage {
     this.intervalTimer = setInterval(run, intervalMs);
     this.initialTimer.unref?.();
     this.intervalTimer.unref?.();
+    sweeperOwners.set(key, this);
   }
 }

--- a/packages/mochi/src/cache/cache-storage.ts
+++ b/packages/mochi/src/cache/cache-storage.ts
@@ -6,15 +6,13 @@ import { mochiEvents } from '../events';
 import { pinGlobal } from '../utils/globalState';
 import { logger } from '../utils/log';
 
-/** A store that can be told to drop its sweep timers when another takes its directory over. */
 interface SweeperOwner {
   stopSweepTimers(): void;
 }
 
-// Dev HMR re-executes a site's module graph in a fresh copy on every reload, so a module-scope FileStorage is rebuilt
-// each time while the previous copy becomes unreachable — nobody is left to dispose() it and its unref'd interval keeps
-// sweeping forever. Keyed on the resolved directory because a sweep deletes files by mtime, making it a property of the
-// directory rather than of any one instance. Pinned so duplicate bundled framework copies share one registry.
+// Dev HMR rebuilds a module-scope FileStorage on every reload while the previous copy becomes unreachable, so nobody
+// is left to dispose() it and its unref'd interval sweeps forever. Keyed by directory since a sweep deletes files by
+// mtime; pinned so duplicate bundled framework copies share one registry.
 const sweeperOwners = pinGlobal('__mochi_cache_sweeper_owners__', () => new Map<string, SweeperOwner>());
 
 /**
@@ -464,10 +462,8 @@ export class FileStorage implements Storage {
     return options.reportKeys ? { removed, removedKeys } : { removed };
   }
 
-  /**
-   * @internal Drop the sweep timers without releasing directory ownership. Public only so `FileStorage` structurally
-   * satisfies the registry's `SweeperOwner`, which may hold an instance from a different bundled copy of this class.
-   */
+  // @internal Public only so `FileStorage` structurally satisfies `SweeperOwner` — the registry may hold an instance
+  // from a different bundled copy of this class.
   stopSweepTimers(): void {
     if (this.initialTimer) {
       clearTimeout(this.initialTimer);
@@ -482,8 +478,7 @@ export class FileStorage implements Storage {
   /** Stop the background sweep. Call when the cache is no longer needed (e.g. in tests). */
   dispose(): void {
     this.stopSweepTimers();
-    // Only relinquish ownership while it is still ours — a newer instance may have taken the directory over and must
-    // keep sweeping it.
+    // A newer instance may have taken the directory over and must keep sweeping it.
     if (this.sweepKey !== undefined && sweeperOwners.get(this.sweepKey) === this) {
       sweeperOwners.delete(this.sweepKey);
     }
@@ -579,8 +574,8 @@ export class FileStorage implements Storage {
         logger.warn(`Cache sweep failed: ${err instanceof Error ? err.message : String(err)}`);
       }
     };
-    // Newest instance wins the directory: an older one is usually a dead HMR module copy, and if it is instead a live
-    // store that later gets disposed, first-wins would leave the directory unswept.
+    // Newest wins: an older instance is usually a dead HMR copy, and first-wins would pin the sweep to one that
+    // `dispose()` can never reach.
     const key = resolve(this.directory);
     sweeperOwners.get(key)?.stopSweepTimers();
     this.sweepKey = key;


### PR DESCRIPTION
## Problem

Dev logs showed several `CACHE sweep nothing expired` lines per minute at distinct second-offsets:

```
18:34:04 CACHE sweep nothing expired 1ms
18:34:06 CACHE sweep nothing expired 1ms
18:34:20 CACHE sweep nothing expired 1ms
18:34:26 CACHE sweep nothing expired 1ms
```

Each offset is a **separate leaked sweep timer**, not one noisy sweeper.

`FileStorage`'s constructor calls `startSweeper()` unconditionally, and `startSweeper` sets a 1s one-shot plus a 60s interval with no dedupe guard of any kind. In dev, `devWatcher.buildEntry()` bundles the site entry with `packages: 'external'` — which inlines relative deps like `packages/site/src/lib/ci.ts` — and `extractServeOptions` then calls `freshImport`, which copies the bundle to a unique `*.hmr-N.js` name to force a module-cache miss. All top-level module code re-runs, constructing another `FileStorage`.

The previous copy is unreachable, so nothing ever calls its `dispose()`, and the timers are `unref`'d rather than cleared — the zombie keeps sweeping for the life of the process. `mochiEvents` is pinned on `globalThis`, so every dead copy's emit still reaches the one (correctly deduped) console logger.

You get 2 timers before any edit (the dev watcher builds the entry on top of the server's own import) plus 1 per non-`.svelte` edit to an entry dep.

## Fix

A `pinGlobal` registry keyed by resolved cache directory. The newest `FileStorage` for a directory takes ownership and stops the previous owner's timers; `dispose()` releases ownership only while it still holds it.

Newest-wins rather than first-wins: after an HMR reload the *first* instance is the dead one, so first-wins would pin sweeping to a garbage instance that no `dispose()` can reach. A sweep deletes files by mtime, making it a property of the directory rather than of any one instance — two sweepers on one directory are pure duplicated I/O. The one user-visible consequence, documented in `145-cache.md`: if two instances on a directory disagree on `maxAge`, the newest one's threshold governs.

`MemoryStorage` is deliberately untouched — its instances have disjoint `Map`s, so there's no key meaning "same data", and its `purgeInterval` is opt-in and unset by default.

The 1s `initialTimer` stays: with the guard it's one line per boot, and it makes a misconfigured `maxAge` visible immediately.

## Out of scope

Disposing storages from `server.stop`. The framework holds no registry of user-constructed `MochiCache`/`FileStorage` instances, the timers are `unref`'d so they never delay exit, and sweeping the registry there would break an in-process server restart.

## Verification

**Unit tests** — two new tests in `cache-storage-file.test.ts`. Both assert on "does the directory go silent", which is deterministic, rather than counting events over a window (flaky when CI load starves the 20ms interval). Confirmed they catch the bug: with the take-over line disabled, the first fails with 12 ticks vs the expected 2.

**End-to-end** — ran the site dev server and made four entry-dep edits, giving six `FileStorage` constructions in total:

```
18:58:40 CACHE sweep nothing expired 6ms   <- boot: server's own import
18:58:42 CACHE sweep nothing expired 5ms   <- boot: devWatcher buildEntry
18:59:26 CACHE sweep nothing expired 0ms   <- edit 1 (new owner's 1s pass)
18:59:32 CACHE sweep nothing expired 1ms   <- edit 2
18:59:38 CACHE sweep nothing expired 1ms   <- edit 3
18:59:44 CACHE sweep nothing expired 1ms   <- revert
19:00:43 CACHE sweep nothing expired 0ms   <- steady state: ONE line
```

The six clustered lines are each new owner's one-shot pass. The following minute has a single sweep — before this change it would have shown six, one per leaked interval.

`bun run checks` passes (lint, format, typecheck, tests; no files modified).