### PR TITLE
feat(site): add Runed utilities demo

### DIFF
--- a/.claude/skills/add-library-demo/SKILL.md
+++ b/.claude/skills/add-library-demo/SKILL.md
@@ -16,8 +16,7 @@ The demo's intro (a `<p>`/`<div>` at the top of the `DemoPage` **body**, not the
 2. **Basic install info** — an install line (`bun add <lib>`).
 3. **A very basic code sample of using the library** — a minimal real snippet (an import plus the simplest call), not just the install command.
 
-Render both through `CodeSnippet` (`import CodeSnippet from '../../components/CodeSnippet.svelte'`) fed by `highlightCode(code, 'bash' | 'typescript')` from `../../lib/highlight.server` — Shiki-highlighted and consistent with the other demos, and it sidesteps the `.svelte` brace/generic-parsing trap of putting a literal code sample in markup.
-4. **A link to the library's website**, `target="_blank" rel="noopener noreferrer"` (matches the site's outbound-link convention).
+Render both through `CodeSnippet` (`import CodeSnippet from '../../components/CodeSnippet.svelte'`) fed by `highlightCode(code, 'bash' | 'typescript')` from `../../lib/highlight.server` — Shiki-highlighted and consistent with the other demos, and it sidesteps the `.svelte` brace/generic-parsing trap of putting a literal code sample in markup. 4. **A link to the library's website**, `target="_blank" rel="noopener noreferrer"` (matches the site's outbound-link convention).
 
 ## Steps
 

--- a/.claude/skills/add-library-demo/SKILL.md
+++ b/.claude/skills/add-library-demo/SKILL.md
@@ -13,8 +13,10 @@ Build one demo folder that exercises the interesting parts of a library across o
 The demo's intro (a `<p>`/`<div>` at the top of the `DemoPage` **body**, not the `description` prop — that prop is escaped plain text and also feeds SEO meta) must state:
 
 1. **Setup — whether anything special is required.** If the library needs nothing special, say so plainly (e.g. "needs no special setup — it's a plain Svelte 5 runes library, so you install it and import from `<lib>`; in Mochi it bundles straight into whichever island imports it"). If it _does_ need config/a plugin/a provider, describe that instead — don't claim zero-setup unless it's true.
-2. **Basic install info** — an install line in a `<pre><code>bun add <lib></code></pre>` block.
+2. **Basic install info** — an install line (`bun add <lib>`).
 3. **A very basic code sample of using the library** — a minimal real snippet (an import plus the simplest call), not just the install command.
+
+Render both through `CodeSnippet` (`import CodeSnippet from '../../components/CodeSnippet.svelte'`) fed by `highlightCode(code, 'bash' | 'typescript')` from `../../lib/highlight.server` — Shiki-highlighted and consistent with the other demos, and it sidesteps the `.svelte` brace/generic-parsing trap of putting a literal code sample in markup.
 4. **A link to the library's website**, `target="_blank" rel="noopener noreferrer"` (matches the site's outbound-link convention).
 
 ## Steps

--- a/.claude/skills/add-library-demo/SKILL.md
+++ b/.claude/skills/add-library-demo/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: add-library-demo
+description: Add a demo to the Mochi site (`packages/site`) that showcases a third-party library (usually a Svelte 5 / runes library like Runed) running inside islands. Use when the user asks to "add a demo for <library>", "demo <library> in Mochi", "show <library> off", or "/add-library-demo <library>".
+user-invocable: true
+---
+
+# Add a third-party-library demo
+
+Build one demo folder that exercises the interesting parts of a library across one or more `mochi:hydrate` islands, then wire it into the four registration points. Most such libraries are browser-driven, so this is a hydration showcase: the page renders on the server with default values, then the library comes alive on the client.
+
+## Intro text — always three things
+
+The demo's intro (a `<p>`/`<div>` at the top of the `DemoPage` **body**, not the `description` prop — that prop is escaped plain text and also feeds SEO meta) must state:
+
+1. **Setup.** If the library needs nothing special, say so plainly (e.g. "needs no special setup — it's a plain Svelte 5 runes library, so you install it and import from `<lib>`; in Mochi it bundles straight into whichever island imports it"). If it _does_ need config/a plugin/a provider, describe that instead — don't claim zero-setup unless it's true.
+2. **A basic install/usage code example.** At minimum an install line in a `<pre><code>bun add <lib></code></pre>` block; a tiny usage snippet is even better.
+3. **A link to the library's website**, `target="_blank" rel="noopener noreferrer"` (matches the site's outbound-link convention).
+
+## Steps
+
+1. **Pin the version, then add the dep:** `bun info <lib> version`, then `bun add <lib> --cwd packages/site`. This is likely the first third-party _runtime_ library bundled into an island — that's fine, but see the browser check below.
+
+2. **Create `packages/site/src/demos/<slug>/`** — model on `demos/cookies/` and `demos/hydration/`:
+   - Entry `<Name>.svelte`: wrap in `<DemoPage title description {sources}>`, `const sources = await loadSources(files)`, place each island with `mochi:hydrate`. Group by theme — one island component per themed card reads better than one giant island.
+   - Island component(s): `<script lang="ts">`, import from `<lib>`, scoped `<style>` using the site CSS custom properties (`--surface`, `--border`, `--text`, `--accent`, `--font-mono`, `--code-bg`, badge tokens…). Reuse `components/Badge.svelte` for status pills. Element-ref utilities need `$state()` + `bind:this` passed as a getter `() => el`.
+   - `routes.ts`: `'/demos/<slug>': Mochi.page('./src/demos/<slug>/<Name>.svelte')` plus any backing `Mochi.api` the demo needs.
+   - `files.ts`: `SourceSpec[]` listing every source, ending with `{ label: 'index.ts', path: './src/demoIndex.ts' }` (verbatim, like every demo).
+
+3. **Wire the four registration points** (`demoRegistry.test.ts` enforces they stay consistent):
+   - `src/routes.ts` — `import { routes as <x>Routes } from './demos/<slug>/routes';` + `...<x>Routes,`.
+   - `src/lib/demos.ts` — `import { files as <x> } from '../demos/<slug>/files.ts';` + a `demos[]` entry `{ href: '/demos/<slug>/', slug, files, title, hook, category: 'hydration' }`.
+   - `src/lib/demoIcons.ts` — import an **unused** per-icon Lucide path and add `'<Title>': { icon, label }` to `demoIconFor` (keyed by title, not slug).
+   - No `Site.svelte` edit — the landing page derives from the registry.
+
+## Gotchas
+
+- **API routes obey `trailingSlash: 'always'`.** A client `fetch('/api/<slug>/x')` 301/308-redirects; fetch the canonical `'/api/<slug>/x/'` directly.
+- **SSR runs the island too.** Browser-only utilities are SSR-safe but return defaults (`0`/`false`/`undefined`) during SSR, then the top-level re-runs on the client during hydration — design each card so the SSR state reads as intended, not broken.
+- **A class utility whose constructor synchronously touches the instance being assigned** (e.g. a `FiniteStateMachine` initial-state `_enter` that references the `const`) hits the temporal dead zone — defer the self-reference (`queueMicrotask`) and/or guard on `isBrowser`.
+
+## Verify
+
+- Start one site on a free port: `PORT=4444 bun run dev:site`. `curl` the page (trailing slash) for a 200 + the intro's install line/link.
+- **Drive a real browser** (chrome-devtools MCP) against `/demos/<slug>/` — curl only exercises SSR. Confirm every island hydrates with **zero console errors/warnings** (this is the load-bearing check for a first-time island dependency), any backing `fetch` succeeds, and interactions work. Screenshot for a visual check.
+- Tear down with `pkill -f dev:site` (verify `pgrep -x bun`).
+- Delegate `bun run checks` + `bun run format` to a sub-agent (keep the output out of the main context). **Never commit** unless asked.

