### PR TITLE
feat(mochi): add `bun` escape hatch for raw Bun.serve() options

### DIFF
--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -73,10 +73,34 @@ The forced fallback is not optional: a plain `server.stop()` never resolves whil
 - `hooks`: `MochiHooks` map of named lifecycle hooks. See `Extensions (hooks & filters)`.
 - `filters`: `MochiFilters` map of named value-replacement filters. See `Extensions (hooks & filters)`.
 - `warmup`: Warm the SSR pipeline at startup by invoking every static page route once. `boolean | { enabledInProd: boolean; enabledInDev: boolean }`. `true` warms in **production only**; pass the object form for per-mode control. Default: `false`. See `Route warmup` below.
+- `bun`: Escape hatch for raw `Bun.serve()` options Mochi doesn't surface — e.g. `idleTimeout`, `maxRequestBodySize`, `reusePort`, `tls`. Spread into `Bun.serve()`; `fetch` / `websocket` / `routes` / `error` are framework-owned and throw if set. See `Raw Bun.serve options` below.
 
 <Callout type="info">
 
 **Sync `assetPrefix` between build time and runtime.** When using a prebuilt manifest, pass `assetPrefix` to the `build()` call (or `--asset-prefix`) so the baked-in URLs match. The manifest's precomputed URLs take precedence at runtime if the two disagree, causing silent breakage.
+
+</Callout>
+
+### Raw Bun.serve options
+
+`bun` is spread straight into the underlying `Bun.serve()`, so any option Mochi doesn't expose is reachable through it:
+
+```ts
+Mochi.serve({
+  port: 3333,
+  routes,
+  bun: {
+    idleTimeout: 30, // seconds; HTTP default is 10, max 255, 0 disables
+    maxRequestBodySize: 1024 * 1024 * 256,
+  },
+});
+```
+
+Bun times a connection out after `idleTimeout` seconds of inactivity, so a response that stays quiet for longer than the default 10 seconds dies with `request timed out after 10 seconds`. Raise it for slow uploads or long-lived streams (SSE, chunked responses).
+
+<Callout type="info">
+
+`fetch`, `websocket`, `routes`, and `error` are owned by the framework — setting them under `bun` throws at startup. Use the top-level `Mochi.serve()` options instead. To keep a single long stream alive without raising the global timeout, call `server.timeout(request, seconds)` from inside that handler.
 
 </Callout>
 

