### PR TITLE
feat(mochi): export pinGlobal; dedupe the site's Shiki highlighter per process

### DIFF
--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
@@ -44,6 +44,9 @@ export { setLogLevel, getLogLevel };
 export const logger = __mochi_logger;
 if (typeof window !== "undefined" && window.__mochi_log_level) setLogLevel(window.__mochi_log_level);
 export function devWarn(msg) { if (typeof window !== "undefined" && window.__mochi_warn) window.__mochi_warn(msg); else __mochi_logger.warn(msg); }
+// Isomorphic: pins a value on globalThis (per realm in the browser). Real re-export,
+// not a server-only stub, so island code can dedupe singletons on the client too.
+export { pinGlobal } from "__MOCHI_GLOBAL_STATE__";
 export { stringify, parse } from "__MOCHI_DEVALUE__";
 export { trailingSlashIt } from "__MOCHI_TRAILING_SLASH__";
 // Server-only; the preprocessor never injects __mochi_emit_props__

--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
@@ -31,6 +31,9 @@ import { logger as __mochi_logger, setLogLevel, getLogLevel } from "__MOCHI_LOG_
 export { setLogLevel, getLogLevel };
 export const logger = __mochi_logger;
 export function devWarn(msg) { __mochi_logger.warn(msg); }
+// Isomorphic: pins a value on globalThis so duplicate bundled copies share one
+// instance per process. Re-exported so .svelte-graph modules can dedupe singletons.
+export { pinGlobal } from "__MOCHI_GLOBAL_STATE__";
 // Re-export devalue so .svelte files (and the preprocessor's
 // injected hydration-prop import) can use stringify/parse without
 // a separate install. Resolved from the framework's own deps.

