### PR TITLE
test(mochi): cover postgresStore against in-process PGlite Postgres

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -118,6 +118,8 @@
         "zimmerframe": "^1.1.4",
       },
       "devDependencies": {
+        "@electric-sql/pglite": "0.5.4",
+        "@electric-sql/pglite-socket": "0.2.7",
         "@happy-dom/global-registrator": "^20.11.0",
         "@tailwindcss/node": "^4.3.3",
         "@tailwindcss/oxide": "^4.3.3",
@@ -272,6 +274,24 @@
     "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
     "@css-inline/css-inline-wasm": ["@css-inline/css-inline-wasm@0.21.0", "", {}, "sha512-Nu64m556iTOe80sFt9unvRQnPUhjx6s1jjHMtFNGv7q5eneBOax2DHhwc636XmWoAjsWUhQbk12j+kgyuO81Zw=="],
+
+    "@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
+
+    "@electric-sql/pglite-age": ["@electric-sql/pglite-age@0.0.5", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4" } }, "sha512-0PoZu8c5tkvqvVrS77Wcz3hK+nSGw8u8omX8cOWzrg7P95lvS3t4ie9tg5RUPSoFS3xkGJFMBwrqWm5BHTDjiQ=="],
+
+    "@electric-sql/pglite-pg_hashids": ["@electric-sql/pglite-pg_hashids@0.0.5", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4" } }, "sha512-z8iR0ui18LiK8QBCQfq4vrzMIBEUROdYPWJSG5f91v8JHv0lbCc5B/qw5pSKnoht1pXlH0yPcvLF/+GuMYSRdQ=="],
+
+    "@electric-sql/pglite-pg_ivm": ["@electric-sql/pglite-pg_ivm@0.0.5", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4" } }, "sha512-xx9IjXcRmbHivVLB9DbaA9MsMx8vJGk+cqN2N592oCoKqe+k7SXcUuRh/PSglS7jaHPXM/KvE7KDOh+lip3LfA=="],
+
+    "@electric-sql/pglite-pg_textsearch": ["@electric-sql/pglite-pg_textsearch@0.0.6", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4" } }, "sha512-n5lTjivQn/ZvVFdMoW3Rn9u30S0LeAh/sOmjKptnF0nsTa1zIZxa0mAuynzIKrMoUQ0wOFHyB3mj1lIK2UWHUA=="],
+
+    "@electric-sql/pglite-pg_uuidv7": ["@electric-sql/pglite-pg_uuidv7@0.0.5", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4" } }, "sha512-uAatun9hKF6TKYZBc83SaU+snWsg6v2cRatzmty+3e6ai4yDpcOMJBjmA+I73ec0Dk6tykEDsgcsJ0+Eg8af+Q=="],
+
+    "@electric-sql/pglite-pgtap": ["@electric-sql/pglite-pgtap@0.0.5", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4" } }, "sha512-Bf2L2mcsN8AjqZJVXKoUOIaXljtrapclfgrgx4MN2UMLxJtzoPju0KR9aD89mi09eJEMZuKIDsKrtEdXUPuzLQ=="],
+
+    "@electric-sql/pglite-pgvector": ["@electric-sql/pglite-pgvector@0.0.5", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4" } }, "sha512-KEPAkD/3FN6WlDM6XPi2Ko1Xk0ecjOU9OfzCoclVkiRoEVNRYwKo1iO+tlkelMgp07SszmSC4JdSBueH2p7uOQ=="],
+
+    "@electric-sql/pglite-socket": ["@electric-sql/pglite-socket@0.2.7", "", { "peerDependencies": { "@electric-sql/pglite": "0.5.4", "@electric-sql/pglite-age": "0.0.5", "@electric-sql/pglite-pg_hashids": "0.0.5", "@electric-sql/pglite-pg_ivm": "0.0.5", "@electric-sql/pglite-pg_textsearch": "0.0.6", "@electric-sql/pglite-pg_uuidv7": "0.0.5", "@electric-sql/pglite-pgtap": "0.0.5", "@electric-sql/pglite-pgvector": "0.0.5" }, "bin": { "pglite-server": "dist/scripts/server.js" } }, "sha512-lhYx1OOVueiWJRa2Uj1QiIjCWmpRnYLNs5rRH/g47EqrYXP/Qt3VvcXGGum4uIouKKMVlPlkXb6E5Uw0aHRymw=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -116,6 +116,8 @@
     "zimmerframe": "^1.1.4"
   },
   "devDependencies": {
+    "@electric-sql/pglite": "0.5.4",
+    "@electric-sql/pglite-socket": "0.2.7",
     "@happy-dom/global-registrator": "^20.11.0",
     "@tailwindcss/node": "^4.3.3",
     "@tailwindcss/oxide": "^4.3.3",

--- a/packages/mochi/src/__fixtures__/postgres/startTestPostgres.ts
+++ b/packages/mochi/src/__fixtures__/postgres/startTestPostgres.ts
@@ -1,0 +1,45 @@
+// In-process Postgres for tests: a PGlite (WASM Postgres) instance exposed over the
+// Postgres wire protocol by @electric-sql/pglite-socket, so bun:sql connects to it by URL
+// exactly as it would to a real server — no external service, no Docker, cross-platform.
+// The backend is deliberately hidden behind this handle so it can be swapped without
+// touching call sites. Mirrors the port-0 + readback shape of email/fakeSmtpServer.ts.
+import { PGlite } from '@electric-sql/pglite';
+import { PGLiteSocketServer } from '@electric-sql/pglite-socket';
+
+export interface TestPostgres {
+  /** Connection string for bun:sql / `postgresStore({ url })`. */
+  url: string;
+  port: number;
+  /** Run SQL directly against the underlying database (seeding, assertions). */
+  query<T = Record<string, unknown>>(sql: string): Promise<{ rows: T[] }>;
+  close(): Promise<void>;
+}
+
+export async function startTestPostgres(opts?: { initSql?: string }): Promise<TestPostgres> {
+  const db = await PGlite.create();
+  const server = new PGLiteSocketServer({ db, port: 0, host: '127.0.0.1' });
+
+  // `PGLiteSocketServer.port` is private; the only way to learn the OS-assigned port from
+  // `port: 0` is the `listening` event it fires from inside start().
+  const port = await new Promise<number>((resolve, reject) => {
+    server.addEventListener('listening', (event) => {
+      resolve((event as CustomEvent<{ port: number; host: string }>).detail.port);
+    });
+    server.addEventListener('error', (event) => reject((event as CustomEvent<Error>).detail));
+    server.start().catch(reject);
+  });
+
+  if (opts?.initSql) {
+    await db.exec(opts.initSql);
+  }
+
+  return {
+    url: `postgres://postgres:postgres@127.0.0.1:${port}/postgres`,
+    port,
+    query: (sql) => db.query(sql) as Promise<{ rows: never[] }>,
+    close: async () => {
+      await server.stop();
+      await db.close();
+    },
+  };
+}

--- a/packages/mochi/src/runtime/rateLimit.postgres.integration.test.ts
+++ b/packages/mochi/src/runtime/rateLimit.postgres.integration.test.ts
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from '../Mochi';
+import { postgresStore } from './rateLimit';
+import { json } from '../utils';
+import { startTestPostgres, type TestPostgres } from '../__fixtures__/postgres/startTestPostgres';
+
+// Exercises the real `postgresStore()` backend (bun:sql over the wire) against an in-process
+// PGlite Postgres. The memory/sqlite stores have coverage; this closes the Postgres gap and
+// proves counters actually round-trip to a Postgres server, not a local map.
+describe('rateLimit postgresStore backend', () => {
+  let pg: TestPostgres;
+  let store: ReturnType<typeof postgresStore>;
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+
+  beforeAll(async () => {
+    pg = await startTestPostgres();
+    store = postgresStore({ url: pg.url });
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-pg-ratelimit-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      routes: {
+        '/api/limited': Mochi.api(async () => json({ ok: true }), { rateLimit: { limit: 2, window: '1m', store } }),
+      },
+    });
+    base = `http://localhost:${server.port}`;
+  });
+
+  afterAll(async () => {
+    server.stop(true);
+    await store.shutdown?.();
+    await pg.close();
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('blocks with 429 once the limit is exhausted', async () => {
+    expect((await fetch(`${base}/api/limited`)).status).toBe(200);
+    expect((await fetch(`${base}/api/limited`)).status).toBe(200);
+    expect((await fetch(`${base}/api/limited`)).status).toBe(429);
+  });
+
+  test('persists the counter to Postgres over the wire', async () => {
+    const { rows } = await pg.query<{ key: string; count: number }>('SELECT key, count FROM hitlimit_hits');
+    expect(rows).toHaveLength(1);
+    const [row] = rows;
+    expect(Number(row?.count)).toBeGreaterThanOrEqual(2);
+  });
+});


### PR DESCRIPTION
## What

Adds a reusable in-process Postgres test fixture and uses it to give the framework's previously-untested `postgresStore()` rate-limit backend end-to-end coverage.

- **`packages/mochi/src/__fixtures__/postgres/startTestPostgres.ts`** — boots [PGlite](https://pglite.dev) (WASM Postgres) and exposes it over the Postgres wire protocol via `@electric-sql/pglite-socket` on an OS-assigned ephemeral port (read back from the server's `listening` event). Returns a backend-agnostic handle `{ url, port, query(), close() }`, so `bun:sql` / `postgresStore({ url })` connect exactly as to a real server — no external service, no Docker, no per-dev setup. Modeled on the existing `email/fakeSmtpServer.ts` fixture.
- **`packages/mochi/src/runtime/rateLimit.postgres.integration.test.ts`** — boots `Mochi.serve` with `postgresStore({ url })`, asserts a route returns `200, 200, 429` past its limit, then queries `hitlimit_hits` directly to prove the counter round-tripped to Postgres (not a local map).
- **`packages/mochi/package.json`** — two test-only devDeps, exact-pinned: `@electric-sql/pglite@0.5.4`, `@electric-sql/pglite-socket@0.2.7`.

## Why

`postgresStore()` (Bun's native `bun:sql` via `@joint-ops/hitlimit-bun`) is the only real Postgres code path in the repo and had **zero** coverage, because there was no Postgres to point at — the devcontainer and CI matrix provision none. This fixture gives every test an instant, cross-platform Postgres.

## Design notes

- The PGlite-over-socket backend is hidden behind the `TestPostgres` interface, so it can be swapped for real embedded binaries (if ever needed) by touching only the one fixture file — no test changes.
- Empirically verified that the open upstream issue [electric-sql/pglite#812](https://github.com/electric-sql/pglite/issues/812) ("WASM 'Unreachable code' with the socket server under Bun") is **stale on the pinned versions** under Bun 1.3.14 — a full `bun:sql` round-trip works.
- `test:` commit — test-only tooling, no release, no change to published behavior.

## Verification

- New test passes locally (both the 429 behavior and the Postgres-persistence assertion); process exits cleanly.
- `bun run checks` green (lint + format + typecheck + test); `syncpack` clean.
- Cross-platform (macOS/Windows) is validated by the CI matrix on this PR.