--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -96,11 +96,11 @@ Mochi.serve({
 });
 ```
 
-Bun times a connection out after `idleTimeout` seconds of inactivity, so a response that stays quiet for longer than the default 10 seconds dies with `request timed out after 10 seconds`. Raise it for slow uploads or long-lived streams (SSE, chunked responses).
+Bun times a connection out after `idleTimeout` seconds of inactivity, so a response that stays quiet for longer than the default 10 seconds dies with `request timed out after 10 seconds`. Mochi already disables the idle timer for page renders and SSE streams (`Mochi.sse`), so raising it mainly matters for quiet or long-lived `Mochi.api` responses (chunked streams) and slow request bodies.
 
 <Callout type="info">
 
-`fetch`, `websocket`, `routes`, and `error` are owned by the framework — setting them under `bun` throws at startup. Use the top-level `Mochi.serve()` options instead. To keep a single long stream alive without raising the global timeout, call `server.timeout(request, seconds)` from inside that handler.
+`fetch`, `websocket`, `routes`, and `error` are owned by the framework — setting them under `bun` throws at startup. Use the top-level `Mochi.serve()` options instead. To lift the timeout for one route without raising the global value, call `server.timeout(request, seconds)` (seconds, or `0` to disable) inside the handler — the `server` and `request` are on the API event.
 
 </Callout>
 

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -283,6 +283,15 @@ export class Mochi {
   }
 
   static async serve(options: MochiServeOptions): Promise<Server<undefined>> {
+    // Reject before initMochiConfig pins the process singleton, so a bad `bun` passthrough fails fast without wedging it.
+    if (options.bun && typeof options.bun === 'object') {
+      for (const key of ['fetch', 'websocket', 'routes', 'error'] as const) {
+        if (key in options.bun) {
+          throw new Error(`Mochi.serve({ bun }): "${key}" is owned by the framework and cannot be overridden. Use the top-level Mochi.serve() option instead.`);
+        }
+      }
+    }
+
     const { svelteVersion } = await checkEnvironment();
     const mochiVersion = await readMochiVersion();
     initExtensions(options);
@@ -1583,6 +1592,7 @@ export class Mochi {
       handle: _handle,
       markdown: _markdown,
       websocket: userWebSocketOptions,
+      bun: bunPassthrough,
       ...bunOptions
     } = options as Record<string, unknown>;
 
@@ -1665,6 +1675,7 @@ export class Mochi {
 
     const server = Bun.serve({
       ...bunOptions,
+      ...(bunPassthrough as Record<string, unknown> | undefined),
       routes: bunRoutes,
       fetch: composedFetch,
       ...(websocketOption ? { websocket: websocketOption } : {}),

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -8,7 +8,18 @@ import { loadSvelteConfig } from './compiler/svelteConfig';
 import { buildInlineWebComponent } from './compiler/buildInlineWebComponent';
 import { buildClientStatsRoutes, CLIENT_STATS_COMPONENT } from './dev/clientStatsRoutes';
 import { buildEmailViewerRoutes, EMAIL_VIEWER_COMPONENT } from './dev/emailViewerRoutes';
-import { isMochiPage, isMochiApi, isMochiWs, isMochiSse, isMochiFile, isMochiQueue, isServerPropsResolver, isAlsoHydrateMode, ALSO_HYDRATE_ENVELOPE_KEY } from './types';
+import {
+  isMochiPage,
+  isMochiApi,
+  isMochiWs,
+  isMochiSse,
+  isMochiFile,
+  isMochiQueue,
+  isServerPropsResolver,
+  isAlsoHydrateMode,
+  ALSO_HYDRATE_ENVELOPE_KEY,
+  FRAMEWORK_OWNED_BUN_KEYS,
+} from './types';
 import { HYDRATABLE_CONTEXT_KEY } from './islands/isHydratable';
 import type {
   BunRouteValue,
@@ -285,7 +296,7 @@ export class Mochi {
   static async serve(options: MochiServeOptions): Promise<Server<undefined>> {
     // Reject before initMochiConfig pins the process singleton, so a bad `bun` passthrough fails fast without wedging it.
     if (options.bun && typeof options.bun === 'object') {
-      for (const key of ['fetch', 'websocket', 'routes', 'error'] as const) {
+      for (const key of FRAMEWORK_OWNED_BUN_KEYS) {
         if (key in options.bun) {
           throw new Error(`Mochi.serve({ bun }): "${key}" is owned by the framework and cannot be overridden. Use the top-level Mochi.serve() option instead.`);
         }

--- a/packages/mochi/src/bunPassthrough.test.ts
+++ b/packages/mochi/src/bunPassthrough.test.ts
@@ -1,0 +1,51 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+
+describe('Mochi.serve({ bun })', () => {
+  const servers: Server<undefined>[] = [];
+  const outDirs: string[] = [];
+
+  function tempOutDir(): string {
+    const dir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-bun-passthrough-'));
+    outDirs.push(dir);
+    return dir;
+  }
+
+  afterAll(() => {
+    for (const server of servers) {
+      server?.stop(true);
+    }
+    for (const dir of outDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  // Rejection happens before the process singleton is pinned, so these run before the one boot test below.
+  test.each(['fetch', 'websocket', 'routes', 'error'])('rejects framework-owned key %p', async (key) => {
+    const boot = Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir: tempOutDir(),
+      routes: {},
+      bun: { [key]: (() => {}) as never },
+    });
+    await expect(boot).rejects.toThrow(`"${key}" is owned by the framework`);
+  });
+
+  test('spreads raw Bun.serve options through and boots', async () => {
+    const server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir: tempOutDir(),
+      routes: {},
+      bun: { idleTimeout: 42 },
+    });
+    servers.push(server);
+    expect(server.port).toBeGreaterThan(0);
+  });
+});

--- a/packages/mochi/src/bunServerTimeout.test.ts
+++ b/packages/mochi/src/bunServerTimeout.test.ts
@@ -1,0 +1,81 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import net from 'node:net';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+
+// Proves the two claims in `160-serve-options.md`: `bun: { idleTimeout }` reaches Bun.serve(), and a handler can
+// override it per-request with `server.timeout(request, seconds)`. A quiet stream is the only way to observe the idle
+// timer, and it must be driven over a raw socket — in-process `fetch()` against the loopback silently keeps the socket
+// active, so it never trips the timeout. `api` is the kind under test because it does not auto-disable the timer the way
+// `page`/`sse` do (see KIND_POLICY in runtime/requestSetup.ts).
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+function quietStream(): Response {
+  const enc = new TextEncoder();
+  return new Response(
+    new ReadableStream({
+      async start(controller) {
+        controller.enqueue(enc.encode('hi '));
+        await sleep(6000); // silent for longer than idleTimeout, so an un-extended request is cut mid-stream
+        controller.enqueue(enc.encode('bye'));
+        controller.close();
+      },
+    }),
+  );
+}
+
+function rawGet(port: number, pathname: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const socket = net.connect(port, '127.0.0.1', () => {
+      socket.write(`GET ${pathname} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+    });
+    let buf = '';
+    socket.setEncoding('utf8');
+    socket.on('data', (chunk) => (buf += chunk));
+    socket.on('close', () => resolve(buf));
+    socket.on('error', reject);
+  });
+}
+
+describe('bun.idleTimeout passthrough + server.timeout()', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-bun-timeout-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      bun: { idleTimeout: 2 },
+      routes: {
+        '/quiet': Mochi.api(() => quietStream()),
+        '/quiet-extended': Mochi.api(({ server, request }) => {
+          server.timeout(request, 0);
+          return quietStream();
+        }),
+      },
+    });
+  }, 20000);
+
+  afterAll(() => {
+    server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('bun.idleTimeout is applied — a quiet stream is cut mid-response', async () => {
+    const body = await rawGet(server.port!, '/quiet');
+    expect(body).toContain('hi '); // first chunk flushed before the gap
+    expect(body).not.toContain('bye'); // connection closed during the 6s silence
+  }, 20000);
+
+  test('server.timeout(request, 0) overrides it — the stream runs to completion', async () => {
+    const body = await rawGet(server.port!, '/quiet-extended');
+    expect(body).toContain('hi ');
+    expect(body).toContain('bye');
+  }, 20000);
+});

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -394,11 +394,14 @@ export interface MochiWarmupOptions {
   enabledInDev: boolean;
 }
 