--- a/.claude/skills/add-library-demo/SKILL.md
+++ b/.claude/skills/add-library-demo/SKILL.md
@@ -8,13 +8,14 @@ user-invocable: true
 
 Build one demo folder that exercises the interesting parts of a library across one or more `mochi:hydrate` islands, then wire it into the four registration points. Most such libraries are browser-driven, so this is a hydration showcase: the page renders on the server with default values, then the library comes alive on the client.
 
-## Intro text — always three things
+## Intro text — always four things
 
 The demo's intro (a `<p>`/`<div>` at the top of the `DemoPage` **body**, not the `description` prop — that prop is escaped plain text and also feeds SEO meta) must state:
 
-1. **Setup.** If the library needs nothing special, say so plainly (e.g. "needs no special setup — it's a plain Svelte 5 runes library, so you install it and import from `<lib>`; in Mochi it bundles straight into whichever island imports it"). If it _does_ need config/a plugin/a provider, describe that instead — don't claim zero-setup unless it's true.
-2. **A basic install/usage code example.** At minimum an install line in a `<pre><code>bun add <lib></code></pre>` block; a tiny usage snippet is even better.
-3. **A link to the library's website**, `target="_blank" rel="noopener noreferrer"` (matches the site's outbound-link convention).
+1. **Setup — whether anything special is required.** If the library needs nothing special, say so plainly (e.g. "needs no special setup — it's a plain Svelte 5 runes library, so you install it and import from `<lib>`; in Mochi it bundles straight into whichever island imports it"). If it _does_ need config/a plugin/a provider, describe that instead — don't claim zero-setup unless it's true.
+2. **Basic install info** — an install line in a `<pre><code>bun add <lib></code></pre>` block.
+3. **A very basic code sample of using the library** — a minimal real snippet (an import plus the simplest call), not just the install command.
+4. **A link to the library's website**, `target="_blank" rel="noopener noreferrer"` (matches the site's outbound-link convention).
 
 ## Steps
 

--- a/bun.lock
+++ b/bun.lock
@@ -192,6 +192,7 @@
         "mochi-framework": "workspace:*",
         "mochi-shared": "workspace:*",
         "rehype-slug": "^6.0.0",
+        "runed": "^0.37.1",
         "shiki": "^4.3.1",
         "slugify": "^1.6.9",
         "svelte": "^5.56.8",
@@ -969,6 +970,8 @@
 
     "lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@1.0.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA=="],
 
     "marky": ["marky@1.3.0", "", {}, "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ=="],
