### PR TITLE
Prepare for Bun 1.4.0: dual-version tests + canary CI leg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,59 @@ jobs:
       - name: Run tests
         run: bun run test
 
+  # TEMPORARY living check: install the pinned Bun, then upgrade to the latest canary
+  # and run the full suite on all three OSes. Fetches the moving canary every run by
+  # design (early warning for Bun 1.4.0). Non-blocking — kept out of the `test` gate's
+  # needs and marked continue-on-error, so a canary-side regression never blocks a PR.
+  # Remove once we pin 1.4.0 (or drop the 1.4.0 prep).
+  test-matrix-canary:
+    name: Test (Bun canary)
+    runs-on: ${{ matrix.os }}
+    continue-on-error: true
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version-file: .bun-version
+
+      - name: Upgrade to the latest Bun canary
+        run: |
+          bun upgrade --canary
+          bun --version
+          bun --revision
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-canary-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-canary-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Try building server
+        run: bun run build
+
+      - name: Run tests
+        run: bun run test
+
   test:
     if: always()
     needs: test-matrix

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -73,11 +73,11 @@ const SRC_DIR = path.join(path.dirname(Bun.fileURLToPath(import.meta.url)), '..'
 /** Manifest schema version this runtime writes; see `MochiManifest.version` for the path families it implies. */
 const MANIFEST_VERSION = 2;
 
-// TODO
-// Bun's CSS bundler unquotes `format('woff2-variations')` to `format(woff2-variations)`,
+// Bun <1.4.0's CSS bundler unquotes `format('woff2-variations')` to `format(woff2-variations)`,
 // which is invalid CSS — only the seven plain keywords (woff2, woff, truetype, opentype,
 // embedded-opentype, svg, collection) work bare. Browsers silently drop the src and the
 // font never loads. Re-quote the four compound `*-variations` hints back to strings.
+// Bun 1.4.0 keeps them quoted, so this is a no-op there — delete once 1.3.14 support is dropped.
 const VARIATION_FORMAT_RE = /\bformat\((woff2-variations|woff-variations|truetype-variations|opentype-variations)\)/g;
 function restoreVariationsFormat(css: string): string {
   return css.replace(VARIATION_FORMAT_RE, "format('$1')");

--- a/packages/mochi/src/compiler/cssImports.test.ts
+++ b/packages/mochi/src/compiler/cssImports.test.ts
@@ -106,7 +106,9 @@ describe('CSS imports — variable-font format() preservation', () => {
     const cssUrl = `/_mochi/import-css/${cssOutput!.name}`;
     const cssText = registry.getClientFile(cssUrl);
     expect(cssText).toBeDefined();
-    expect(cssText).toContain("format('woff2-variations')");
+    // Bun <1.4.0 stripped the quotes (framework re-quotes to single); Bun >=1.4.0 keeps
+    // them (double). Either quote style is valid CSS — the bare unquoted form is the real bug.
+    expect(cssText).toMatch(/\bformat\((['"])woff2-variations\1\)/);
     expect(cssText).not.toMatch(/\bformat\(woff2-variations\)/);
   });
 });

--- a/packages/mochi/src/runtime/rateLimit.test.ts
+++ b/packages/mochi/src/runtime/rateLimit.test.ts
@@ -218,34 +218,50 @@ describe('sqliteStore persistence', () => {
     await secondLimiter.store.shutdown?.();
   });
 
-  // The wrapped shutdown's finalize sweep depends on hitlimit's private field
-  // layout; its `db.close(true)` verification throws "database is locked" if any
-  // statement is still outstanding. These two tests keep that guard honest on
-  // every platform (the leak itself only bites on Windows, where an open handle
-  // blocks unlink):
-  //   1. the wrapped shutdown passes its own verification, and
-  //   2. the verification actually detects unfinalized statements — guarding
-  //      against bun:sqlite ever making close(true) tolerant, which would turn
-  //      test 1 vacuous.
+  // The wrapped shutdown's finalize sweep depends on hitlimit's private field layout so
+  // db.close() actually releases the handle (an outstanding statement only zombies the
+  // connection; the leak bites on Windows, where an open handle blocks unlink). bun:sqlite's
+  // own tripwire — close(true) throwing on an outstanding statement — was removed in 1.4.0, so
+  // these tests verify finalization the version-independent way: a finalized statement throws
+  // when reused, and the same own-enumerable-field find() the sweep relies on must locate a
+  // statement (else a hitlimit field-layout change slipped through, on every OS and Bun version).
+  type Finalizable = { finalize(): void; get(...args: unknown[]): unknown };
+  const findStatement = (store: object): Finalizable | undefined =>
+    Object.values(store as Record<string, unknown>).find((v): v is Finalizable => typeof (v as { finalize?: unknown } | null)?.finalize === 'function');
+
   test('shutdown finalizes hitlimit statements so the close fully releases the handle', async () => {
     const store = sqliteStore({ path: path.join(tempDir, 'finalize-check.db') });
     await store.hit('k', 60_000, 5);
+
+    const stmt = findStatement(store);
+    expect(stmt).toBeDefined(); // layout tripwire: sweep can't finalize statements it can't find
+    expect(() => stmt!.get()).not.toThrow();
+
     expect(() => store.shutdown!()).not.toThrow();
+
+    // The sweep finalized the statement, so the close released the handle (Windows can unlink).
+    expect(() => stmt!.get()).toThrow(/finaliz/i);
   });
 
-  test('negative control: close(true) with an outstanding statement throws', async () => {
+  test('negative control: finalizing a statement is what makes it unusable', async () => {
     const raw = hitlimitSqliteStore({ path: path.join(tempDir, 'finalize-control.db') });
     await raw.hit('k', 60_000, 5);
-    const db = (raw as unknown as { db: { close(throwOnError?: boolean): void } }).db;
-    expect(() => db.close(true)).toThrow();
 
-    // Release the handle for real — otherwise Windows can't unlink finalize-control.db
-    // in afterAll (EBUSY). Mirror the production sqliteStore() shutdown: finalize the
-    // outstanding statements, then close(true) actually releases the db/-wal/-shm files.
+    // Without the sweep the statement stays usable — proving the positive test's post-shutdown
+    // throw comes from finalization, not merely from the db being closed underneath it.
+    const stmt = findStatement(raw);
+    expect(stmt).toBeDefined();
+    expect(() => stmt!.get()).not.toThrow();
+    stmt!.finalize();
+    expect(() => stmt!.get()).toThrow(/finaliz/i);
+
+    // Release the handle for real — otherwise Windows can't unlink finalize-control.db in
+    // afterAll (EBUSY). Mirror the production sqliteStore() shutdown: finalize the remaining
+    // statements, then close(true) releases the db/-wal/-shm files.
     for (const value of Object.values(raw)) {
       (value as { finalize?: () => void } | null)?.finalize?.();
     }
-    db.close(true);
+    (raw as unknown as { db: { close(throwOnError?: boolean): void } }).db.close(true);
     await raw.shutdown?.();
   });
 });

--- a/packages/mochi/src/runtime/rateLimit.ts
+++ b/packages/mochi/src/runtime/rateLimit.ts
@@ -137,10 +137,11 @@ export function postgresStore(options: MochiPostgresStoreOptions): MochiRateLimi
  * actually releases the handles.
  *
  * The finalize sweep and the `db` access depend on hitlimit's private field
- * layout (the dep is pinned). `db.close(true)` is the guard: it throws
- * "database is locked" if any statement is still outstanding — so a hitlimit bump
- * that moves statements off own-enumerable fields fails loudly on every platform
- * (covered by rateLimit.test.ts), not as a silent Windows-only unlink failure.
+ * layout (the dep is pinned). Bun <1.4.0's `db.close(true)` doubled as a tripwire —
+ * it threw if any statement was still outstanding — but 1.4.0 made it tolerant, so
+ * that layout guard now lives in rateLimit.test.ts (the same own-enumerable-field
+ * find() asserted to locate a statement), catching a hitlimit bump that moves
+ * statements off own-enumerable fields before it becomes a silent Windows unlink leak.
  */
 export function sqliteStore(options?: MochiSqliteStoreOptions): MochiRateLimitStore {
   const store = hitlimitSqliteStore(options);


### PR DESCRIPTION
## What

Running the suite on the Bun **1.4.0** canary surfaced exactly two failing tests in `packages/mochi`, both from deliberate Bun behavior changes — the framework itself works on both versions. This PR makes the suite pass on **both 1.3.14 (pinned) and 1.4.0**, and adds a temporary living CI leg that tests the moving canary.

We are **not** bumping the pinned version — `.bun-version`, `@types/bun`, `engines.bun`, and the Dockerfiles stay on 1.3.14.

## Changes

**1. CSS `format()` test — tolerant assertion** (`compiler/cssImports.test.ts`)
Bun 1.4.0's CSS bundler stopped stripping quotes from `format('woff2-variations')`; it now emits the valid double-quoted `format("woff2-variations")`. The assertion now accepts either quote style while still rejecting the invalid bare `format(woff2-variations)`. The framework's `restoreVariationsFormat()` workaround correctly degrades to a no-op on 1.4.0 (noted as deletable once 1.3.14 support is dropped).

**2. rateLimit finalization tests — version-independent rewrite** (`runtime/rateLimit.test.ts`)
`bun:sqlite`'s `db.close(true)` no longer throws on an outstanding statement in 1.4.0, which broke the old negative control (and silently defeated the identical tripwire in the production shutdown shim). The tests now verify finalization the version-independent way — a finalized statement throws `"Statement has finalized"` when reused (confirmed identical on 1.3.14 and 1.4.0) — and keep the hitlimit field-layout guard in the test itself (`expect(stmt).toBeDefined()`), replacing the defeated `close(true)` tripwire. Production `rateLimit.ts` logic is unchanged; only its now-inaccurate comment was updated.

**3. Temporary canary CI leg** (`.github/workflows/test.yml`)
New `test-matrix-canary` job across Ubuntu/macOS/Windows: installs the pinned Bun from `.bun-version`, then `bun upgrade --canary`, then runs the full suite (typecheck → lint → build → test). **Non-blocking** — `continue-on-error: true` and kept out of the required `test` gate, so a canary-side regression never blocks a PR. Fetches the latest canary every run by design.

## Verification

- Both edited test files pass on **1.3.14** and **1.4.0** (27 pass, 0 fail each).
- Full `bun run checks` green on 1.4.0 canary (143/143 framework test files; all workspaces green).
- Empirically confirmed (not assumed) on both versions: a `bun:sqlite` statement is usable before `.finalize()` and throws on reuse after; `.isFinalized` exists only on 1.4.0, so it was deliberately avoided.

## Notes / open question

The production `sqliteStore` shutdown (`rateLimit.ts:145`) still calls `db.close(true)`, which on 1.4.0 no longer self-checks that the finalize sweep found every statement. The **test** now carries that layout tripwire (in CI on every OS), so production is safe — but if you'd like production to keep its own runtime self-check on 1.4.0 deployments, I can add a small "sweep found ≥1 statement" assertion. Left out here pending your call.