+/** Keys the framework sets on `Bun.serve()` itself; rejected under `bun` and stripped from `BunServeOverrides`. */
+export const FRAMEWORK_OWNED_BUN_KEYS = ['fetch', 'websocket', 'routes', 'error'] as const;
+
 /**
  * Options spread directly into the underlying `Bun.serve()`. The framework owns
- * `fetch`, `websocket`, `routes`, and `error`; setting any of them here throws.
+ * the keys in {@link FRAMEWORK_OWNED_BUN_KEYS}; setting any of them here throws.
  */
-export type BunServeOverrides = Omit<NonNullable<Parameters<typeof Bun.serve>[0]>, 'fetch' | 'websocket' | 'routes' | 'error'>;
+export type BunServeOverrides = Omit<NonNullable<Parameters<typeof Bun.serve>[0]>, (typeof FRAMEWORK_OWNED_BUN_KEYS)[number]>;
 
 export interface MochiServeOptions {
   port?: number;

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -394,9 +394,21 @@ export interface MochiWarmupOptions {
   enabledInDev: boolean;
 }
 
+/**
+ * Options spread directly into the underlying `Bun.serve()`. The framework owns
+ * `fetch`, `websocket`, `routes`, and `error`; setting any of them here throws.
+ */
+export type BunServeOverrides = Omit<NonNullable<Parameters<typeof Bun.serve>[0]>, 'fetch' | 'websocket' | 'routes' | 'error'>;
+
 export interface MochiServeOptions {
   port?: number;
   hostname?: string;
+  /**
+   * Escape hatch for raw `Bun.serve()` options Mochi doesn't surface — e.g.
+   * `idleTimeout` (seconds; HTTP default 10, max 255, 0 disables), `maxRequestBodySize`,
+   * `reusePort`, `tls`. Spread into `Bun.serve()`; framework-owned keys are rejected.
+   */
+  bun?: BunServeOverrides;
   development?: boolean;
   /** Mount the dev-only debug toolbar. Default: `true`, and ignored entirely when `development` is `false`. */
   debugBar?: boolean;


### PR DESCRIPTION
## What & why

Long-lived requests (streaming responses, slow SSE, big uploads) hit Bun's default **10-second** HTTP \`idleTimeout\` and die with:

\`\`\`
[Bun.serve]: request timed out after 10 seconds. Pass \`idleTimeout\` to configure.
\`\`\`

There was **no typed/documented way** to set \`idleTimeout\` (or any other \`Bun.serve()\` knob — \`maxRequestBodySize\`, \`reusePort\`, \`tls\`, …). It only "worked" by accident via the untyped \`[key: string]: unknown\` index signature.

This adds a first-class, typed \`bun\` escape hatch:

\`\`\`ts
Mochi.serve({
  port: 3333,
  routes,
  bun: { idleTimeout: 30, maxRequestBodySize: 1024 * 1024 * 256 },
});
\`\`\`

## Details

- **`types.ts`** — new `BunServeOverrides` type (derived from Bun's own serve options minus the framework-owned keys) + documented `bun?` field on `MochiServeOptions`.
- **`Mochi.ts`** — validates protected keys (`fetch`/`websocket`/`routes`/`error`) at the top of `serve()`, before the process singleton is pinned, so a bad config fails fast without wedging the process; spreads `bun` into `Bun.serve()` ahead of the framework-owned keys (defense in depth).
- **`bunPassthrough.test.ts`** — 4 protected-key rejection cases + one boot-with-`idleTimeout` case.
- **`160-serve-options.md`** — reference bullet + a `Raw Bun.serve options` section (with the `server.timeout()` per-request note).

Purely additive / non-breaking — the legacy top-level passthrough is untouched.

## Verification

- Typecheck probe: `bun.idleTimeout` resolves to `number`; `fetch` is stripped from the type.
- End-to-end repro: a >10s stream dies at the default 10s and completes with `idleTimeout: 30`.
- Docs page renders 200 with the new section/Callout intact.
- `bun run checks` was kicked off; will confirm green.