@@ -1148,6 +1151,8 @@
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "rimraf": ["rimraf@6.1.3", "", { "dependencies": { "glob": "^13.0.3", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA=="],
+
+    "runed": ["runed@0.37.1", "", { "dependencies": { "dequal": "^2.0.3", "esm-env": "^1.0.0", "lz-string": "^1.5.0" }, "peerDependencies": { "@sveltejs/kit": "^2.21.0", "svelte": "^5.7.0", "zod": "^4.1.0" }, "optionalPeers": ["@sveltejs/kit", "zod"] }, "sha512-MeFY73xBW8IueWBm012nNFIGy19WUGPLtknavyUPMpnyt350M47PhGSGrGoSLbidwn+Zlt/O0cp8/OZE3LASWA=="],
 
     "sade": ["sade@1.8.1", "", { "dependencies": { "mri": "^1.1.0" } }, "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A=="],
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -26,6 +26,7 @@
     "mochi-framework": "workspace:*",
     "mochi-shared": "workspace:*",
     "rehype-slug": "^6.0.0",
+    "runed": "^0.37.1",
     "shiki": "^4.3.1",
     "slugify": "^1.6.9",
     "svelte": "^5.56.8",

--- a/packages/site/src/demos/entity-props/EntityDemo.svelte
+++ b/packages/site/src/demos/entity-props/EntityDemo.svelte
@@ -1,12 +1,26 @@
 <script lang="ts">
   import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
   import EntityIsland from './EntityIsland.svelte';
   import { loadSources } from '../../components/utils.ts';
+  import { highlightCode } from '../../lib/highlight.server';
   import { files } from './files.ts';
 
   const sources = await loadSources(files);
 
   const name = 'friend';
+
+  const codeUsage = await highlightCode(
+    `<EntityIsland
+  label="Tom &amp; Jerry"
+  quote="She said &quot;hi&quot;"
+  comparison="5 &lt; 10 &amp;&amp; 10 &gt; 5"
+  copyright="&copy; 2026 Mochi"
+  greeting="Hi &amp; welcome, {name}"
+  mochi:hydrate
+/>`,
+    'svelte',
+  );
 </script>
 
 <DemoPage
@@ -20,16 +34,7 @@
       and Mochi's preprocessor decodes the same value into the serialized props the client hydrates with — so the two never disagree. Watch the
       <strong>Rendered on</strong> line flip from <code>server</code> to <code>client</code> after hydration while every value stays the same.
     </p>
-    <pre><code
-        >{`<EntityIsland
-  label="Tom &amp; Jerry"
-  quote="She said &quot;hi&quot;"
-  comparison="5 &lt; 10 &amp;&amp; 10 &gt; 5"
-  copyright="&copy; 2026 Mochi"
-  greeting="Hi &amp; welcome, {name}"
-  mochi:hydrate
-/>`}</code
-      ></pre>
+    <CodeSnippet html={codeUsage} />
   </section>
 
   <EntityIsland
@@ -69,23 +74,5 @@
     padding: 0.1em 0.35em;
     border-radius: 4px;
     font-size: 0.85em;
-  }
-
-  pre {
-    margin: 0;
-    padding: 0.75rem 0.85rem;
-    background: var(--surface-muted);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    overflow-x: auto;
-    font-size: 0.85rem;
-    line-height: 1.5;
-  }
-
-  pre code {
-    background: transparent;
-    border: none;
-    padding: 0;
-    color: var(--text);
   }
 </style>

--- a/packages/site/src/demos/error/ErrorDemo.svelte
+++ b/packages/site/src/demos/error/ErrorDemo.svelte
@@ -1,6 +1,7 @@
 <script>
   import { highlightCode } from '../../lib/highlight.server';
   import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
   import { loadSources } from '../../components/utils.ts';
   import { files } from './files.ts';
 
@@ -61,8 +62,7 @@
 
     <p class="lead">This site's <code>handleError</code>:</p>
 
-    <!-- eslint-disable-next-line svelte/no-at-html-tags -->
-    {@html handleErrorHtml}
+    <CodeSnippet html={handleErrorHtml} />
 
     <p>
       Watch your dev server output while clicking the links above — each visit logs one

--- a/packages/site/src/demos/font-loading/FontLoading.svelte
+++ b/packages/site/src/demos/font-loading/FontLoading.svelte
@@ -2,10 +2,20 @@
   import '@fontsource/jetbrains-mono';
   import './lobster.css';
   import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
   import { loadSources } from '../../components/utils.ts';
+  import { highlightCode } from '../../lib/highlight.server';
   import { files } from './files.ts';
 
   const sources = await loadSources(files);
+
+  const codeFontFace = await highlightCode(
+    `@font-face {
+  font-family: 'Lobster';
+  src: url('./lobster.woff2') format('woff2');
+}`,
+    'css',
+  );
 </script>
 
 <DemoPage
@@ -27,12 +37,7 @@
       Drop a <code>.woff2</code> next to your component and reference it from a tiny
       <code>@font-face</code> CSS file:
     </p>
-    <pre><code
-        >{`@font-face {
-  font-family: 'Lobster';
-  src: url('./lobster.woff2') format('woff2');
-}`}</code
-      ></pre>
+    <CodeSnippet html={codeFontFace} />
     <p>
       Import the CSS (<code>import './lobster.css'</code>). Bun's CSS bundler inlines the <code>.woff2</code> as a base64 data URI in the bundled CSS.
     </p>
@@ -62,8 +67,5 @@
   .sample-display {
     font-family: 'Lobster', cursive;
     font-size: 2rem;
-  }
-  pre {
-    margin: 0.75rem 0;
   }
 </style>

--- a/packages/site/src/demos/island-props/ServerRenderedParent.svelte
+++ b/packages/site/src/demos/island-props/ServerRenderedParent.svelte
@@ -1,11 +1,26 @@
 <script lang="ts">
   import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
   import ClientRenderedChild from './ClientRenderedChild.svelte';
   import { typeOf } from './devalueTypeOf.ts';
   import { loadSources } from '../../components/utils.ts';
+  import { highlightCode } from '../../lib/highlight.server';
   import { files } from './files.ts';
 
   const sources = await loadSources(files);
+
+  const codeProps = await highlightCode(
+    `const dateVal = new Date('2025-01-15T12:00:00Z');
+const mapVal = new Map([['a', 1], ['b', 2], ['c', 3]]);
+const setVal = new Set([10, 20, 30]);
+const bigintVal = 9007199254740993n;
+const urlVal = new URL('https://mochi.dev/docs?version=5');
+// ...
+const cyclic: { name: string; self?: unknown } = { name: 'cyclic' };
+cyclic.self = cyclic;
+const cyclicRef = cyclic;`,
+    'ts',
+  );
 
   const shared = { x: 1 };
   const cyclic: { name: string; self?: unknown } = { name: 'cyclic' };
@@ -62,17 +77,7 @@
         <code>Client type</code> column is resolved after hydration. Matching values prove the round-trip preserved each type.
       </p>
     </header>
-    <pre><code
-        >{`const dateVal = new Date('2025-01-15T12:00:00Z');
-const mapVal = new Map([['a', 1], ['b', 2], ['c', 3]]);
-const setVal = new Set([10, 20, 30]);
-const bigintVal = 9007199254740993n;
-const urlVal = new URL('https://mochi.dev/docs?version=5');
-// ...
-const cyclic: { name: string; self?: unknown } = { name: 'cyclic' };
-cyclic.self = cyclic;
-const cyclicRef = cyclic;`}</code
-      ></pre>
+    <CodeSnippet html={codeProps} />
   </section>
 
   <div class="arrow" aria-hidden="true">
@@ -141,25 +146,6 @@ const cyclicRef = cyclic;`}</code
     padding: 0.1em 0.35em;
     border-radius: 4px;
     font-size: 0.85em;
-  }
-
-  pre {
-    margin: 0;
-    padding: 0.75rem 0.85rem;
-    background: var(--surface-muted);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    overflow-x: auto;
-    font-size: 0.85rem;
-    line-height: 1.5;
-  }
-
-  pre code {
-    background: transparent;
-    border: none;
-    padding: 0;
-    font-family: var(--font-mono);
-    color: var(--text);
   }
 
   .arrow {

--- a/packages/site/src/demos/runed/AsyncFsm.svelte
+++ b/packages/site/src/demos/runed/AsyncFsm.svelte
@@ -1,0 +1,219 @@
+<script lang="ts">
+  import { FiniteStateMachine, resource } from 'runed';
+  import { isBrowser } from 'mochi-framework';
+
+  type Light = 'red' | 'yellow' | 'green';
+  type LightEvent = 'next';
+
+  // The FSM fires the initial state's _enter synchronously inside its constructor —
+  // before `light` is assigned — so defer the self-referencing debounce to a microtask
+  // (and only drive the cycle on the client, never during SSR).
+  function scheduleNext(ms: number) {
+    if (!isBrowser) {
+      return;
+    }
+    queueMicrotask(() => light.debounce(ms, 'next'));
+  }
+
+  const light = new FiniteStateMachine<Light, LightEvent>('red', {
+    red: { next: 'green', _enter: () => scheduleNext(3000) },
+    green: { next: 'yellow', _enter: () => scheduleNext(3000) },
+    yellow: { next: 'red', _enter: () => scheduleNext(1200) },
+  });
+
+  const fruits = ['apple', 'apricot', 'banana', 'blueberry', 'cherry', 'grape', 'lemon', 'mango', 'orange', 'peach', 'pear', 'plum'];
+
+  let query = $state('');
+  const search = resource(
+    () => query,
+    async (q, _prev, { signal }) => {
+      const res = await fetch(`/api/runed/search/?q=${encodeURIComponent(q)}`, { signal });
+      return (await res.json()) as { matches: string[] };
+    },
+    { debounce: 300, initialValue: { matches: fruits } },
+  );
+</script>
+
+<div class="grid">
+  <div class="panel">
+    <div class="head">
+      <h3>FiniteStateMachine</h3>
+      <span class="hint">_enter hooks auto-advance via .debounce()</span>
+    </div>
+    <div class="light" aria-label="traffic light">
+      <span class="lamp red" class:on={light.current === 'red'}></span>
+      <span class="lamp yellow" class:on={light.current === 'yellow'}></span>
+      <span class="lamp green" class:on={light.current === 'green'}></span>
+    </div>
+    <div class="light-actions">
+      <code>{light.current}</code>
+      <button onclick={() => light.send('next')}>Next →</button>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="head">
+      <h3>resource</h3>
+      <span class="hint">debounced fetch with cancellation</span>
+    </div>
+    <input type="search" bind:value={query} placeholder="Filter fruits…" />
+    <div class="status">
+      {#if search.loading}
+        <span class="meta">Loading…</span>
+      {:else if search.error}
+        <span class="meta error">Error: {search.error.message}</span>
+      {:else}
+        <span class="meta">{search.current?.matches.length ?? 0} match{search.current?.matches.length === 1 ? '' : 'es'}</span>
+      {/if}
+    </div>
+    <div class="matches">
+      {#each search.current?.matches ?? [] as fruit (fruit)}
+        <span class="chip">{fruit}</span>
+      {/each}
+    </div>
+  </div>
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--surface-muted);
+  }
+
+  .head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .head h3 {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text);
+  }
+
+  .hint {
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .light {
+    display: inline-flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.5rem;
+    width: fit-content;
+    background: #1a1a1a;
+    border-radius: 999px;
+  }
+
+  .lamp {
+    width: 1.4rem;
+    height: 1.4rem;
+    border-radius: 50%;
+    background: #333;
+    opacity: 0.3;
+    transition: opacity 0.2s ease;
+  }
+
+  .lamp.on {
+    opacity: 1;
+  }
+
+  .lamp.red {
+    background: #ef4444;
+  }
+
+  .lamp.yellow {
+    background: #f59e0b;
+  }
+
+  .lamp.green {
+    background: #22c55e;
+  }
+
+  .light-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+  }
+
+  input {
+    padding: 0.5rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    outline: none;
+  }
+
+  input:focus {
+    border-color: var(--accent);
+    box-shadow: var(--focus-ring);
+  }
+
+  button {
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      border-color 0.12s ease;
+  }
+
+  button:hover {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--accent-soft-text);
+  }
+
+  .matches {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .chip {
+    font-size: 0.8rem;
+    padding: 0.2rem 0.55rem;
+    border-radius: 999px;
+    background: var(--surface);
+    border: 1px solid var(--border);
+    color: var(--text-muted);
+  }
+
+  code {
+    background: var(--code-bg);
+    color: var(--code-accent);
+    font-family: var(--font-mono);
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  .meta {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  .meta.error {
+    color: var(--badge-danger-text);
+  }
+</style>

--- a/packages/site/src/demos/runed/AsyncFsm.svelte
+++ b/packages/site/src/demos/runed/AsyncFsm.svelte
@@ -5,6 +5,11 @@
   type Light = 'red' | 'yellow' | 'green';
   type LightEvent = 'next';
 
+  // Time spent in each state before auto-advancing.
+  const DURATIONS: Record<Light, number> = { red: 3000, green: 3000, yellow: 1200 };
+
+  let auto = $state(true);
+
   // The FSM fires the initial state's _enter synchronously inside its constructor —
   // before `light` is assigned — so defer the self-referencing debounce to a microtask
   // (and only drive the cycle on the client, never during SSR).
@@ -12,14 +17,21 @@
     if (!isBrowser) {
       return;
     }
-    queueMicrotask(() => light.debounce(ms, 'next'));
+    queueMicrotask(() => {
+      if (auto) light.debounce(ms, 'next');
+    });
   }
 
   const light = new FiniteStateMachine<Light, LightEvent>('red', {
-    red: { next: 'green', _enter: () => scheduleNext(3000) },
-    green: { next: 'yellow', _enter: () => scheduleNext(3000) },
-    yellow: { next: 'red', _enter: () => scheduleNext(1200) },
+    red: { next: 'green', _enter: () => scheduleNext(DURATIONS.red) },
+    green: { next: 'yellow', _enter: () => scheduleNext(DURATIONS.green) },
+    yellow: { next: 'red', _enter: () => scheduleNext(DURATIONS.yellow) },
   });
+
+  function toggleAuto() {
+    auto = !auto;
+    if (auto) scheduleNext(DURATIONS[light.current]);
+  }
 
   const fruits = ['apple', 'apricot', 'banana', 'blueberry', 'cherry', 'grape', 'lemon', 'mango', 'orange', 'peach', 'pear', 'plum'];
 
@@ -48,6 +60,7 @@
     <div class="light-actions">
       <code>{light.current}</code>
       <button onclick={() => light.send('next')}>Next →</button>
+      <button onclick={toggleAuto}>{auto ? 'Pause' : 'Resume'}</button>
     </div>
   </div>
 

--- a/packages/site/src/demos/runed/AsyncFsm.svelte
+++ b/packages/site/src/demos/runed/AsyncFsm.svelte
@@ -18,7 +18,9 @@
       return;
     }
     queueMicrotask(() => {
-      if (auto) light.debounce(ms, 'next');
+      if (auto) {
+        light.debounce(ms, 'next');
+      }
     });
   }
 
@@ -30,7 +32,9 @@
 
   function toggleAuto() {
     auto = !auto;
-    if (auto) scheduleNext(DURATIONS[light.current]);
+    if (auto) {
+      scheduleNext(DURATIONS[light.current]);
+    }
   }
 
   const fruits = ['apple', 'apricot', 'banana', 'blueberry', 'cherry', 'grape', 'lemon', 'mango', 'orange', 'peach', 'pear', 'plum'];

--- a/packages/site/src/demos/runed/Elements.svelte
+++ b/packages/site/src/demos/runed/Elements.svelte
@@ -1,0 +1,214 @@
+<script lang="ts">
+  import { ElementSize, useResizeObserver, IsInViewport, activeElement, IsFocusWithin } from 'runed';
+  import Badge from '../../components/Badge.svelte';
+
+  let box = $state<HTMLElement>();
+  const size = new ElementSize(() => box);
+
+  let resizes = $state(0);
+  useResizeObserver(
+    () => box,
+    () => resizes++,
+  );
+
+  let scroller = $state<HTMLElement>();
+  let target = $state<HTMLElement>();
+  const inViewport = new IsInViewport(() => target, { root: () => scroller ?? null });
+
+  let form = $state<HTMLFormElement>();
+  const focusWithin = new IsFocusWithin(() => form);
+</script>
+
+<div class="grid">
+  <div class="panel">
+    <div class="head">
+      <h3>ElementSize + useResizeObserver</h3>
+      <span class="hint">drag the corner of the box</span>
+    </div>
+    <textarea bind:this={box} class="resizable" readonly>Drag my bottom-right corner ↘</textarea>
+    <div class="readout">
+      <code>{Math.round(size.width)} × {Math.round(size.height)}</code>
+      <span class="meta">{resizes} resize event{resizes === 1 ? '' : 's'}</span>
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="head">
+      <h3>IsInViewport</h3>
+      <span class="hint">scroll the target in and out</span>
+    </div>
+    <div bind:this={scroller} class="scroller">
+      <div class="spacer">scroll down ↓</div>
+      <div bind:this={target} class="target" class:visible={inViewport.current}>
+        {inViewport.current ? 'In viewport' : 'Out of viewport'}
+      </div>
+      <div class="spacer">↑ scroll up</div>
+    </div>
+    {#if inViewport.current}
+      <Badge kind="success">visible</Badge>
+    {:else}
+      <Badge kind="default">hidden</Badge>
+    {/if}
+  </div>
+
+  <div class="panel">
+    <div class="head">
+      <h3>activeElement + IsFocusWithin</h3>
+      <span class="hint">tab through the fields</span>
+    </div>
+    <form bind:this={form} class="fields" class:lit={focusWithin.current}>
+      <input type="text" placeholder="First" />
+      <input type="text" placeholder="Second" />
+      <button type="button">Button</button>
+    </form>
+    <div class="readout">
+      <span class="meta">focused: <code>{activeElement.current?.localName ?? 'none'}</code></span>
+      {#if focusWithin.current}
+        <Badge kind="info">focus within</Badge>
+      {/if}
+    </div>
+  </div>
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--surface-muted);
+  }
+
+  .head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .head h3 {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text);
+  }
+
+  .hint {
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .resizable {
+    resize: both;
+    min-width: 120px;
+    min-height: 60px;
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text-muted);
+    font: inherit;
+    font-size: 0.85rem;
+  }
+
+  .scroller {
+    height: 120px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+  }
+
+  .spacer {
+    height: 100px;
+    display: grid;
+    place-items: center;
+    color: var(--text-subtle);
+    font-size: 0.8rem;
+  }
+
+  .target {
+    margin: 0.5rem;
+    padding: 0.75rem;
+    border-radius: var(--radius-sm);
+    background: var(--surface-muted);
+    color: var(--text-muted);
+    text-align: center;
+    font-size: 0.85rem;
+    transition:
+      background 0.2s ease,
+      color 0.2s ease;
+  }
+
+  .target.visible {
+    background: var(--accent-soft);
+    color: var(--accent-soft-text);
+  }
+
+  .fields {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    padding: 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    transition: box-shadow 0.15s ease;
+  }
+
+  .fields.lit {
+    box-shadow: var(--focus-ring);
+  }
+
+  .fields input {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    outline: none;
+  }
+
+  .fields input:focus {
+    border-color: var(--accent);
+  }
+
+  .fields button {
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .readout {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    flex-wrap: wrap;
+  }
+
+  code {
+    background: var(--code-bg);
+    color: var(--code-accent);
+    font-family: var(--font-mono);
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  .meta {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+</style>

--- a/packages/site/src/demos/runed/Elements.svelte
+++ b/packages/site/src/demos/runed/Elements.svelte
@@ -128,7 +128,7 @@
   }
 
   .spacer {
-    height: 100px;
+    height: 180px;
     display: grid;
     place-items: center;
     color: var(--text-subtle);

--- a/packages/site/src/demos/runed/Reactivity.svelte
+++ b/packages/site/src/demos/runed/Reactivity.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+  import { Debounced, Throttled, Previous, watch } from 'runed';
+
+  let text = $state('');
+  const debounced = new Debounced(() => text, 400);
+  const throttled = new Throttled(() => text, 400);
+  const previous = new Previous(() => text);
+
+  let log = $state<string[]>([]);
+  watch(
+    () => debounced.current,
+    (value, prev) => {
+      log = [`"${prev ?? ''}" → "${value}"`, ...log].slice(0, 5);
+    },
+    { lazy: true },
+  );
+</script>
+
+<div class="grid">
+  <label class="field">
+    <span>Type here</span>
+    <input type="text" bind:value={text} placeholder="Start typing…" />
+  </label>
+
+  <div class="readouts">
+    <div class="row"><span class="key">live</span><code>{text || '—'}</code></div>
+    <div class="row"><span class="key">Debounced (400ms)</span><code>{debounced.current || '—'}</code></div>
+    <div class="row"><span class="key">Throttled (400ms)</span><code>{throttled.current || '—'}</code></div>
+    <div class="row"><span class="key">Previous</span><code>{previous.current ?? '—'}</code></div>
+  </div>
+
+  <div class="watch">
+    <span class="key">watch() change log</span>
+    {#if log.length === 0}
+      <p class="empty">Waiting for the debounced value to settle…</p>
+    {:else}
+      <ul>
+        {#each log as entry (entry + log.length)}
+          <li><code>{entry}</code></li>
+        {/each}
+      </ul>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .grid {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--text-muted);
+  }
+
+  .field input {
+    padding: 0.5rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    outline: none;
+  }
+
+  .field input:focus {
+    border-color: var(--accent);
+    box-shadow: var(--focus-ring);
+  }
+
+  .readouts {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .key {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    min-width: 150px;
+  }
+
+  code {
+    background: var(--code-bg);
+    color: var(--code-accent);
+    font-family: var(--font-mono);
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  .watch {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .watch ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .empty {
+    font-size: 0.9rem;
+    color: var(--text-subtle);
+    margin: 0;
+  }
+</style>

--- a/packages/site/src/demos/runed/Reactivity.svelte
+++ b/packages/site/src/demos/runed/Reactivity.svelte
@@ -6,11 +6,12 @@
   const throttled = new Throttled(() => text, 400);
   const previous = new Previous(() => text);
 
-  let log = $state<string[]>([]);
+  let seq = 0;
+  let log = $state<{ id: number; text: string }[]>([]);
   watch(
     () => debounced.current,
     (value, prev) => {
-      log = [`"${prev ?? ''}" → "${value}"`, ...log].slice(0, 5);
+      log = [{ id: seq++, text: `"${prev ?? ''}" → "${value}"` }, ...log].slice(0, 5);
     },
     { lazy: true },
   );
@@ -35,8 +36,8 @@
       <p class="empty">Waiting for the debounced value to settle…</p>
     {:else}
       <ul>
-        {#each log as entry (entry + log.length)}
-          <li><code>{entry}</code></li>
+        {#each log as entry (entry.id)}
+          <li><code>{entry.text}</code></li>
         {/each}
       </ul>
     {/if}

--- a/packages/site/src/demos/runed/Runed.svelte
+++ b/packages/site/src/demos/runed/Runed.svelte
@@ -9,6 +9,14 @@
   import { files } from './files.ts';
 
   const sources = await loadSources(files);
+
+  // Kept as a string (not literal markup) so the braces and generics render as
+  // text instead of being parsed as Svelte expressions.
+  const usage = `import { Debounced } from 'runed';
+
+let query = $state('');
+const search = new Debounced(() => query, 400);
+// search.current — query, 400ms after it stops changing`;
 </script>
 
 <DemoPage
@@ -22,6 +30,8 @@
       <code>runed</code>. In Mochi it bundles straight into whichever island imports it.
     </p>
     <pre class="install"><code>bun add runed</code></pre>
+    <p>Then import a utility and use it like any rune — e.g. the <code>Debounced</code> value driving the first card:</p>
+    <pre class="usage"><code>{usage}</code></pre>
     <p>Explore the full toolkit at <a href="https://runed.dev" target="_blank" rel="noopener noreferrer">runed.dev</a>.</p>
   </div>
 
@@ -82,7 +92,8 @@
     text-decoration: underline;
   }
 
-  .intro .install {
+  .intro .install,
+  .intro .usage {
     margin: 0 0 0.75rem;
     padding: 0.6rem 0.85rem;
     background: var(--code-bg);
@@ -91,7 +102,12 @@
     overflow-x: auto;
   }
 
-  .intro .install code {
+  .intro .usage {
+    line-height: 1.5;
+  }
+
+  .intro .install code,
+  .intro .usage code {
     font-family: var(--font-mono);
     font-size: 0.9rem;
     color: var(--code-accent);

--- a/packages/site/src/demos/runed/Runed.svelte
+++ b/packages/site/src/demos/runed/Runed.svelte
@@ -16,6 +16,15 @@
   description="Runed is a Svelte 5 collection of reactive utilities built on runes. Because most of them read the DOM, timers, or device sensors, each card is its own mochi:hydrate island — the page renders on the server with default values, then Runed brings it to life on the client."
   {sources}
 >
+  <div class="intro">
+    <p>
+      Runed needs no special setup — it's a plain Svelte 5 runes library, so you install it and import from
+      <code>runed</code>. In Mochi it bundles straight into whichever island imports it.
+    </p>
+    <pre class="install"><code>bun add runed</code></pre>
+    <p>Explore the full toolkit at <a href="https://runed.dev" target="_blank" rel="noopener noreferrer">runed.dev</a>.</p>
+  </div>
+
   <section class="card">
     <header>
       <h2>Reactivity & timing</h2>
@@ -58,6 +67,50 @@
 </DemoPage>
 
 <style>
+  .intro {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0 0 1.75rem;
+  }
+
+  .intro p {
+    margin: 0 0 0.75rem;
+  }
+
+  .intro a {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+
+  .intro .install {
+    margin: 0 0 0.75rem;
+    padding: 0.6rem 0.85rem;
+    background: var(--code-bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    overflow-x: auto;
+  }
+
+  .intro .install code {
+    font-family: var(--font-mono);
+    font-size: 0.9rem;
+    color: var(--code-accent);
+  }
+
+  .intro > p:last-child {
+    margin-bottom: 0;
+  }
+
+  .intro p code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
   .card {
     margin-bottom: 2rem;
   }

--- a/packages/site/src/demos/runed/Runed.svelte
+++ b/packages/site/src/demos/runed/Runed.svelte
@@ -1,22 +1,26 @@
 <script>
   import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
   import Reactivity from './Reactivity.svelte';
   import StateCard from './StateCard.svelte';
   import Elements from './Elements.svelte';
   import Sensors from './Sensors.svelte';
   import AsyncFsm from './AsyncFsm.svelte';
   import { loadSources } from '../../components/utils.ts';
+  import { highlightCode } from '../../lib/highlight.server';
   import { files } from './files.ts';
 
   const sources = await loadSources(files);
 
-  // Kept as a string (not literal markup) so the braces and generics render as
-  // text instead of being parsed as Svelte expressions.
-  const usage = `import { Debounced } from 'runed';
+  const codeInstall = await highlightCode('bun add runed', 'bash');
+  const codeUsage = await highlightCode(
+    `import { Debounced } from 'runed';
 
 let query = $state('');
 const search = new Debounced(() => query, 400);
-// search.current — query, 400ms after it stops changing`;
+// search.current — query, 400ms after it stops changing`,
+    'typescript',
+  );
 </script>
 
 <DemoPage
@@ -29,9 +33,9 @@ const search = new Debounced(() => query, 400);
       Runed needs no special setup — it's a plain Svelte 5 runes library, so you install it and import from
       <code>runed</code>. In Mochi it bundles straight into whichever island imports it.
     </p>
-    <pre class="install"><code>bun add runed</code></pre>
+    <CodeSnippet html={codeInstall} />
     <p>Then import a utility and use it like any rune — e.g. the <code>Debounced</code> value driving the first card:</p>
-    <pre class="usage"><code>{usage}</code></pre>
+    <CodeSnippet html={codeUsage} />
     <p>Explore the full toolkit at <a href="https://runed.dev" target="_blank" rel="noopener noreferrer">runed.dev</a>.</p>
   </div>
 
@@ -90,27 +94,6 @@ const search = new Debounced(() => query, 400);
   .intro a {
     color: var(--accent);
     text-decoration: underline;
-  }
-
-  .intro .install,
-  .intro .usage {
-    margin: 0 0 0.75rem;
-    padding: 0.6rem 0.85rem;
-    background: var(--code-bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-sm);
-    overflow-x: auto;
-  }
-
-  .intro .usage {
-    line-height: 1.5;
-  }
-
-  .intro .install code,
-  .intro .usage code {
-    font-family: var(--font-mono);
-    font-size: 0.9rem;
-    color: var(--code-accent);
   }
 
   .intro > p:last-child {

--- a/packages/site/src/demos/runed/Runed.svelte
+++ b/packages/site/src/demos/runed/Runed.svelte
@@ -1,0 +1,84 @@
+<script>
+  import DemoPage from '../../components/DemoPage.svelte';
+  import Reactivity from './Reactivity.svelte';
+  import StateCard from './StateCard.svelte';
+  import Elements from './Elements.svelte';
+  import Sensors from './Sensors.svelte';
+  import AsyncFsm from './AsyncFsm.svelte';
+  import { loadSources } from '../../components/utils.ts';
+  import { files } from './files.ts';
+
+  const sources = await loadSources(files);
+</script>
+
+<DemoPage
+  title="Runed Utilities"
+  description="Runed is a Svelte 5 collection of reactive utilities built on runes. Because most of them read the DOM, timers, or device sensors, each card is its own mochi:hydrate island — the page renders on the server with default values, then Runed brings it to life on the client."
+  {sources}
+>
+  <section class="card">
+    <header>
+      <h2>Reactivity & timing</h2>
+      <p><code>Debounced</code>, <code>Throttled</code>, <code>Previous</code>, and <code>watch</code> — one input, four derived views.</p>
+    </header>
+    <Reactivity mochi:hydrate />
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>State</h2>
+      <p><code>StateHistory</code> undo/redo, <code>PersistedState</code> across reloads and tabs, and <code>IsMounted</code>.</p>
+    </header>
+    <StateCard mochi:hydrate />
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>Elements & observers</h2>
+      <p><code>ElementSize</code> + <code>useResizeObserver</code>, <code>IsInViewport</code>, <code>activeElement</code>, and <code>IsFocusWithin</code>.</p>
+    </header>
+    <Elements mochi:hydrate />
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>Sensors & animation</h2>
+      <p><code>PressedKeys</code>, <code>IsIdle</code>, and <code>AnimationFrames</code> with a live FPS cap.</p>
+    </header>
+    <Sensors mochi:hydrate />
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>State machine & async</h2>
+      <p>A self-driving <code>FiniteStateMachine</code> traffic light and a debounced <code>resource</code> search over a Mochi API.</p>
+    </header>
+    <AsyncFsm mochi:hydrate />
+  </section>
+</DemoPage>
+
+<style>
+  .card {
+    margin-bottom: 2rem;
+  }
+
+  .card header {
+    margin-bottom: 0.9rem;
+  }
+
+  .card header p {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0.25rem 0 0;
+  }
+
+  .card header code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+</style>

--- a/packages/site/src/demos/runed/Sensors.svelte
+++ b/packages/site/src/demos/runed/Sensors.svelte
@@ -1,0 +1,175 @@
+<script lang="ts">
+  import { PressedKeys, IsIdle, AnimationFrames } from 'runed';
+  import Badge from '../../components/Badge.svelte';
+
+  const keys = new PressedKeys();
+
+  const idle = new IsIdle({ timeout: 2000 });
+
+  let frames = $state(0);
+  let fpsLimit = $state(30);
+  const animation = new AnimationFrames(() => frames++, { fpsLimit: () => fpsLimit });
+</script>
+
+<div class="grid">
+  <div class="panel">
+    <div class="head">
+      <h3>PressedKeys</h3>
+      <span class="hint">hold any keys — try Ctrl + Shift</span>
+    </div>
+    <div class="keys">
+      {#if keys.all.length === 0}
+        <span class="empty">No keys pressed</span>
+      {:else}
+        {#each keys.all as key (key)}
+          <kbd>{key}</kbd>
+        {/each}
+      {/if}
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="head">
+      <h3>IsIdle</h3>
+      <span class="hint">stop moving the mouse for 2s</span>
+    </div>
+    {#if idle.current}
+      <Badge kind="warning">idle</Badge>
+    {:else}
+      <Badge kind="success">active</Badge>
+    {/if}
+    <p class="meta">Last active: <code>{new Date(idle.lastActive).toLocaleTimeString()}</code></p>
+  </div>
+
+  <div class="panel">
+    <div class="head">
+      <h3>AnimationFrames</h3>
+      <span class="hint">rAF loop with an FPS cap</span>
+    </div>
+    <div class="fps">
+      <code>{Math.round(animation.fps)} fps</code>
+      <span class="meta">{frames} frames</span>
+    </div>
+    <label class="slider">
+      <span>Limit: {fpsLimit} fps</span>
+      <input type="range" min="1" max="60" bind:value={fpsLimit} />
+    </label>
+    <button onclick={() => (animation.running ? animation.stop() : animation.start())}>
+      {animation.running ? 'Stop' : 'Start'}
+    </button>
+  </div>
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .panel {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--surface-muted);
+    align-items: flex-start;
+  }
+
+  .head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .head h3 {
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text);
+  }
+
+  .hint {
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .keys {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    min-height: 2rem;
+    align-items: center;
+  }
+
+  kbd {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    padding: 0.2rem 0.5rem;
+    border: 1px solid var(--border-strong);
+    border-bottom-width: 2px;
+    border-radius: 4px;
+    background: var(--surface);
+    color: var(--text);
+  }
+
+  .empty {
+    font-size: 0.9rem;
+    color: var(--text-subtle);
+  }
+
+  .fps {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+  }
+
+  .slider {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    width: 100%;
+  }
+
+  .slider input {
+    width: 100%;
+  }
+
+  button {
+    padding: 0.4rem 0.9rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      border-color 0.12s ease;
+  }
+
+  button:hover {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--accent-soft-text);
+  }
+
+  code {
+    background: var(--code-bg);
+    color: var(--code-accent);
+    font-family: var(--font-mono);
+    padding: 0.15rem 0.5rem;
+    border-radius: 4px;
+    font-size: 0.85rem;
+  }
+
+  .meta {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin: 0;
+  }
+</style>

--- a/packages/site/src/demos/runed/StateCard.svelte
+++ b/packages/site/src/demos/runed/StateCard.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import { StateHistory, PersistedState, IsMounted } from 'runed';
+  import Badge from '../../components/Badge.svelte';
+
+  let count = $state(0);
+  const history = new StateHistory(
+    () => count,
+    (c) => (count = c),
+  );
+
+  const persisted = new PersistedState('mochi-runed-demo:count', 0);
+
+  const isMounted = new IsMounted();
+</script>
+
+<div class="grid">
+  <div class="card">
+    <div class="head">
+      <h3>StateHistory</h3>
+      <span class="hint">undo / redo any $state</span>
+    </div>
+    <div class="counter">
+      <button onclick={() => count--}>−</button>
+      <span class="value">{count}</span>
+      <button onclick={() => count++}>+</button>
+    </div>
+    <div class="actions">
+      <button onclick={history.undo} disabled={!history.canUndo}>Undo</button>
+      <button onclick={history.redo} disabled={!history.canRedo}>Redo</button>
+    </div>
+    <p class="meta">{history.log.length} snapshot{history.log.length === 1 ? '' : 's'} recorded</p>
+  </div>
+
+  <div class="card">
+    <div class="head">
+      <h3>PersistedState</h3>
+      <span class="hint">localStorage · survives reload · syncs tabs</span>
+    </div>
+    <div class="counter">
+      <button onclick={() => persisted.current--}>−</button>
+      <span class="value">{persisted.current}</span>
+      <button onclick={() => persisted.current++}>+</button>
+    </div>
+    <p class="meta">Reload the page — the value sticks. Open a second tab to watch it sync.</p>
+  </div>
+
+  <div class="card mounted">
+    <div class="head">
+      <h3>IsMounted</h3>
+      <span class="hint">false during SSR, true after hydration</span>
+    </div>
+    {#if isMounted.current}
+      <Badge kind="success">mounted (client)</Badge>
+    {:else}
+      <Badge kind="warning">not mounted (server)</Badge>
+    {/if}
+  </div>
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--surface-muted);
+  }
+
+  .card.mounted {
+    align-items: flex-start;
+  }
+
+  .head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .head h3 {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text);
+  }
+
+  .hint {
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .counter {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .value {
+    font-family: var(--font-mono);
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--accent);
+    min-width: 2ch;
+    text-align: center;
+  }
+
+  .actions {
+    display: flex;
+    gap: 0.4rem;
+  }
+
+  button {
+    padding: 0.35rem 0.7rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      border-color 0.12s ease;
+  }
+
+  button:hover:not(:disabled) {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--accent-soft-text);
+  }
+
+  button:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+
+  .meta {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+    margin: 0;
+  }
+</style>

--- a/packages/site/src/demos/runed/files.ts
+++ b/packages/site/src/demos/runed/files.ts
@@ -1,0 +1,12 @@
+import type { SourceSpec } from '../../components/utils.ts';
+
+export const files: SourceSpec[] = [
+  { label: 'Runed.svelte', path: './src/demos/runed/Runed.svelte' },
+  { label: 'Reactivity.svelte', path: './src/demos/runed/Reactivity.svelte' },
+  { label: 'StateCard.svelte', path: './src/demos/runed/StateCard.svelte' },
+  { label: 'Elements.svelte', path: './src/demos/runed/Elements.svelte' },
+  { label: 'Sensors.svelte', path: './src/demos/runed/Sensors.svelte' },
+  { label: 'AsyncFsm.svelte', path: './src/demos/runed/AsyncFsm.svelte' },
+  { label: 'routes.ts', path: './src/demos/runed/routes.ts' },
+  { label: 'index.ts', path: './src/demoIndex.ts' },
+];

--- a/packages/site/src/demos/runed/routes.ts
+++ b/packages/site/src/demos/runed/routes.ts
@@ -1,0 +1,14 @@
+import { Mochi, getRequestContext } from 'mochi-framework';
+import type { MochiRouteValue } from 'mochi-framework';
+
+const FRUITS = ['apple', 'apricot', 'banana', 'blueberry', 'cherry', 'grape', 'lemon', 'mango', 'orange', 'peach', 'pear', 'plum'];
+
+export const routes: Record<string, MochiRouteValue> = {
+  '/demos/runed': Mochi.page('./src/demos/runed/Runed.svelte'),
+  '/api/runed/search': Mochi.api(() => {
+    const { url } = getRequestContext();
+    const q = (url.searchParams.get('q') ?? '').toLowerCase();
+    const matches = q ? FRUITS.filter((f) => f.includes(q)) : FRUITS;
+    return Response.json({ matches });
+  }),
+};

--- a/packages/site/src/lib/demoIcons.ts
+++ b/packages/site/src/lib/demoIcons.ts
@@ -52,6 +52,7 @@ import Ampersand from '@lucide/svelte/icons/ampersand';
 import Mail from '@lucide/svelte/icons/mail';
 import Gauge from '@lucide/svelte/icons/gauge';
 import Recycle from '@lucide/svelte/icons/recycle';
+import Atom from '@lucide/svelte/icons/atom';
 
 export interface DemoIconMeta {
   icon: Component;
@@ -83,6 +84,7 @@ export const demoIconFor: Record<string, DemoIconMeta> = {
   'Font loading': { icon: Type, label: 'Bundle fontsource + standalone fonts' },
   'Crossing the server-client boundary with props': { icon: Package2, label: 'Props serialized into the island — every devalue type' },
   'HTML Entities in Props': { icon: Ampersand, label: 'HTML entities in static island props decode across SSR + hydration' },
+  'Runed Utilities': { icon: Atom, label: 'Runed reactive utilities hydrated in islands' },
   'Nested Components': { icon: ListTree, label: 'Five-level deep tree under one island' },
   'Nested Islands': { icon: SquareStack, label: 'Islands nested inside server islands' },
   'Nested Island Max Depth': { icon: Layers2, label: 'Server islands nested several levels deep' },

--- a/packages/site/src/lib/demos.ts
+++ b/packages/site/src/lib/demos.ts
@@ -43,6 +43,7 @@ import { files as rateLimit } from '../demos/rate-limit/files.ts';
 import { files as reloadFormData } from '../demos/reload-form-data/files.ts';
 import { files as requestCache } from '../demos/request-cache/files.ts';
 import { files as requestId } from '../demos/request-id/files.ts';
+import { files as runed } from '../demos/runed/files.ts';
 import { files as serverIsland } from '../demos/server-island/files.ts';
 import { files as serverProps } from '../demos/server-props/files.ts';
 import { files as sharedState } from '../demos/shared-state/files.ts';
@@ -498,6 +499,14 @@ export const demos: Demo[] = [
     files: entityProps,
     title: 'HTML Entities in Props',
     hook: 'How HTML entities in island props work — an entity in a static prop (label="Tom &amp; Jerry") decodes identically on the server and after hydration.',
+    category: 'hydration',
+  },
+  {
+    href: '/demos/runed/',
+    slug: 'runed',
+    files: runed,
+    title: 'Runed Utilities',
+    hook: "How third-party Svelte 5 libraries run in islands — Runed's reactive utilities (Debounced, StateHistory, PersistedState, PressedKeys, AnimationFrames, FiniteStateMachine, resource…) hydrated inside Mochi.",
     category: 'hydration',
   },
 ];

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -64,6 +64,7 @@ import { routes as rateLimitRoutes } from './demos/rate-limit/routes';
 import { routes as reloadFormDataRoutes } from './demos/reload-form-data/routes';
 import { routes as requestCacheRoutes } from './demos/request-cache/routes';
 import { routes as requestIdRoutes } from './demos/request-id/routes';
+import { routes as runedRoutes } from './demos/runed/routes';
 import { routes as serverIslandRoutes } from './demos/server-island/routes';
 import { routes as shotRoutes } from './shot/routes';
 import { routes as serverPropsRoutes } from './demos/server-props/routes';
@@ -341,6 +342,7 @@ export const routes: Record<string, MochiRouteValue> = {
   ...reloadFormDataRoutes,
   ...requestCacheRoutes,
   ...requestIdRoutes,
+  ...runedRoutes,
   ...serverIslandRoutes,
   ...serverPropsRoutes,
   ...shotRoutes,


### PR DESCRIPTION
## What

Adds a single **Runed Utilities** demo to `packages/site` that exercises ~16 of [Runed](https://runed.dev)'s reactive utilities (v0.37.1), split into five `mochi:hydrate` island cards:

| Card | Utilities |
|------|-----------|
| **Reactivity & timing** | `Debounced`, `Throttled`, `Previous`, `watch` |
| **State** | `StateHistory` (undo/redo), `PersistedState` (reload + cross-tab), `IsMounted` |
| **Elements & observers** | `ElementSize` + `useResizeObserver`, `IsInViewport`, `activeElement`, `IsFocusWithin` |
| **Sensors & animation** | `PressedKeys`, `IsIdle`, `AnimationFrames` (live FPS + cap) |
| **State machine & async** | `FiniteStateMachine` (self-driving traffic light) + `resource` (debounced search over a `Mochi.api` endpoint) |

Runed is browser-driven, so this is a natural hydration showcase: each card renders on the server with default values, then comes alive on the client. It's also the first third-party runtime library bundled into a Mochi client island — it bundles and hydrates cleanly.

## Files

- New: `packages/site/src/demos/runed/` — entry page, five island components, `routes.ts` (page + `/api/runed/search`), `files.ts`
- Wired into the four registration points: `routes.ts`, `lib/demos.ts` (registry entry, `hydration` category), `lib/demoIcons.ts` (`Atom` icon), `package.json` (`runed@0.37.1`)

## Notes

- `useSearchParams` was excluded — it's SvelteKit-only and unusable in Mochi.
- The `FiniteStateMachine` fires the initial state's `_enter` synchronously in its constructor, so a self-referencing `debounce` would hit the temporal dead zone; the cycle is scheduled via a microtask and only driven on the client.

## Verification

- All five islands hydrate with zero console errors/warnings; `resource` debounced correctly and returned filtered results; `watch`, `StateHistory` undo, `IsMounted`, `ElementSize`, `IsInViewport`, and `AnimationFrames` confirmed live via browser (chrome-devtools MCP).
- `bun run checks` and `bun run format` pass, including `demoRegistry.test.ts`.