--- a/packages/mochi/src/compiler/virtualModuleTemplate.ts
+++ b/packages/mochi/src/compiler/virtualModuleTemplate.ts
@@ -31,6 +31,7 @@ export function renderMochiEnvServer(development: boolean): string {
   return fill(SERVER_TEMPLATE, {
     __MOCHI_DEV__: String(development),
     __MOCHI_LOG__: frameworkFile('utils/log.ts'),
+    __MOCHI_GLOBAL_STATE__: frameworkFile('utils/globalState.ts'),
     __MOCHI_DEVALUE__: toPosixPath(Bun.resolveSync('devalue', FRAMEWORK_DIR)),
     __MOCHI_TRAILING_SLASH__: frameworkFile('runtime/trailingSlash.ts'),
     __MOCHI_ISLAND_PROPS__: frameworkFile('islands/islandPropsRegistry.ts'),
@@ -50,6 +51,7 @@ export function renderMochiEnvClient(development: boolean, cookiesClientPath: st
     __MOCHI_DEV__: String(development),
     __MOCHI_COOKIES_CLIENT__: cookiesClientPath,
     __MOCHI_LOG__: frameworkFile('utils/log.ts'),
+    __MOCHI_GLOBAL_STATE__: frameworkFile('utils/globalState.ts'),
     __MOCHI_DEVALUE__: toPosixPath(Bun.resolveSync('devalue', FRAMEWORK_DIR)),
     __MOCHI_TRAILING_SLASH__: frameworkFile('runtime/trailingSlash.ts'),
     __MOCHI_ENHANCE_CLIENT__: enhanceClientPath,

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -48,6 +48,7 @@ export { consoleLogger, silenceInternalRoutes } from './dev/consoleLogger';
 export type { ConsoleLoggerOptions } from './dev/consoleLogger';
 export { logger, setLogLevel, getLogLevel } from './utils/log';
 export type { LogLevel } from './utils/log';
+export { pinGlobal } from './utils/globalState';
 export { mochiEvents, hasSubscribers } from './events';
 export type { MochiCompileError } from './compiler/ComponentRegistry';
 export type {

--- a/packages/site/src/components/sourceUtils.ts
+++ b/packages/site/src/components/sourceUtils.ts
@@ -1,0 +1,33 @@
+export type SourceSpec = { label: string; path: string; lang?: string; showImageConfig?: boolean };
+
+export function isDemoIndex(path: string): boolean {
+  return path.endsWith('demoIndex.ts');
+}
+
+// Drop the `image: {…}` block (and its leading comment) — it's noise in every demo
+// except the image ones, which opt back in via `showImageConfig`.
+export function stripImageConfig(code: string): string {
+  const lines = code.split('\n');
+  const out: string[] = [];
+  let depth = 0;
+  let skipping = false;
+  for (const line of lines) {
+    if (skipping) {
+      depth += (line.match(/\{/g)?.length ?? 0) - (line.match(/\}/g)?.length ?? 0);
+      if (depth <= 0) {
+        skipping = false;
+      }
+      continue;
+    }
+    if (/^\s*image:\s*\{/.test(line)) {
+      while (out.length && /^\s*\/\//.test(out[out.length - 1]!)) {
+        out.pop();
+      }
+      depth = (line.match(/\{/g)?.length ?? 0) - (line.match(/\}/g)?.length ?? 0);
+      skipping = depth > 0;
+      continue;
+    }
+    out.push(line);
+  }
+  return out.join('\n');
+}

--- a/packages/site/src/components/utils.ts
+++ b/packages/site/src/components/utils.ts
@@ -1,11 +1,13 @@
 import { highlightCode } from '../lib/highlight.server';
+import { isDemoIndex, stripImageConfig, type SourceSpec } from './sourceUtils';
+
+export { isDemoIndex, stripImageConfig, type SourceSpec } from './sourceUtils';
 
 export function delay(minMs: number, maxMs: number = minMs): Promise<void> {
   const ms = minMs + Math.random() * (maxMs - minMs);
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-export type SourceSpec = { label: string; path: string; lang?: string; showImageConfig?: boolean };
 type Source = { label: string; lang: string; html: string; styleHtml?: string };
 
 const cache = new Map<string, string>();
@@ -44,38 +46,6 @@ export async function loadSources(specs: SourceSpec[]): Promise<Source[]> {
       };
     }),
   );
-}
-
-export function isDemoIndex(path: string): boolean {
-  return path.endsWith('demoIndex.ts');
-}
-
-// Drop the `image: {…}` block (and its leading comment) — it's noise in every demo
-// except the image ones, which opt back in via `showImageConfig`.
-export function stripImageConfig(code: string): string {
-  const lines = code.split('\n');
-  const out: string[] = [];
-  let depth = 0;
-  let skipping = false;
-  for (const line of lines) {
-    if (skipping) {
-      depth += (line.match(/\{/g)?.length ?? 0) - (line.match(/\}/g)?.length ?? 0);
-      if (depth <= 0) {
-        skipping = false;
-      }
-      continue;
-    }
-    if (/^\s*image:\s*\{/.test(line)) {
-      while (out.length && /^\s*\/\//.test(out[out.length - 1]!)) {
-        out.pop();
-      }
-      depth = (line.match(/\{/g)?.length ?? 0) - (line.match(/\}/g)?.length ?? 0);
-      skipping = depth > 0;
-      continue;
-    }
-    out.push(line);
-  }
-  return out.join('\n');
 }
 
 const STYLE_RE = /\n<style(?:\s[^>]*)?>[\s\S]*?<\/style>\s*$/;

--- a/packages/site/src/lib/docs.ts
+++ b/packages/site/src/lib/docs.ts
@@ -7,7 +7,7 @@ import { SITE_ROOT } from './siteRoot';
 import { loadPosts, getPost } from './blog';
 import { CHANGELOG_SLUG, CHANGELOG_TITLE, CHANGELOG_DESCRIPTION, getChangelogTxt } from './changelog';
 import { demos, type Demo } from './demos';
-import { isDemoIndex, stripImageConfig, type SourceSpec } from '../components/utils.ts';
+import { isDemoIndex, stripImageConfig, type SourceSpec } from '../components/sourceUtils';
 import { collectHeadings, type HastNode, type MdsvexRehypePlugin } from './markdown';
 import type { TocEntry } from './toc';
 

--- a/packages/site/src/lib/highlight.server.ts
+++ b/packages/site/src/lib/highlight.server.ts
@@ -1,31 +1,35 @@
 import { createHighlighter as createShiki, createJavaScriptRegexEngine } from 'shiki';
 import { createHighlighter } from 'mochi-framework/highlight';
-import { logger } from 'mochi-framework';
+import { logger, pinGlobal } from 'mochi-framework';
 import { mochiTheme } from './shiki-theme';
 
-// Use Shiki's JS RegExp engine instead of oniguruma WASM: each SSR bundle importing this
-// module would otherwise instantiate its own ~100-150MB oniguruma WebAssembly.Memory that's
-// never reclaimed, which matters only on the deployed Linux container. On Windows the JS
-// engine's translated patterns backtrack pathologically under Bun (hanging CI), so fall
-// back to oniguruma WASM there instead.
-logger.warn(`[highlight] shiki engine for platform '${process.platform}': ${process.platform === 'win32' ? 'oniguruma WASM' : 'JS RegExp'}`);
-const engine = process.platform === 'win32' ? undefined : createJavaScriptRegexEngine({ forgiving: true });
-const shiki = await createShiki({
-  ...(engine ? { engine } : {}),
-  themes: [mochiTheme],
-  langs: ['bash', 'css', 'dockerfile', 'html', 'javascript', 'json', 'plaintext', 'svelte', 'toml', 'typescript', 'xml'],
+// Pin the highlighter once per process: this module is bundled into every SSR graph that
+// imports it (the main server bundle plus each demo/island bundle), so without the guard each
+// copy would run `createShiki` again — loading ~11 TextMate grammars and, on Windows, its own
+// ~100-150MB oniguruma WebAssembly.Memory that's never reclaimed. On Linux/macOS we use Shiki's
+// JS RegExp engine; on Windows the JS engine's translated patterns backtrack pathologically
+// under Bun (hanging CI), so fall back to oniguruma WASM there instead.
+export const highlightCode = pinGlobal('__mochi_site_highlight__', () => {
+  logger.warn(`[highlight] shiki engine for platform '${process.platform}': ${process.platform === 'win32' ? 'oniguruma WASM' : 'JS RegExp'}`);
+  const engine = process.platform === 'win32' ? undefined : createJavaScriptRegexEngine({ forgiving: true });
+  const shiki = createShiki({
+    ...(engine ? { engine } : {}),
+    themes: [mochiTheme],
+    langs: ['bash', 'css', 'dockerfile', 'html', 'javascript', 'json', 'plaintext', 'svelte', 'toml', 'typescript', 'xml'],
+  });
+  return createHighlighter((code, lang) =>
+    shiki.then((s) =>
+      s.codeToHtml(code, {
+        lang,
+        theme: 'mochi',
+        transformers: [
+          {
+            pre(node) {
+              node.properties.style = 'background-color:var(--code-bg);color:var(--code-text)';
+            },
+          },
+        ],
+      }),
+    ),
+  );
 });
-
-export const highlightCode = createHighlighter((code, lang) =>
-  shiki.codeToHtml(code, {
-    lang,
-    theme: 'mochi',
-    transformers: [
-      {
-        pre(node) {
-          node.properties.style = 'background-color:var(--code-bg);color:var(--code-text)';
-        },
-      },
-    ],
-  }),
-);


### PR DESCRIPTION
## Why

Building \`packages/site\` printed

\`\`\`
[mochi] [highlight] shiki engine for platform 'darwin': JS RegExp
\`\`\`

**four times**, which raised the question of whether docs were being built repeatedly / shipping CSR bundles for SSR-only content.

**Root cause:** `packages/site/src/lib/highlight.server.ts` initialised Shiki with eager, unguarded top-level side effects — a `logger.warn` and a top-level-`await createShiki` (which loads ~11 TextMate grammars) — with **no per-process singleton guard**. So the module re-ran both every time a distinct module graph evaluated it. During one build that's four realms:

1. the prebuild process (`generateDocsBarrel → loadDocs → docs.ts → components/utils.ts → highlight.server`);
2. the build's route-extraction `import(index.ts)`;
3. the "pages" `Bun.build` cohort (each compiled `.server.js` is `import()`-ed to read island metadata);
4. the "islands" cohort — a **separate** `Bun.build`, so a different content-hashed chunk path → ESM cache miss → evaluated again.

At production runtime it's worse: every demo SSR bundle importing the module (~11) allocated its own highlighter.

**Not** a problem the original hypotheses guessed at: docs are compiled/highlighted **once per build** (server target, compile-cached), never at request time, and doc markdown is **already SSR-only** (`.md` files are never client-bundled). The `/docs/:slug` "10 islands / 1.37 MB" figure is a build-time attribution artifact of the all-docs barrel, not repeated doc building.

## What

- **Export `pinGlobal`** from `mochi-framework` (the existing internal primitive for "duplicate bundled copies share one instance per process") and add it to both `mochi-env` virtual-module templates — a real re-export on the client too, since it's isomorphic (`globalThis`-only), per the CLAUDE.md "add new exports to both `build.onLoad` blocks" rule.
- **Guard the highlighter** with `pinGlobal(...)` in `highlight.server.ts`: the log + engine selection + `createShiki` + `highlightCode` now initialise at most once per process; the module-level top-level `await` is gone (`createHighlighter` already accepts an async callback).
- **Sever the prebuild import chain:** move the highlight-free helpers `isDemoIndex`/`stripImageConfig` and the `SourceSpec` type into a new leaf `components/sourceUtils.ts`, imported from there by `lib/docs.ts`. The barrel-generating prebuild process no longer pulls in the highlighter it never uses. `utils.ts` re-exports them so the ~55 type-only importers are untouched.

## Result

- Build logs the engine line **once** (was 4).
- Runtime collapses to **one** highlighter per process (was ~11).

## Verification

- `bun run build` in `packages/site` — log count 4 → 1, build succeeds.
- Highlighting intact: `/docs/cache/` renders 5 shiki code blocks; `/demos/runed/` source panel highlighted; clean browser console (no hydration errors) on both a docs page and an island page.
- `bun run checks` (lint:fix + format + typecheck + test) passes; no files auto-modified; only pre-existing unrelated warnings.