### PR TITLE
feat!: replace bunqueue with fedify MessageQueue backends

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ Bun workspaces monorepo (`packages/*`):
 - `packages/support` — the support form at `support.mochi.fast`. Port 3336. Deployed separately via `Dockerfile.production`. It lives apart from `packages/site` because it is the only site configured with a real SMTP transport (`Mochi.serve({ email })`, driven by `SMTP_*` env vars — see its `.env.example`); every other site rides the framework default, which never sends. Refuses to boot in production without `ADMIN_PASSWORD` + `SMTP_HOST` + `MOCHI_ORIGIN`.
 - `packages/docs` — `mochi-docs`: markdown content only (no server/scripts of its own); consumed and rendered by `packages/site`.
 - `packages/cli` — published as `create-mochi`: the `mochi-framework build` and project-scaffolding CLI (`@clack/prompts` + `commander`).
-- `packages/msgpackr-extract-stub` — published as `@mochi-framework/msgpackr-extract-stub`; a pure-JS stub wired in via the root `overrides` so the native `msgpackr-extract` is never built.
+- `packages/msgpackr-extract-stub` — published as `@mochi-framework/msgpackr-extract-stub`; a historical pure-JS stub for the native `msgpackr-extract` accelerator. No longer wired into any workspace (the bunqueue dependency that pulled in msgpackr is gone); kept published for projects scaffolded by older `create-mochi` versions.
 - `packages/video-animations` — Satori-based frame generation for promo videos (`bun run mochi:animate`). Satori (yoga) rounds element `left`/`top` to the integer pixel grid, so animate position via `transform: translate(${x}px, ${y}px)` with the element pinned at `left:0/top:0` — driving per-frame motion through `left`/`top` stair-steps and jitters ~1–2px. See `leaf()` in `src/frame.ts`.
 - `packages/remotion` — rendered video output assets.
 
@@ -72,6 +72,7 @@ Source is grouped by subsystem; only the entry points and public API surface (`M
 - **`compiler/`** — the `.svelte` → JS pipeline: `ComponentRegistry.ts`, `svelteAstPreprocess.ts`, `svelteConfig.ts`, `svelteShaker.ts`, `compileCache.ts`, `preprocessCache.ts`, `serverOnlyScan.ts`, `buildInlineWebComponent.ts`, `freshImport.ts`, `tailwind.ts`.
 - **`runtime/`** — the per-request pipeline: `requestSetup.ts`, `requestContext.ts`, `cookies.ts`, `csrf.ts`, `proxy.ts`, `trailingSlash.ts`, `errors.ts`, `hooks.ts`, `rateLimit.ts`, `warmup.ts`, `publicDir.ts`, and forms (`forms.ts`, `formsJson.ts`, `enhance.*`).
 - **`islands/`** — `islandPropsRegistry.ts`, `serverIslandCrypto.ts`, `payloadCrypto.ts`.
+- **`queue/`** — the queue transport internals behind the top-level `queue.ts`: `backends.ts` (resolves `'memory'` / `{ sqlite }` / `{ postgres }` / raw fedify `MessageQueue` instances; lazy driver imports), `memoryQueue.ts` (the in-house fedify-compatible default backend — never runtime-import `@fedify/fedify`, its types are the only sanctioned import), `workerPool.ts` (per-queue concurrency gate). Retry/backoff/events live in `queue.ts`; the drivers are pure transports.
 - **`cache/`** — `cache.ts`, `cache-storage.ts`.
 - **`cli/`** — `cli.ts` (+ the `cli.js` bin shim), `build.ts`, `updateSkill.ts`, `generateKey.ts`, `checkEnvironment.ts`, `extractServeOptions.ts`, `testing.ts`.
 - **`dev/`** — `devWatcher.ts`, `consoleLogger.ts`, and the built-in admin/dev routes.

--- a/bun.lock
+++ b/bun.lock
@@ -101,10 +101,13 @@
       },
       "dependencies": {
         "@css-inline/css-inline-wasm": "^0.21.0",
+        "@fedify/fedify": "^2.3.4",
+        "@fedify/postgres": "^2.3.4",
+        "@fedify/sqlite": "^2.3.4",
         "@joint-ops/hitlimit-bun": "1.5.0",
+        "@js-temporal/polyfill": "^0.5.1",
         "@noble/ciphers": "2.2.0",
         "@noble/hashes": "2.2.0",
-        "bunqueue": "^2.8.44",
         "chokidar": "^5.0.0",
         "deepmerge": "^4.3.1",
         "devalue": "^5.8.2",
@@ -114,6 +117,7 @@
         "mitt": "^3.0.1",
         "negotiator": "^1.0.0",
         "nodemailer": "^9.0.3",
+        "postgres": "^3.4.9",
         "svelte-shaker": ">=0.18.1",
         "zimmerframe": "^1.1.4",
       },
@@ -245,9 +249,6 @@
   "patchedDependencies": {
     "svelte-check@4.7.4": "packages/mochi/patches/svelte-check@4.7.4.patch",
   },
-  "overrides": {
-    "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*",
-  },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
@@ -269,11 +270,15 @@
 
     "@bluwy/giget-core": ["@bluwy/giget-core@0.1.7", "", { "dependencies": { "modern-tar": "^0.7.5" } }, "sha512-6XG8TZt8DVYLuGDVSpFJaSMlNowOg5RGecvWbKvlgMoqVbztUAQ3AcWq6oZ5DoCnTzNAPcO7rhkwt8ZVgrS7CQ=="],
 
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
+
     "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
 
     "@clack/prompts": ["@clack/prompts@1.7.0", "", { "dependencies": { "@clack/core": "1.4.3", "fast-string-width": "^3.0.2", "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A=="],
 
     "@css-inline/css-inline-wasm": ["@css-inline/css-inline-wasm@0.21.0", "", {}, "sha512-Nu64m556iTOe80sFt9unvRQnPUhjx6s1jjHMtFNGv7q5eneBOax2DHhwc636XmWoAjsWUhQbk12j+kgyuO81Zw=="],
+
+    "@digitalbazaar/http-client": ["@digitalbazaar/http-client@4.3.0", "", { "dependencies": { "ky": "^1.14.2", "undici": "^6.23.0" } }, "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw=="],
 
     "@electric-sql/pglite": ["@electric-sql/pglite@0.5.4", "", {}, "sha512-yYZUyyXrHU7tPlCjwZQJ6hIG9DscdCCn7Uk0mYKwC1FeHX286AbcmFveMiRBEak8e9iPupjsoVImN3yJZVed2g=="],
 
@@ -308,6 +313,22 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
+    "@fedify/fedify": ["@fedify/fedify@2.3.4", "", { "dependencies": { "@fedify/uri-template": "2.3.4", "@fedify/vocab": "2.3.4", "@fedify/vocab-runtime": "2.3.4", "@fedify/webfinger": "2.3.4", "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.2.0", "@opentelemetry/api": "^1.9.1", "@opentelemetry/core": "^2.7.1", "@opentelemetry/sdk-metrics": "2.7.1", "@opentelemetry/sdk-trace-base": "^2.7.1", "@opentelemetry/semantic-conventions": "^1.40.0", "byte-encodings": "^1.0.11", "es-toolkit": "1.46.1", "json-canon": "^1.0.1", "jsonld": "^9.0.0", "structured-field-values": "^2.0.4", "urlpattern-polyfill": "^10.1.0" } }, "sha512-mrANyBg/2+LgDooOpDPfa5MWUZzWPU/HubgO6Gpw5jR+U15UU5bHGUEUpWsFGsC61ciCVq0BycV3mdD0EivLxA=="],
+
+    "@fedify/postgres": ["@fedify/postgres@2.3.4", "", { "dependencies": { "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.2.0" }, "peerDependencies": { "@fedify/fedify": "^2.3.4", "postgres": "^3.4.7" } }, "sha512-FRnAPR6KybWzwHmU0ZyRHxt5t7IEGbL6iA0w7vMlc2UnEUez4mDLVWX8JCNPqAMgSN9mI/1PE8GXQHy8lP18dQ=="],
+
+    "@fedify/sqlite": ["@fedify/sqlite@2.3.4", "", { "dependencies": { "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.2.0", "es-toolkit": "^1.46.1" }, "peerDependencies": { "@fedify/fedify": "^2.3.4" } }, "sha512-4lBfGPRoXotDqu1rLLErk3wIJENM1UodlC/7GhyLlXfM8ifA1ppW37+VjszavTMkVQUjyxIZ4os9XbDqCrVl/A=="],
+
+    "@fedify/uri-template": ["@fedify/uri-template@2.3.4", "", {}, "sha512-J7/eNopw/5hFSQJ3mJneg9hl0yzZxrQrH5/RZrnErLBpdW2NA6zshRMiIu5yFvVGcK5d23R87oWqmfCXDUcw4w=="],
+
+    "@fedify/vocab": ["@fedify/vocab@2.3.4", "", { "dependencies": { "@fedify/vocab-runtime": "2.3.4", "@fedify/vocab-tools": "2.3.4", "@fedify/webfinger": "2.3.4", "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.2.0", "@multiformats/base-x": "^4.0.1", "@opentelemetry/api": "^1.9.1", "asn1js": "^3.0.10", "es-toolkit": "1.46.1", "jsonld": "^9.0.0", "pkijs": "^3.3.3" } }, "sha512-xQ9QbTD9WFQAKl2Lt1chPCr5Oe+V+VQNtvjsfN7NxZQ5Q8f7K40NTMjHAMfYprFxos9ldYV5IQ3INsOeWQcGOw=="],
+
+    "@fedify/vocab-runtime": ["@fedify/vocab-runtime@2.3.4", "", { "dependencies": { "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.2.0", "@multiformats/base-x": "^4.0.1", "@opentelemetry/api": "^1.9.1", "asn1js": "^3.0.10", "byte-encodings": "^1.0.11", "jsonld": "^9.0.0", "pkijs": "^3.3.3" } }, "sha512-ibpuxBWLopyC0hambvWWqXejniFlCx+QNAUp9/WgnJbq1w77WDJ+6B5pNjMdzUhmQlvCKErdebJCTwp/NgRqNQ=="],
+
+    "@fedify/vocab-tools": ["@fedify/vocab-tools@2.3.4", "", { "dependencies": { "@cfworker/json-schema": "^4.1.1", "byte-encodings": "^1.0.11", "es-toolkit": "^1.46.1", "yaml": "^2.9.0" } }, "sha512-hh6J5xFqGjMpEB40IM5uWpR4y8YovhQt6CWfC9ylpPZv5zwIDq5D4STNi4WIUQ15xt3/z7HCcZh5dzGS6wgKog=="],
+
+    "@fedify/webfinger": ["@fedify/webfinger@2.3.4", "", { "dependencies": { "@fedify/vocab-runtime": "2.3.4", "@logtape/logtape": "^2.2.0", "@opentelemetry/api": "^1.9.1", "es-toolkit": "1.46.1" } }, "sha512-mjerv2yWIHi6MJVPMi/HY9FVKX9ZuuwjWXOueWnZvi9NToXeboHM086jciQeOjBqxSyWvO6n+qWMhnWbv6xqxQ=="],
 
     "@fontsource-variable/fraunces": ["@fontsource-variable/fraunces@5.3.0", "", {}, "sha512-9BYGySn4AHEJdgp9Z28tQ3X+laJMEOITXkQarZXeloWQZDq5oOvXJ3kDA8c7MGIfpogIaZfjrQBqmda8POOCKA=="],
 
@@ -345,6 +366,10 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
+
+    "@logtape/logtape": ["@logtape/logtape@2.3.0", "", {}, "sha512-s/pxCgf9Gg75ypTV/bRUq355Dy/JP/zUJWfgJQPO5pTkXC23X2AXBcmBBgFiWH+bSi4yiX/G06qGV8CdAWD3SA=="],
+
     "@lucide/svelte": ["@lucide/svelte@1.25.0", "", { "peerDependencies": { "svelte": "^5" } }, "sha512-v9m+dD68jxVnqkU3K59mG/RSRFlPGzmKCGSyMfnXcaGv9jODDQMyQkcp1CGvk3Y/cUj9v7f8rw1n//K0B53xGQ=="],
 
     "@memlab/api": ["@memlab/api@2.0.4", "", { "dependencies": { "@memlab/core": "^2.0.4", "@memlab/e2e": "^2.0.4", "@memlab/heap-analysis": "^2.0.4", "ansi": "^0.3.1", "babar": "^0.2.0", "chalk": "^4.0.0", "fs-extra": "^4.0.2", "minimist": "^1.2.8", "puppeteer": "24.31.0", "puppeteer-core": "24.31.0", "string-width": "^4.2.0", "util.promisify": "^1.1.1", "xvfb": "^0.4.0" } }, "sha512-QvW7oX28wQSwVCBMHUy22ktq68SBM/rKTe+2OOCr23IEMIZesCVveAukXD9/45VZ/QyVD3/AkZ2Z/gA4W0ulEQ=="],
@@ -361,9 +386,25 @@
 
     "@mochi-framework/rsvelte": ["@mochi-framework/rsvelte@workspace:packages/mochi-rsvelte"],
 
+    "@multiformats/base-x": ["@multiformats/base-x@4.0.1", "", {}, "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="],
+
     "@noble/ciphers": ["@noble/ciphers@2.2.0", "", {}, "sha512-Z6pjIZ/8IJcCGzb2S/0Px5J81yij85xASuk1teLNeg75bfT07MV3a/O2Mtn1I2se43k3lkVEcFaR10N4cgQcZA=="],
 
     "@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.10.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-metrics": ["@opentelemetry/sdk-metrics@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.9.0 <1.10.0" } }, "sha512-MpDJdkiFDs3Pm1RHO3KByuZbuBdJEXEAkiC0+yJdsZGVCdf1RpHR6n+LHDcS7ffmfrt5kVCzJSCfm4z2C7v0uQ=="],
+
+    "@opentelemetry/sdk-trace": ["@opentelemetry/sdk-trace@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/resources": "2.10.0", "@opentelemetry/sdk-trace": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.43.0", "", {}, "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg=="],
 
     "@portabletext/svelte": ["@portabletext/svelte@3.0.1", "", { "dependencies": { "@portabletext/toolkit": "^2.0.18" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-zti69Y0kTSOijZmdQQp8emuDM5IYn2zZFPoRH37sCN7bu3QRCQgFqiMouGw+m7x3z7BgaaBLKsyvkDHrA8QnzA=="],
 
@@ -551,6 +592,8 @@
 
     "arraybuffer.prototype.slice": ["arraybuffer.prototype.slice@1.0.4", "", { "dependencies": { "array-buffer-byte-length": "^1.0.1", "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.5", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "is-array-buffer": "^3.0.4" } }, "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ=="],
 
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
+
     "ast-types": ["ast-types@0.13.4", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w=="],
 
     "async-function": ["async-function@1.0.0", "", {}, "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA=="],
@@ -587,7 +630,9 @@
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
-    "bunqueue": ["bunqueue@2.8.44", "", { "dependencies": { "croner": "10.0.1", "msgpackr": "^1.11.8" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.26.0" }, "optionalPeers": ["@modelcontextprotocol/sdk"], "bin": { "bunqueue": "dist/cli/index.js", "bunqueue-mcp": "dist/mcp/index.js" } }, "sha512-gisa8A+ubXt/iqOyVR8X2+zSj7/89ipmI0/q0Qow+WYi5bt4FVVT6uVxhWmRXgtyhrYESZgEBsVl6twHsQZpOQ=="],
+    "byte-encodings": ["byte-encodings@1.0.11", "", {}, "sha512-+/xR2+ySc2yKGtud3DGkGSH1DNwHfRVK0KTnMhoeH36/KwG+tHQ4d9B3jxJFq7dW27YcfudkywaYJRPA2dmxzg=="],
+
+    "bytestreamjs": ["bytestreamjs@2.0.1", "", {}, "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ=="],
 
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 
@@ -598,6 +643,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "camelize": ["camelize@1.0.1", "", {}, "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ=="],
+
+    "canonicalize": ["canonicalize@2.1.0", "", { "bin": { "canonicalize": "bin/canonicalize.js" } }, "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ=="],
 
     "ccount": ["ccount@2.0.1", "", {}, "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="],
 
@@ -632,8 +679,6 @@
     "cosmiconfig": ["cosmiconfig@9.0.2", "", { "dependencies": { "env-paths": "^2.2.1", "import-fresh": "^3.3.0", "js-yaml": "^4.1.0", "parse-json": "^5.2.0" }, "peerDependencies": { "typescript": ">=4.9.5" }, "optionalPeers": ["typescript"] }, "sha512-gtTZxTDau1wL7Y7zifc2dd8jHSK/k6BTx/2Xp/BpdlAdnlYWFVt7qhJqgwi7637yRwRQ3qL4ZidbB4I8tA5VOg=="],
 
     "create-mochi": ["create-mochi@workspace:packages/cli"],
-
-    "croner": ["croner@10.0.1", "", {}, "sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -710,6 +755,8 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.4", "", { "dependencies": { "es-abstract-get": "^1.0.0", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "is-callable": "^1.2.7", "is-date-object": "^1.1.0", "is-symbol": "^1.1.1" } }, "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw=="],
+
+    "es-toolkit": ["es-toolkit@1.46.1", "", {}, "sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -937,9 +984,13 @@
 
     "js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
+    "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-canon": ["json-canon@1.0.1", "", {}, "sha512-PQcj4PFOTAQxE8PgoQ4KrM0DcKWZd7S3ELOON8rmysl9I8JuFMgxu1H9v+oZsTPjjkpeS3IHPwLjr7d+gKygnw=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
@@ -951,9 +1002,13 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "jsonld": ["jsonld@9.0.0", "", { "dependencies": { "@digitalbazaar/http-client": "^4.2.0", "canonicalize": "^2.1.0", "lru-cache": "^6.0.0", "rdf-canonize": "^5.0.0" } }, "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg=="],
+
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "known-css-properties": ["known-css-properties@0.37.0", "", {}, "sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ=="],
+
+    "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -995,7 +1050,7 @@
 
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
-    "lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
+    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
 
@@ -1115,6 +1170,8 @@
 
     "picomatch": ["picomatch@4.0.5", "", {}, "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A=="],
 
+    "pkijs": ["pkijs@3.4.0", "", { "dependencies": { "@noble/hashes": "1.4.0", "asn1js": "^3.0.6", "bytestreamjs": "^2.0.1", "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw=="],
+
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
 
     "postcss": ["postcss@8.5.15", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A=="],
@@ -1128,6 +1185,8 @@
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
+
+    "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -1158,6 +1217,12 @@
     "puppeteer-core": ["puppeteer-core@24.31.0", "", { "dependencies": { "@puppeteer/browsers": "2.10.13", "chromium-bidi": "11.0.0", "debug": "^4.4.3", "devtools-protocol": "0.0.1521046", "typed-query-selector": "^2.12.0", "webdriver-bidi-protocol": "0.3.9", "ws": "^8.18.3" } }, "sha512-pnAohhSZipWQoFpXuGV7xCZfaGhqcBR9C4pVrU0QSrcMi7tQMH9J9lDBqBvyMAHQqe8HCARuREqFuVKRQOgTvg=="],
 
     "pure-rand": ["pure-rand@8.4.2", "", {}, "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng=="],
+
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
+    "rdf-canonize": ["rdf-canonize@5.0.0", "", { "dependencies": { "setimmediate": "^1.0.5" } }, "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w=="],
 
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
@@ -1202,6 +1267,8 @@
     "set-function-name": ["set-function-name@2.0.2", "", { "dependencies": { "define-data-property": "^1.1.4", "es-errors": "^1.3.0", "functions-have-names": "^1.2.3", "has-property-descriptors": "^1.0.2" } }, "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ=="],
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
@@ -1256,6 +1323,8 @@
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "structured-field-values": ["structured-field-values@2.0.4", "", {}, "sha512-5zpJXYLPwW3WYUD/D58tQjIBs10l3Yx64jZfcKGs/RH79E2t9Xm/b9+ydwdMNVSksnsIY+HR/2IlQmgo0AcTAg=="],
 
     "subset-font": ["subset-font@2.5.0", "", { "dependencies": { "fontverter": "^2.0.0", "harfbuzzjs": "^0.10.3", "lodash": "^4.17.21", "p-limit": "^3.1.0" } }, "sha512-Vsa8ngQ/ohhUj0an7on49y9jLZ2rK5U+T1FzPM4/ZQY0xUy5mLis6BfFtPGzecTjFgYXQlvY7FlsJF4t3R/6Ug=="],
 
@@ -1339,6 +1408,8 @@
 
     "unbox-primitive": ["unbox-primitive@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "has-bigints": "^1.0.2", "has-symbols": "^1.1.0", "which-boxed-primitive": "^1.1.1" } }, "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw=="],
 
+    "undici": ["undici@6.28.0", "", {}, "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA=="],
+
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unicode-trie": ["unicode-trie@2.0.0", "", { "dependencies": { "pako": "^0.2.5", "tiny-inflate": "^1.0.0" } }, "sha512-x7bc76x0bm4prf1VLg79uhAzKw8DVboClSN5VxJuQ+LKDOVEW9CdH+VY7SP+vX7xCYQqzzgQpFqz15zeLvAtZQ=="],
@@ -1360,6 +1431,8 @@
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "uri-template-matcher": ["uri-template-matcher@1.1.2", "", {}, "sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ=="],
+
+    "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
@@ -1401,6 +1474,8 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
     "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "yargs": ["yargs@17.7.3", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g=="],
@@ -1420,6 +1495,16 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@fedify/vocab-tools/yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
+
+    "@opentelemetry/resources/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-metrics/@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/sdk-trace/@opentelemetry/resources": ["@opentelemetry/resources@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA=="],
+
+    "@opentelemetry/sdk-trace-base/@opentelemetry/resources": ["@opentelemetry/resources@2.10.0", "", { "dependencies": { "@opentelemetry/core": "2.10.0", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA=="],
 
     "@tailwindcss/node/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1446,6 +1531,10 @@
     "mdast-util-to-hast/unist-util-visit": ["unist-util-visit@5.1.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg=="],
 
     "mdsvex/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "path-scurry/lru-cache": ["lru-cache@11.5.0", "", {}, "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA=="],
+
+    "pkijs/@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
 
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 

--- a/package.json
+++ b/package.json
@@ -69,8 +69,5 @@
   },
   "patchedDependencies": {
     "svelte-check@4.7.4": "packages/mochi/patches/svelte-check@4.7.4.patch"
-  },
-  "overrides": {
-    "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*"
   }
 }

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -29,8 +29,5 @@
     "@types/bun": "1.3.14",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
-  },
-  "overrides": {
-    "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*"
   }
 }

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -1,7 +1,7 @@
 ---
 title: 'Queues'
 slug: queues
-description: 'Run background jobs in-process with Mochi.queue(), backed by bunqueue embedded mode.'
+description: 'Run background jobs with Mochi.queue() on a memory, SQLite, or PostgreSQL backend — or any fedify MessageQueue.'
 ---
 
 <script>
@@ -11,7 +11,7 @@ description: 'Run background jobs in-process with Mochi.queue(), backed by bunqu
 
 ## Queues
 
-Offload work that shouldn't block a response — sending email, encoding media, calling slow third-party APIs — to a background **queue**. A queue bundles a job channel with the `process` function that consumes it; both run in your process, backed by [bunqueue](https://bunqueue.dev/)'s embedded mode.
+Offload work that shouldn't block a response — sending email, encoding media, calling slow third-party APIs — to a background **queue**. A queue bundles a job channel with the `process` function that consumes it; both run in your process. Messages travel through a pluggable backend — in-memory by default, SQLite or PostgreSQL for persistence — using the [fedify `MessageQueue`](https://fedify.dev/manual/mq) transport model, while retry, backoff, concurrency, and events are handled by Mochi.
 
 `Mochi.queue()` — like `Mochi.page` / `api` / `ws` / `sse` — returns an **inert config** that you mount in `Mochi.serve({ queues })`, keyed by name, so every background queue the server runs is declared in one place. Add jobs from anywhere with `Mochi.getQueue(name).add(...)`.
 
@@ -36,6 +36,53 @@ await Mochi.serve({
 await Mochi.getQueue<{ to: string }>('emails').add('send', { to: 'alice@example.com' });
 ```
 
+### Backends
+
+The default backend is `'memory'`: nothing to configure, nothing survives a restart. Choose per queue with the `backend` option, or set a server-wide default with `queueBackend` (a queue's own `backend` overrides it):
+
+```ts
+await Mochi.serve({
+  // default for every queue in the map
+  queueBackend: { sqlite: '.mochi/queue.sqlite' },
+  queues: {
+    emails: Mochi.queue({ process: sendEmail }),
+    // this one overrides the default
+    critical: Mochi.queue({ process: charge, backend: { postgres: process.env.DATABASE_URL } }),
+  },
+});
+```
+
+| Backend                   | Persistence | Notes                                                                                               |
+| ------------------------- | ----------- | --------------------------------------------------------------------------------------------------- |
+| `'memory'`                | none        | The default. Jobs are lost on restart — pair with [`recover`](#recovery-on-start).                  |
+| `{ sqlite: path }`        | file        | One SQLite file can back many queues (one table each). Single instance only.                        |
+| `{ postgres: url }`       | server      | `LISTEN`/`NOTIFY` + polling via [@fedify/postgres](https://www.npmjs.com/package/@fedify/postgres). |
+| a `MessageQueue` instance | up to you   | Bring your own fedify driver — Redis, AMQP, or custom. One instance per queue.                      |
+
+Any object implementing fedify's `MessageQueue` interface works as a `backend`, so the whole [fedify driver ecosystem](https://fedify.dev/manual/mq) plugs in:
+
+```ts
+import { RedisMessageQueue } from '@fedify/redis';
+import Redis from 'ioredis';
+
+Mochi.queue({ process, backend: new RedisMessageQueue(() => new Redis()) });
+```
+
+The `fedify` object on the `sqlite` / `postgres` forms is the escape hatch: it is passed verbatim to the driver constructor, so any [`SqliteMessageQueueOptions`](https://www.npmjs.com/package/@fedify/sqlite) / [`PostgresMessageQueueOptions`](https://www.npmjs.com/package/@fedify/postgres) field can be overridden:
+
+```ts
+Mochi.queue({
+  process,
+  backend: { sqlite: '.mochi/queue.sqlite', fedify: { pollInterval: { seconds: 2 }, journalMode: 'WAL' } },
+});
+```
+
+<Callout type="danger">
+
+**Delivery is at-most-once.** The SQLite and PostgreSQL backends remove a message from the store _before_ the handler runs, so a process crash mid-job loses that job — there is no lock-based reclaim. `recover` is the sanctioned answer: keep the source of truth in your own store and re-enqueue unfinished work at boot. The memory backend loses everything on restart regardless.
+
+</Callout>
+
 ### `Mochi.queue()`
 
 ```ts
@@ -51,9 +98,9 @@ const queueConfig = Mochi.queue<JobData, Result>({ process, ...options });
 | `data`       | `T`      | the enqueued payload                    |
 | `queue`      | `string` | queue name                              |
 | `attempt`    | `number` | 1-based attempt number (1 on first run) |
-| `enqueuedAt` | `number` | epoch ms when enqueued                  |
+| `enqueuedAt` | `number` | epoch ms when first enqueued            |
 
-Options: `concurrency` (jobs processed at once), `dataPath` (see below), `lockDuration` (see [Long-running jobs](#long-running-jobs)), `recover` (a startup callback for re-enqueuing unfinished work — see [Recovery on start](#recovery-on-start)), and `on` for lifecycle listeners:
+Options: `concurrency` (jobs processed at once), `backend` (see [Backends](#backends)), `backoff` (see [Retries](#retries--backoff)), `defaultJobOptions`, `recover` (a startup callback for re-enqueuing unfinished work — see [Recovery on start](#recovery-on-start)), and `on` for lifecycle listeners:
 
 ```ts
 Mochi.queue({
@@ -72,21 +119,47 @@ Or subscribe globally on the [`mochiEvents` bus](#observability) (filter by `que
 
 `Mochi.getQueue<JobData>(name)` resolves a mounted queue's handle — call `.add()` on it to add jobs. Pass the payload type explicitly. It throws if the name was never declared in `Mochi.serve({ queues })`, or if reached before `Mochi.serve()` mounted its queues — the message tells you which, so a mistimed call is never reported as a misspelled name.
 
-| Method                   | Returns                  | Notes                    |
-| ------------------------ | ------------------------ | ------------------------ |
-| `add(name, data, opts?)` | `Promise<MochiJobRef>`   | enqueue one job          |
-| `addBulk(jobs)`          | `Promise<MochiJobRef[]>` | enqueue many in one call |
+| Method                   | Returns                                 | Notes                       |
+| ------------------------ | --------------------------------------- | --------------------------- |
+| `add(name, data, opts?)` | `Promise<MochiJobRef>`                  | enqueue one job             |
+| `addBulk(jobs)`          | `Promise<MochiJobRef[]>`                | enqueue many in one call    |
+| `depth()`                | `Promise<MochiQueueDepth \| undefined>` | what's waiting in the store |
 
-`MochiJobRef` is `{ id, name }`. Per-job options: `priority`, `delay` (ms), `attempts`, `jobId`.
+`MochiJobRef` is `{ id, name }`. Per-job options: `delay` (ms before the job becomes runnable), `attempts`, `orderingKey`.
 
 ```ts
 const emails = Mochi.getQueue<{ to: string }>('emails');
-await emails.add('send', { to: 'bob@example.com' }, { priority: 10, delay: 5000 });
+await emails.add('send', { to: 'bob@example.com' }, { delay: 5000, attempts: 3 });
 await emails.addBulk([
   { name: 'send', data: { to: 'a@x.com' } },
-  { name: 'send', data: { to: 'b@x.com' }, opts: { priority: 10 } },
+  { name: 'send', data: { to: 'b@x.com' }, opts: { delay: 1000 } },
 ]);
 ```
+
+`depth()` reports `{ queued, ready?, delayed? }` — messages still waiting in the backend, excluding jobs already handed to `process`. It returns `undefined` when the backend driver doesn't support counting (all three built-ins do).
+
+#### Ordering
+
+Jobs sharing an `orderingKey` are delivered sequentially in enqueue order; jobs without one (or with different keys) can interleave. The guarantee comes from the backend driver and assumes one consumer per key at a time — with `concurrency` above 1 Mochi may still run differently-keyed jobs in parallel, so `concurrency: 1` is the strict spelling:
+
+```ts
+await queue.add('create', { noteId: '123' }, { orderingKey: 'note:123' });
+await queue.add('delete', { noteId: '123' }, { orderingKey: 'note:123' }); // runs after create
+```
+
+### Retries & backoff
+
+A job whose `process` throws is retried until its `attempts` budget (default 1 — no retry) is spent. `backoff` on the queue spaces the retries; `exponential` doubles the base delay each attempt, clamped by `maxDelay`:
+
+```ts
+Mochi.queue({
+  process: sendEmail,
+  defaultJobOptions: { attempts: 3 },
+  backoff: { type: 'exponential', delay: 5000, maxDelay: 60_000 },
+});
+```
+
+Each failure emits [`queue:failed`](#observability) with a `willRetry` flag — `true` while attempts remain, `false` on the terminal failure. Retries are handled by Mochi itself (a re-enqueue with the computed delay), so they behave identically on every backend.
 
 ### A shared queue module
 
@@ -133,45 +206,9 @@ await Mochi.serve({
 });
 ```
 
-### Persistence
-
-By default the queue is **in-memory** — jobs do not survive a restart. Pass `dataPath` to persist to SQLite:
-
-```ts
-Mochi.queue({ process, dataPath: '.mochi/queue.sqlite' });
-```
-
-<Callout type="warning">
-
-bunqueue locks the embedded store to the **first** `dataPath` used in the process. Use one `dataPath` across all your queues; conflicting paths are ignored (Mochi logs a warning).
-
-</Callout>
-
-### Long-running jobs
-
-A job holds a lock while it runs. If the job outlives the lock, the queue assumes the worker died and hands the job to someone else — while the original is still running. Mochi allows **30 minutes** by default, which is also the longest a job may run at all; lower it with `lockDuration` (ms) if you want a stuck job reclaimed sooner:
-
-```ts
-Mochi.queue({ process: resizeImage, lockDuration: 60_000 });
-```
-
-<Callout type="warning">
-
-`lockDuration` must exceed the **worst case** runtime of `process`, not the typical one. A job that overruns it is re-queued mid-flight, and its eventual success is rejected as `Invalid or expired lock token` and reported as a failure — even though the work succeeded. Depending on the queue version it is then either retried, firing its side effects a second time, or abandoned where it stands.
-
-</Callout>
-
-<Callout type="danger">
-
-**30 minutes is a ceiling, not just a default.** The underlying queue drops any job that has been processing for longer, whatever `lockDuration` says — so raising it past 30 minutes buys nothing, and the job still fails. Work that can run longer belongs outside the queue, or split into jobs that each finish well inside the limit.
-
-</Callout>
-
-Lowering `lockDuration` does not make a crashed worker's jobs recover faster — that's handled separately by heartbeat-based stall detection, which is independent of the lock.
-
 ### Recovery on start
 
-An in-memory queue loses its jobs on restart, and even a persisted one can't know about work your own database recorded before the job was accepted. `recover` runs once at startup — after every queue in `Mochi.serve({ queues })` is mounted — with this queue's handle, so it's the place to add back whatever your store still considers unfinished:
+An in-memory queue loses its jobs on restart, and even a persisted one can't know about work your own database recorded before the job was accepted — or a job lost to a mid-run crash (see the delivery callout above). `recover` runs once at startup — after every queue in `Mochi.serve({ queues })` is mounted — with this queue's handle, so it's the place to add back whatever your store still considers unfinished:
 
 ```ts
 Mochi.queue<{ id: number }>({
@@ -185,7 +222,7 @@ Mochi.queue<{ id: number }>({
 
 Recovery is awaited before `Mochi.serve()` resolves, so recovered jobs are enqueued before the `mochi:ready` hook fires. Because the server is already bound and serving by then, a throw is contained: Mochi logs it and emits `queue:error`, and the server keeps running.
 
-A `recover` that never settles is never cut short — abandoning it would drop the jobs it was about to add. Since warmup, `mochi:ready` and `serve()` resolving all wait behind it, Mochi logs a warning naming the queue if one is still running after 30 seconds.
+A `recover` that never settles is never cut short — abandoning it would drop the jobs it was about to add. Since warmup, `mochi:ready` and `serve()` resolving all wait behind it, Mochi logs a warning naming the queue if one is still running after 30 seconds (tune per queue with the [`queue:recoveryStallWarningMs`](/docs/extensions/) filter).
 
 <Callout type="info">
 
@@ -193,34 +230,9 @@ A `recover` that never settles is never cut short — abandoning it would drop t
 
 </Callout>
 
-### Advanced options
-
-Mochi wraps a small, stable core. For bunqueue features Mochi doesn't surface first-class — retry backoff, rate limiting, cron/repeat, dead-letter queue, deduplication — pass a `bunqueue` object that is forwarded verbatim to the underlying queue and worker:
-
-```ts
-const apiCalls = Mochi.queue({
-  process,
-  defaultJobOptions: { attempts: 5 },
-  bunqueue: { limiter: { max: 100, duration: 1000 } },
-});
-
-await Mochi.getQueue('api-calls').add('call', data, {
-  attempts: 5,
-  bunqueue: { backoff: { type: 'jitter', delay: 1000 } },
-});
-```
-
-See the [bunqueue docs](https://bunqueue.dev/guide/simple-mode/) for the full option set.
-
-<Callout type="info">
-
-`bunqueue` is applied last, so anything it repeats wins over the first-class option next to it. Prefer the first-class option where one exists. The one exception is `lockDuration`, which either spelling can set but the [`queue:lockDurationMs`](/docs/extensions/) filter always gets the final say on.
-
-</Callout>
-
 ### Observability
 
-Queues emit [events](/docs/events/) on the `mochiEvents` bus — `queue:added`, `queue:active`, `queue:completed`, `queue:failed`, `queue:error` — and the built-in [console logger](/docs/logging/) prints a `QUEUE` line for `added`, `completed`, `failed`, and `error`. Those four print at `warn`, so they're visible under the production default level; demote them with the [`consoleLogger:level` filter](/docs/extensions/) if you don't want them there. The per-attempt `active` line needs `logger: { level: 'debug' }`. Wire your own metrics directly:
+Queues emit [events](/docs/events/) on the `mochiEvents` bus — `queue:added`, `queue:active`, `queue:completed`, `queue:failed` (with `willRetry`), `queue:error` — and the built-in [console logger](/docs/logging/) prints a `QUEUE` line for `added`, `completed`, `failed`, and `error`. Those four print at `warn`, so they're visible under the production default level; demote them with the [`consoleLogger:level` filter](/docs/extensions/) if you don't want them there. The per-attempt `active` line needs `logger: { level: 'debug' }`. Wire your own metrics directly:
 
 ```ts
 import { mochiEvents } from 'mochi-framework';
@@ -244,7 +256,7 @@ A long-running resource the `process` function _opens_ (a DB pool, a client conn
 
 ### Shutdown
 
-Queues close gracefully when `Mochi.serve()` receives `SIGTERM`/`SIGINT` — in-flight jobs drain before the process exits. A **queue-only process** (no page/API routes) is just `Mochi.serve({ queues })` with no `routes`:
+Queues close gracefully when `Mochi.serve()` receives `SIGTERM`/`SIGINT` — the listen loops stop, in-flight jobs drain, then the backing stores close. Backends Mochi opened itself (memory, sqlite, postgres) are closed for you; a raw `MessageQueue` instance you passed in is yours to close. A **queue-only process** (no page/API routes) is just `Mochi.serve({ queues })` with no `routes`:
 
 ```ts
 // worker.ts — run with `bun worker.ts`
@@ -263,14 +275,10 @@ await Mochi.serve({
 
 <Callout type="info">
 
-**Embedded mode only.** The code that adds jobs and the worker that runs them share one process. bunqueue also supports a TCP server mode for distributed workers; Mochi doesn't expose that yet.
+**One process per queue.** Producers and the consumer share the process — Mochi starts exactly one listen loop per queue, and `recover` runs in every process that boots. The postgres backend's store supports multiple workers, but running several Mochi instances against one queue is not supported yet: recovery would re-enqueue the same work once per instance.
 
 </Callout>
 
-### Dependencies
-
-Mochi uses bunqueue as the underlying implementation for queues. bunqueue pulls in `msgpackr`, whose optional native accelerator (`msgpackr-extract`) would otherwise drag platform-specific prebuilt binaries into your install — so Mochi swaps it out via a `package.json` `overrides` entry pointing at [`@mochi-framework/msgpackr-extract-stub`](https://www.npmjs.com/package/@mochi-framework/msgpackr-extract-stub), an empty stub that keeps `msgpackr` on its pure-JS codec so no native binaries are installed. New projects scaffolded with `create-mochi` ship this override by default — to opt out and use the native bindings, just delete the `overrides` entry from your `package.json`.
-
 <SeeItInAction
-demos={[{ href: "/demos/queue/", title: "Background jobs with queues", hook: "How background job queues work — offload work to a Mochi.queue() with an embedded worker, no Redis." }]}
+demos={[{ href: "/demos/queue/", title: "Background jobs with queues", hook: "How background job queues work — offload work to a Mochi.queue() with a pluggable backend, no Redis." }]}
 />

--- a/packages/docs/162-extensions.md
+++ b/packages/docs/162-extensions.md
@@ -645,22 +645,3 @@ await Mochi.serve({
 ```
 
 Return `0` to silence the warning for a queue entirely — no timer is scheduled at all.
-
-#### `queue:lockDurationMs`
-
-How long a job may run before its queue reclaims it. Resolved once per queue as it is created, after the per-queue [`lockDuration`](/docs/queues/#long-running-jobs) option — `explicit` says whether the incoming value came from that option rather than the framework default, so a blanket filter can leave queues that chose for themselves alone. Sync. Defaults to `1_800_000` (30 minutes), which is also the ceiling: returning more does not let a job run longer.
-
-```ts
-await Mochi.serve({
-  filters: {
-    // Nothing here should ever hold a job for half an hour; queues that set their own value keep it.
-    'queue:lockDurationMs': (value, { explicit }) => (explicit ? value : 5 * 60_000),
-  },
-  queues,
-  routes,
-});
-```
-
-The returned value must exceed the **worst case** runtime of `process`. Set it too low and a job is re-queued while still running, its eventual success rejected as `Invalid or expired lock token` — the work is reported failed despite having succeeded, and is then either retried or dropped.
-
-This filter is the last word on the lock: unlike every other queue setting, a `lockDuration` passed through the raw [`bunqueue`](/docs/queues/#advanced-options) escape hatch doesn't override it — that value arrives as the incoming `value` with `explicit: true`, exactly like the first-class option.

--- a/packages/minimal-rsvelte/package.json
+++ b/packages/minimal-rsvelte/package.json
@@ -23,8 +23,5 @@
     "@types/bun": "1.3.14",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
-  },
-  "overrides": {
-    "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*"
   }
 }

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -21,8 +21,5 @@
     "@types/bun": "1.3.14",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
-  },
-  "overrides": {
-    "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*"
   }
 }

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -99,10 +99,13 @@
   },
   "dependencies": {
     "@css-inline/css-inline-wasm": "^0.21.0",
+    "@fedify/fedify": "^2.3.4",
+    "@fedify/postgres": "^2.3.4",
+    "@fedify/sqlite": "^2.3.4",
     "@joint-ops/hitlimit-bun": "1.5.0",
+    "@js-temporal/polyfill": "^0.5.1",
     "@noble/ciphers": "2.2.0",
     "@noble/hashes": "2.2.0",
-    "bunqueue": "^2.8.44",
     "chokidar": "^5.0.0",
     "deepmerge": "^4.3.1",
     "devalue": "^5.8.2",
@@ -112,6 +115,7 @@
     "mitt": "^3.0.1",
     "negotiator": "^1.0.0",
     "nodemailer": "^9.0.3",
+    "postgres": "^3.4.9",
     "svelte-shaker": ">=0.18.1",
     "zimmerframe": "^1.1.4"
   },

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -186,7 +186,7 @@ export class Mochi {
    * anywhere via `Mochi.getQueue(name).add(...)`, and the queue drains gracefully on shutdown.
    */
   static queue<T = unknown, R = unknown>(config: MochiQueueOptions<T, R>): MochiQueueConfig {
-    // Whatever survives the destructure is forwarded verbatim to bunqueue.
+    // Whatever survives the destructure is the runtime options (backend, concurrency, backoff, …), kept inert until mount.
     const { process, on, recover, ...options } = config;
     return {
       __mochiQueue: true,
@@ -1727,7 +1727,7 @@ export class Mochi {
     // just-bound server down rather than leaving it listening half-started.
     try {
       for (const [name, config] of Object.entries(options.queues ?? {})) {
-        createQueue(name, config.process, config.options, config.on);
+        await createQueue(name, config.process, { ...config.options, backend: config.options?.backend ?? options.queueBackend }, config.on);
       }
     } catch (err) {
       await closeAllQueueResources();

--- a/packages/mochi/src/__fixtures__/postgres/startTestPostgres.ts
+++ b/packages/mochi/src/__fixtures__/postgres/startTestPostgres.ts
@@ -17,7 +17,10 @@ export interface TestPostgres {
 
 export async function startTestPostgres(opts?: { initSql?: string }): Promise<TestPostgres> {
   const db = await PGlite.create();
-  const server = new PGLiteSocketServer({ db, port: 0, host: '127.0.0.1' });
+  // maxConnections defaults to 1, which hangs any client needing concurrent sockets — postgres.js keeps a pooled
+  // query connection open while LISTEN holds its own dedicated one. Queries are serialized by the server's shared
+  // query queue regardless, so a higher cap only lifts the socket limit.
+  const server = new PGLiteSocketServer({ db, port: 0, host: '127.0.0.1', maxConnections: 16 });
 
   // `PGLiteSocketServer.port` is private; the only way to learn the OS-assigned port from
   // `port: 0` is the `listening` event it fires from inside start().

--- a/packages/mochi/src/cli/cli.ts
+++ b/packages/mochi/src/cli/cli.ts
@@ -183,9 +183,8 @@ async function main() {
     assetPrefix: values['asset-prefix'],
   });
 
-  // Extracting serve options imports the user's entry for real, so a top-level
-  // Mochi.queue() producer opens an embedded store whose background intervals
-  // keep the event loop alive and hang this one-shot build. Drain and exit.
+  // Extracting serve options imports the user's entry for real; if that entry mounted queues, their listen loops and
+  // delay timers keep the event loop alive and would hang this one-shot build. Drain and exit.
   await closeAllQueueResources();
   process.exit(0);
 }

--- a/packages/mochi/src/cli/extractServeOptions.test.ts
+++ b/packages/mochi/src/cli/extractServeOptions.test.ts
@@ -37,9 +37,9 @@ throw new Error('serve should have halted execution before this line');`,
     expect(options?.optimize).toEqual({ enabled: true, exclude: ['x.svelte'] });
   });
 
-  test('captures the queues map without starting a queue thread', async () => {
+  test('captures the queues map without starting a queue listener', async () => {
     // Mochi.queue() is inert config, so importing the entry for extraction must
-    // not spawn a live bunqueue thread (which would hang the build). The test
+    // not start a live listen loop (which would hang the build). The test
     // simply completing proves nothing kept the event loop alive.
     const entry = writeEntry(
       `import { Mochi } from 'mochi-framework';

--- a/packages/mochi/src/events.ts
+++ b/packages/mochi/src/events.ts
@@ -204,6 +204,8 @@ export interface MochiQueueFailedEvent {
   duration: number;
   /** Message of the error the processor threw. */
   error: string;
+  /** Whether the job will be re-enqueued for another attempt (`attempt < attempts`). */
+  willRetry: boolean;
 }
 
 export interface MochiQueueErrorEvent {

--- a/packages/mochi/src/extensions.test.ts
+++ b/packages/mochi/src/extensions.test.ts
@@ -284,30 +284,6 @@ describe('new extension points', () => {
     expect(applyFilter('queue:recoveryStallWarningMs', 30_000, { queue: 'emails' })).toBe(0);
   });
 
-  test('queue:lockDurationMs returns the default unchanged when no filter registered', () => {
-    expect(applyFilter('queue:lockDurationMs', 1_800_000, { queue: 'emails', explicit: false })).toBe(1_800_000);
-  });
-
-  test('queue:lockDurationMs can raise the lock for one queue only', () => {
-    initExtensions({
-      filters: {
-        'queue:lockDurationMs': (def, { queue }) => (queue === 'transcode' ? 3_600_000 : def),
-      },
-    });
-    expect(applyFilter('queue:lockDurationMs', 1_800_000, { queue: 'transcode', explicit: false })).toBe(3_600_000);
-    expect(applyFilter('queue:lockDurationMs', 1_800_000, { queue: 'emails', explicit: false })).toBe(1_800_000);
-  });
-
-  test('queue:lockDurationMs can leave queues that chose their own value alone', () => {
-    initExtensions({
-      filters: {
-        'queue:lockDurationMs': (value, { explicit }) => (explicit ? value : 60_000),
-      },
-    });
-    expect(applyFilter('queue:lockDurationMs', 50, { queue: 'transcode', explicit: true })).toBe(50);
-    expect(applyFilter('queue:lockDurationMs', 1_800_000, { queue: 'emails', explicit: false })).toBe(60_000);
-  });
-
   test('compile:preprocessors returns the user-supplied list', () => {
     const fakePreprocessor = { name: 'fake', markup: () => ({ code: '' }) };
     initExtensions({

--- a/packages/mochi/src/extensions.ts
+++ b/packages/mochi/src/extensions.ts
@@ -123,7 +123,6 @@ export interface MochiFilterValue {
   'captcha:driftAllowanceMs': number;
   'captcha:solveBudgetMs': number;
   'queue:recoveryStallWarningMs': number;
-  'queue:lockDurationMs': number;
 }
 
 // Overrides the return type where it differs from the input. Most filters are symmetric, so this map is sparse and an
@@ -195,12 +194,6 @@ export interface MochiFilterContext {
   };
   /** Resolved once per queue that declares a `recover` callback, as recovery starts. */
   'queue:recoveryStallWarningMs': { queue: string };
-  /** Resolved once per queue, as it is created. */
-  'queue:lockDurationMs': {
-    queue: string;
-    /** Whether this queue set `lockDuration` itself — through the option or the raw `bunqueue` passthrough — so the incoming value is its choice, not the framework default. */
-    explicit: boolean;
-  };
 }
 
 export interface MochiFilterKindMap {
@@ -229,7 +222,6 @@ export interface MochiFilterKindMap {
   'captcha:driftAllowanceMs': 'sync';
   'captcha:solveBudgetMs': 'sync';
   'queue:recoveryStallWarningMs': 'sync';
-  'queue:lockDurationMs': 'sync';
 }
 
 type FilterReturn<K extends keyof MochiFilterValue> = K extends keyof MochiFilterReturn ? MochiFilterReturn[K] : MochiFilterValue[K];
@@ -279,7 +271,6 @@ const FILTER_KINDS: { [K in keyof MochiFilterValue]: MochiKind } = {
   'captcha:driftAllowanceMs': 'sync',
   'captcha:solveBudgetMs': 'sync',
   'queue:recoveryStallWarningMs': 'sync',
-  'queue:lockDurationMs': 'sync',
 };
 
 // Pinned on globalThis so duplicate bundled copies of mochi-framework share one registry, the same reasoning as the

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -106,8 +106,20 @@ export type {
   MochiCaptchaVerifyEvent,
   MochiCaptchaReason,
 } from './events';
-export type { MochiQueue, MochiJob, MochiJobRef, MochiJobOptions, MochiQueueOptions, MochiQueueRuntimeOptions, MochiQueueListeners, MochiProcessor } from './queue';
-export { DEFAULT_RECOVERY_STALL_WARNING_MS, DEFAULT_LOCK_DURATION_MS } from './queue';
+export type {
+  MochiQueue,
+  MochiJob,
+  MochiJobRef,
+  MochiJobOptions,
+  MochiQueueOptions,
+  MochiQueueRuntimeOptions,
+  MochiQueueListeners,
+  MochiProcessor,
+  MochiQueueBackend,
+  MochiBackoffOptions,
+  MochiQueueDepth,
+} from './queue';
+export { DEFAULT_RECOVERY_STALL_WARNING_MS } from './queue';
 export { json, error, apiError } from './utils';
 export { trailingSlashIt } from './runtime/trailingSlash';
 export { fail, redirect, success } from './runtime/forms';

--- a/packages/mochi/src/queue.test.ts
+++ b/packages/mochi/src/queue.test.ts
@@ -1,20 +1,26 @@
 import { afterAll, afterEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
-import { createQueue, getQueue, closeAllQueueResources, runQueueRecovery, DEFAULT_LOCK_DURATION_MS } from './queue';
-import type { MochiJob } from './queue';
+import { createQueue, getQueue, closeAllQueueResources, runQueueRecovery } from './queue';
+import type { MochiJob, MochiQueueBackend } from './queue';
+import type { MochiQueueFailedEvent } from './events';
 import { mochiEvents } from './events';
 import { initExtensions } from './extensions';
 import { setLogLevel } from './utils/log';
 import { markStartupMilestone, resetStartupMilestones } from './lifecycle';
 
-// bunqueue locks its embedded store to the first dataPath used in the process,
-// so the whole file shares one temp dir and each test uses a unique queue name.
 const dataDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-queue-test-'));
-const dataPath = path.join(dataDir, 'queue.sqlite');
+const sqlitePath = path.join(dataDir, 'queue.sqlite');
 
+// Underscores so queue names survive table-name sanitization unchanged; unique per test so tables never collide.
 let counter = 0;
-const uniqueName = (): string => `q-${counter++}`;
+const uniqueName = (): string => `q_${counter++}`;
+
+// One shared db file (a backend maps each queue to its own table); factories so each test resolves the backend fresh.
+const BACKENDS: Array<{ label: string; backend: () => MochiQueueBackend }> = [
+  { label: 'memory', backend: () => 'memory' },
+  { label: 'sqlite', backend: () => ({ sqlite: sqlitePath, fedify: { pollInterval: { milliseconds: 50 } } }) },
+];
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
   let resolve!: (value: T) => void;
@@ -31,12 +37,12 @@ afterEach(async () => {
 });
 
 afterAll(async () => {
-  // The last afterEach closes bunqueue's embedded store (shutdownManager ->
-  // storage.close()), but Windows releases the underlying SQLite file lock
-  // asynchronously, so an immediate rm throws EBUSY. (Bun ignores rmSync's
-  // maxRetries option, so retry by hand.) This is best-effort cleanup of an
-  // ephemeral temp dir — never fail the suite over it, so give up quietly once
-  // the budget is exhausted; the OS reclaims it on process exit regardless.
+  // The last afterEach closes the shared sqlite handle, but Windows releases the
+  // underlying SQLite file lock asynchronously, so an immediate rm throws EBUSY.
+  // (Bun ignores rmSync's maxRetries option, so retry by hand.) This is
+  // best-effort cleanup of an ephemeral temp dir — never fail the suite over it,
+  // so give up quietly once the budget is exhausted; the OS reclaims it on
+  // process exit regardless.
   for (let attempt = 0; attempt < 25; attempt++) {
     try {
       rmSync(dataDir, { recursive: true, force: true });
@@ -47,18 +53,18 @@ afterAll(async () => {
   }
 });
 
-describe('Mochi queue', () => {
+describe.each(BACKENDS)('Mochi queue ($label)', ({ backend }) => {
   test('roundtrips a job from producer to consumer', async () => {
     const name = uniqueName();
     const seen = deferred<MochiJob<{ to: string }>>();
 
-    const queue = createQueue<{ to: string }>(
+    const queue = await createQueue<{ to: string }>(
       name,
       async (job) => {
         seen.resolve(job);
         return { sent: true };
       },
-      { dataPath },
+      { backend: backend() },
     );
 
     const ref = await queue.add('send', { to: 'alice@example.com' });
@@ -78,14 +84,14 @@ describe('Mochi queue', () => {
     let processed = 0;
     const done = deferred<void>();
 
-    const queue = createQueue<{ n: number }>(
+    const queue = await createQueue<{ n: number }>(
       name,
       async () => {
         if (++processed === 3) {
           done.resolve();
         }
       },
-      { dataPath },
+      { backend: backend() },
     );
 
     const refs = await queue.addBulk([
@@ -106,7 +112,7 @@ describe('Mochi queue', () => {
     let completed = 0;
     const allDone = deferred<void>();
 
-    const queue = createQueue<{ i: number }>(
+    const queue = await createQueue<{ i: number }>(
       name,
       async () => {
         active++;
@@ -117,7 +123,7 @@ describe('Mochi queue', () => {
           allDone.resolve();
         }
       },
-      { dataPath, concurrency: 2 },
+      { backend: backend(), concurrency: 2 },
     );
 
     await queue.addBulk([0, 1, 2, 3].map((i) => ({ name: 'job', data: { i } })));
@@ -140,7 +146,7 @@ describe('Mochi queue', () => {
     mochiEvents.on('queue:active', (e) => active.push(e));
     mochiEvents.on('queue:completed', (e) => completed.resolve(e));
 
-    const queue = createQueue<{ x: number }>(name, async () => ({ ok: true }), { dataPath });
+    const queue = await createQueue<{ x: number }>(name, async () => ({ ok: true }), { backend: backend() });
     await queue.add('compute', { x: 1 });
 
     const done = await completed.promise;
@@ -154,17 +160,17 @@ describe('Mochi queue', () => {
 
   test('reports failures via queue:failed and the on.failed listener', async () => {
     const name = uniqueName();
-    const failedEvent = deferred<{ error: string; attempt: number }>();
+    const failedEvent = deferred<MochiQueueFailedEvent>();
     const failedListener = deferred<Error>();
 
     mochiEvents.on('queue:failed', (e) => failedEvent.resolve(e));
 
-    const queue = createQueue<{ y: number }>(
+    const queue = await createQueue<{ y: number }>(
       name,
       async () => {
         throw new Error('boom');
       },
-      { dataPath },
+      { backend: backend() },
       { failed: (_job, error) => failedListener.resolve(error) },
     );
 
@@ -173,99 +179,268 @@ describe('Mochi queue', () => {
     const event = await failedEvent.promise;
     expect(event.error).toBe('boom');
     expect(event.attempt).toBe(1);
+    expect(event.willRetry).toBe(false);
 
     const error = await failedListener.promise;
     expect(error).toBeInstanceOf(Error);
     expect(error.message).toBe('boom');
   });
 
-  // bunqueue's embedded heartbeat refreshes stall detection but never renews the
-  // job's lock, so a job outliving `lockDuration` is requeued while it is still
-  // running and the success it eventually reports is rejected as someone else's
-  // work. Mochi's default TTL is 30 minutes, so this drives the failure with a
-  // deliberately tiny one; the lock reaper only ticks every 5s, hence the sleep.
-  // `attempts: 2` and `concurrency: 2` are both load-bearing — the requeued copy
-  // has to be retryable and pullable while the original is still running, and with
-  // `attempts: 1` the job completes cleanly instead.
-  //
-  // Only the rejected success is asserted, because what follows it is a bunqueue
-  // implementation detail that has already moved once: on 2.8.32 the job was
-  // retried (double-firing its side effects), on 2.8.44 it is abandoned instead.
-  // Both are the same defect from Mochi's side and both are fixed by not letting
-  // the lock expire. Before `lockDuration` was threaded through to the worker, a
-  // top-level value was silently dropped, the job kept the 30s default lock, and
-  // no failure fired at all — which is how this test catches a regression.
-  test('a job outliving lockDuration has its success rejected', async () => {
+  test('retries a failing job up to attempts with backoff, flagging willRetry', async () => {
     const name = uniqueName();
-    const failed = deferred<string>();
-    let runs = 0;
+    const failures: MochiQueueFailedEvent[] = [];
+    const exhausted = deferred<void>();
+    const attemptsSeen: number[] = [];
 
-    mochiEvents.on('queue:failed', (e) => failed.resolve(e.error));
+    mochiEvents.on('queue:failed', (e) => {
+      failures.push(e);
+      if (!e.willRetry) {
+        exhausted.resolve();
+      }
+    });
 
-    const queue = createQueue<{ z: number }>(
+    const queue = await createQueue<{ n: number }>(
       name,
-      async () => {
-        runs++;
-        await Bun.sleep(7000);
-        return { ok: true };
+      async (job) => {
+        attemptsSeen.push(job.attempt);
+        throw new Error(`fail #${job.attempt}`);
       },
-      { dataPath, concurrency: 2, lockDuration: 50 },
+      { backend: backend(), backoff: { type: 'fixed', delay: 10 } },
     );
 
-    await queue.add('slow', { z: 1 }, { attempts: 2, bunqueue: { backoff: 10 } });
+    await queue.add('retry-me', { n: 1 }, { attempts: 3 });
 
-    expect(await failed.promise).toMatch(/lock token/i);
-    expect(runs).toBe(1);
-  }, 30_000);
-
-  test('queue:lockDurationMs is resolved once per queue, after the per-queue option', () => {
-    const seen: Array<{ value: number; queue: string; explicit: boolean }> = [];
-    initExtensions({ filters: { 'queue:lockDurationMs': (value, ctx) => (seen.push({ value, ...ctx }), value) } });
-
-    const defaulted = uniqueName();
-    const chosen = uniqueName();
-    const passthrough = uniqueName();
-    try {
-      createQueue(defaulted, async () => null, { dataPath });
-      createQueue(chosen, async () => null, { dataPath, lockDuration: 50 });
-      createQueue(passthrough, async () => null, { dataPath, bunqueue: { lockDuration: 70 } });
-    } finally {
-      initExtensions({});
-    }
-
-    expect(seen).toEqual([
-      { value: DEFAULT_LOCK_DURATION_MS, queue: defaulted, explicit: false },
-      { value: 50, queue: chosen, explicit: true },
-      // The raw escape hatch feeds the filter rather than bypassing it, so the
-      // filtered value stays the last word on the lock.
-      { value: 70, queue: passthrough, explicit: true },
-    ]);
+    await exhausted.promise;
+    expect(attemptsSeen).toEqual([1, 2, 3]);
+    expect(failures.map((f) => f.attempt)).toEqual([1, 2, 3]);
+    expect(failures.map((f) => f.willRetry)).toEqual([true, true, false]);
   });
 
-  test('does not leak bunqueue job methods into the processor', async () => {
+  test('a delayed job does not run before its delay elapses', async () => {
+    const name = uniqueName();
+    const ran = deferred<number>();
+
+    const queue = await createQueue<{ v: number }>(
+      name,
+      async () => {
+        ran.resolve(performance.now());
+      },
+      { backend: backend() },
+    );
+
+    const enqueuedAt = performance.now();
+    await queue.add('later', { v: 1 }, { delay: 150 });
+
+    const startedAt = await ran.promise;
+    expect(startedAt - enqueuedAt).toBeGreaterThanOrEqual(140);
+  });
+
+  test('jobs sharing an orderingKey run sequentially in enqueue order at concurrency 1', async () => {
+    const name = uniqueName();
+    const order: number[] = [];
+    const done = deferred<void>();
+
+    const queue = await createQueue<{ seq: number }>(
+      name,
+      async (job) => {
+        order.push(job.data.seq);
+        if (order.length === 3) {
+          done.resolve();
+        }
+      },
+      { backend: backend(), concurrency: 1 },
+    );
+
+    await queue.add('step', { seq: 1 }, { orderingKey: 'chain' });
+    await queue.add('step', { seq: 2 }, { orderingKey: 'chain' });
+    await queue.add('step', { seq: 3 }, { orderingKey: 'chain' });
+
+    await done.promise;
+    expect(order).toEqual([1, 2, 3]);
+  });
+
+  test('depth() reports what is waiting in the store', async () => {
+    const name = uniqueName();
+    const queue = await createQueue(name, async () => null, { backend: backend() });
+
+    // A far-future delayed job stays in the store, so the count is deterministic
+    // even though the listen loop is already draining ready messages.
+    await queue.add('someday', { v: 1 }, { delay: 60_000 });
+
+    const depth = await queue.depth();
+    expect(depth).toBeDefined();
+    expect(depth!.queued).toBe(1);
+    expect(depth!.delayed).toBe(1);
+    expect(depth!.ready).toBe(0);
+  });
+
+  test('does not leak backend message internals into the processor', async () => {
     const name = uniqueName();
     const seen = deferred<MochiJob<unknown>>();
 
-    const queue = createQueue(
+    const queue = await createQueue(
       name,
       async (job) => {
         seen.resolve(job);
         return null;
       },
-      { dataPath },
+      { backend: backend() },
     );
 
     await queue.add('probe', { hello: 'world' });
 
     const job = await seen.promise;
-    expect((job as unknown as Record<string, unknown>).moveToCompleted).toBeUndefined();
-    expect((job as unknown as Record<string, unknown>).updateProgress).toBeUndefined();
+    expect((job as unknown as Record<string, unknown>).__mochi).toBeUndefined();
+    expect((job as unknown as Record<string, unknown>).attempts).toBeUndefined();
     expect(Object.keys(job).sort()).toEqual(['attempt', 'data', 'enqueuedAt', 'id', 'name', 'queue']);
   });
 
-  test('getQueue resolves the producer handle created for a name', () => {
+  test('closeAllQueueResources drains an in-flight job before closing the store', async () => {
     const name = uniqueName();
-    const created = createQueue(name, async () => null, { dataPath });
+    const started = deferred<void>();
+    let finished = false;
+
+    const queue = await createQueue(
+      name,
+      async () => {
+        started.resolve();
+        await Bun.sleep(120);
+        finished = true;
+      },
+      { backend: backend() },
+    );
+
+    await queue.add('slow', { v: 1 });
+    await started.promise;
+    await closeAllQueueResources();
+    expect(finished).toBe(true);
+  });
+});
+
+// Backend-independent behavior (registry, recovery, lifecycle errors) runs once on the memory backend.
+describe('Mochi queue', () => {
+  test('a raw MessageQueue instance works as a backend, and depth() is undefined without getDepth', async () => {
+    const name = uniqueName();
+    const seen = deferred<MochiJob<{ v: number }>>();
+
+    // Minimal fedify-shaped transport: no delay support, no getDepth.
+    const messages: unknown[] = [];
+    let notify: (() => void) | null = null;
+    const rawQueue = {
+      async enqueue(message: unknown) {
+        messages.push(message);
+        notify?.();
+      },
+      async listen(handler: (message: unknown) => Promise<void> | void, options: { signal?: AbortSignal } = {}) {
+        while (!options.signal?.aborted) {
+          if (messages.length > 0) {
+            await handler(messages.shift());
+            continue;
+          }
+          await new Promise<void>((resolve) => {
+            notify = resolve;
+            options.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          notify = null;
+        }
+      },
+    };
+
+    const queue = await createQueue<{ v: number }>(
+      name,
+      async (job) => {
+        seen.resolve(job);
+      },
+      { backend: rawQueue },
+    );
+
+    await queue.add('custom', { v: 42 });
+    const job = await seen.promise;
+    expect(job.data).toEqual({ v: 42 });
+    expect(await queue.depth()).toBeUndefined();
+
+    // The same instance cannot back a second queue — its single listen loop would steal messages.
+    expect(createQueue(uniqueName(), async () => null, { backend: rawQueue })).rejects.toThrow(/already backs another queue/);
+  });
+
+  test('a non-Mochi message on the store is dropped with a queue:error', async () => {
+    const name = uniqueName();
+    const errors: Array<{ queue: string; error: string }> = [];
+    let processed = 0;
+    mochiEvents.on('queue:error', (e) => errors.push(e));
+
+    let notify: (() => void) | null = null;
+    const messages: unknown[] = [];
+    const rawQueue = {
+      async enqueue(message: unknown) {
+        messages.push(message);
+        notify?.();
+      },
+      async listen(handler: (message: unknown) => Promise<void> | void, options: { signal?: AbortSignal } = {}) {
+        while (!options.signal?.aborted) {
+          if (messages.length > 0) {
+            await handler(messages.shift());
+            continue;
+          }
+          await new Promise<void>((resolve) => {
+            notify = resolve;
+            options.signal?.addEventListener('abort', () => resolve(), { once: true });
+          });
+          notify = null;
+        }
+      },
+    };
+
+    await createQueue(
+      name,
+      async () => {
+        processed++;
+      },
+      { backend: rawQueue },
+    );
+
+    // A foreign producer writing to the same store bypasses Mochi's envelope.
+    await rawQueue.enqueue({ some: 'foreign payload' });
+    await Bun.sleep(20);
+
+    expect(processed).toBe(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.queue).toBe(name);
+    expect(errors[0]!.error).toMatch(/non-Mochi message/);
+  });
+
+  test('two queue names that sanitize to the same table are rejected', async () => {
+    const first = await createQueue('collide me', async () => null, { backend: { sqlite: sqlitePath } });
+    expect(first.name).toBe('collide me');
+    expect(createQueue('collide_me', async () => null, { backend: { sqlite: sqlitePath } })).rejects.toThrow(/both map to backend table/);
+  });
+
+  test('a job persisted by the sqlite backend survives a close and remount', async () => {
+    const name = uniqueName();
+    const backend: MochiQueueBackend = { sqlite: sqlitePath, fedify: { pollInterval: { milliseconds: 50 } } };
+
+    const before = await createQueue(name, async () => null, { backend });
+    // Far enough out that the first mount cannot deliver it before we close.
+    await before.add('survivor', { v: 1 }, { delay: 300 });
+    await closeAllQueueResources();
+
+    const seen = deferred<MochiJob<unknown>>();
+    await createQueue(
+      name,
+      async (job) => {
+        seen.resolve(job);
+      },
+      { backend },
+    );
+
+    const job = await seen.promise;
+    expect(job.name).toBe('survivor');
+    expect(job.data).toEqual({ v: 1 });
+  });
+
+  test('getQueue resolves the producer handle created for a name', async () => {
+    const name = uniqueName();
+    const created = await createQueue(name, async () => null, {});
     expect(getQueue(name)).toBe(created);
   });
 
@@ -277,9 +452,9 @@ describe('Mochi queue', () => {
     expect(() => getQueue('never-declared')).toThrow(/mochi:init/);
   });
 
-  test('getQueue names the mounted queues once mounting finished', () => {
+  test('getQueue names the mounted queues once mounting finished', async () => {
     const name = uniqueName();
-    createQueue(name, async () => null, { dataPath });
+    await createQueue(name, async () => null, {});
     markStartupMilestone('mochi:queuesMounted');
     expect(() => getQueue('typoed')).toThrow(/no such queue/);
     expect(() => getQueue('typoed')).toThrow(new RegExp(`Mounted queues: ${name}`));
@@ -292,7 +467,7 @@ describe('Mochi queue', () => {
 
   test('runQueueRecovery hands each callback its own producer handle', async () => {
     const name = uniqueName();
-    const created = createQueue(name, async () => null, { dataPath });
+    const created = await createQueue(name, async () => null, {});
     let received: unknown;
     await runQueueRecovery([[name, { recover: (queue) => void (received = queue) }]]);
     expect(received).toBe(created);
@@ -300,7 +475,7 @@ describe('Mochi queue', () => {
 
   test('a throwing recover is contained and reported on the event bus', async () => {
     const name = uniqueName();
-    createQueue(name, async () => null, { dataPath });
+    await createQueue(name, async () => null, {});
     const errors: Array<{ queue: string; error: string }> = [];
     mochiEvents.on('queue:error', (e) => errors.push(e));
 
@@ -322,7 +497,7 @@ describe('Mochi queue', () => {
   // real threshold is 30s, so these drive it down far enough to observe.
   async function recoveryWarnings(stallMs: number | null): Promise<string[]> {
     const name = uniqueName();
-    createQueue(name, async () => null, { dataPath });
+    await createQueue(name, async () => null, {});
     initExtensions(stallMs === null ? {} : { filters: { 'queue:recoveryStallWarningMs': () => stallMs } });
 
     const warnings: string[] = [];
@@ -357,7 +532,7 @@ describe('Mochi queue', () => {
 
   test('closeAllQueueResources closes resources and is idempotent', async () => {
     const name = uniqueName();
-    createQueue(name, async () => null, { dataPath });
+    await createQueue(name, async () => null, {});
 
     await closeAllQueueResources();
     // After draining, the handle is gone from the registry.

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -1,39 +1,52 @@
-// The isolation boundary around bunqueue: the only module importing `bunqueue/client`, and the only one whose rewrite a
-// backend swap would need.
-import { Queue, Worker, shutdownManager } from 'bunqueue/client';
-import type { Job, JobOptions } from 'bunqueue/client';
+// The isolation boundary around the queue transport: messages travel through fedify `MessageQueue` drivers
+// (see queue/backends.ts), while retry, backoff, concurrency, and the `queue:*` events live here in Mochi's worker
+// layer — the drivers are pure transports and never see a failure.
+import type { MessageQueueEnqueueOptions } from '@fedify/fedify';
+import { Temporal } from '@js-temporal/polyfill';
 import { pinGlobal } from './utils/globalState';
 import { applyFilter } from './extensions';
 import { startupMilestoneReached } from './lifecycle';
 import { mochiEvents } from './events';
 import { logger } from './utils/log';
+import { resolveBackend, closeBackendResources } from './queue/backends';
+import type { MochiQueueBackend } from './queue/backends';
+import { WorkerPool } from './queue/workerPool';
 
-/** Deliberately narrow — data, not bunqueue's ~40 mutation methods — so userland can't reach behind the abstraction. */
+export type { MochiQueueBackend } from './queue/backends';
+
+/** Deliberately narrow — data, not the transport message — so userland can't reach behind the abstraction. */
 export interface MochiJob<T> {
   readonly id: string;
   readonly name: string;
   readonly data: T;
   readonly queue: string;
-  /** 1-based (bunqueue's `attemptsMade` is 0-based on the first run). */
+  /** 1-based; increments on each retry re-enqueue. */
   readonly attempt: number;
   readonly enqueuedAt: number;
 }
 
 export type MochiProcessor<T, R> = (job: MochiJob<T>) => R | Promise<R>;
 
-/** Lightweight handle returned by `add()` / `addBulk()` — never bunqueue's `Job`. */
+/** Lightweight handle returned by `add()` / `addBulk()`. */
 export interface MochiJobRef {
   id: string;
   name: string;
 }
 
+/** Failure backoff between retry attempts; `exponential` doubles per attempt: `delay * 2^(attempt-1)`. */
+export interface MochiBackoffOptions {
+  type: 'fixed' | 'exponential';
+  /** Base delay in ms. */
+  delay: number;
+  maxDelay?: number;
+}
+
 export interface MochiJobOptions {
-  priority?: number;
+  /** Delay before the job becomes runnable, in ms. */
   delay?: number;
   attempts?: number;
-  jobId?: string;
-  /** Forwarded verbatim to bunqueue's `JobOptions`; spread last, so it overrides the fields above. */
-  bunqueue?: Record<string, unknown>;
+  /** Jobs sharing an ordering key are delivered sequentially (guarantee strength is backend-dependent; combine with `concurrency: 1` for strict ordering). */
+  orderingKey?: string;
 }
 
 /** Lifecycle listeners; the same map is used for the per-queue `on` option and the `MochiQueueListeners` config. */
@@ -47,13 +60,11 @@ export interface MochiQueueListeners<T, R> {
 /** The non-processor settings of a queue — what survives on the inert `MochiQueueConfig.options`. */
 export interface MochiQueueRuntimeOptions {
   concurrency?: number;
-  /** Omit for in-memory. bunqueue locks the path to the first queue in the process — see `rememberDataPath`. */
-  dataPath?: string;
-  /** How long a job may run before the queue reclaims it, in ms. Must exceed `process`'s worst-case runtime — see `DEFAULT_LOCK_DURATION_MS`. */
-  lockDuration?: number;
+  /** Where messages live — defaults to the serve-level `queueBackend`, then `'memory'`. */
+  backend?: MochiQueueBackend;
+  /** Applied between retry attempts when a job fails with attempts remaining. */
+  backoff?: MochiBackoffOptions;
   defaultJobOptions?: MochiJobOptions;
-  /** Forwarded verbatim to bunqueue's `Queue` and `Worker` constructors. */
-  bunqueue?: Record<string, unknown>;
 }
 
 /** The full config object passed to `Mochi.queue({ process, … })`. */
@@ -68,113 +79,162 @@ export interface MochiQueueOptions<T, R = unknown> extends MochiQueueRuntimeOpti
   recover?: (queue: MochiQueue<T>) => void | Promise<void>;
 }
 
+/** What's waiting in the backend store, excluding jobs already handed to the processor. */
+export interface MochiQueueDepth {
+  queued: number;
+  ready?: number;
+  delayed?: number;
+}
+
 /** Handle returned by `Mochi.getQueue(name)` — what you add jobs through. */
 export interface MochiQueue<T> {
   readonly name: string;
   add(name: string, data: T, opts?: MochiJobOptions): Promise<MochiJobRef>;
   addBulk(jobs: Array<{ name: string; data: T; opts?: MochiJobOptions }>): Promise<MochiJobRef[]>;
+  /** `undefined` when the backend driver doesn't report depth. */
+  depth(): Promise<MochiQueueDepth | undefined>;
 }
 
-interface Closeable {
-  /** Drain order on shutdown: workers stop pulling jobs before queues close. */
-  kind: 'worker' | 'queue';
-  close(): Promise<void>;
+/** The wire format every Mochi job travels as, whatever the backend. */
+interface MochiQueueEnvelope<T> {
+  /** Marker + version; a message without it (e.g. a foreign producer on a shared store) is dropped with a `queue:error`. */
+  __mochi: 1;
+  id: string;
+  name: string;
+  data: T;
+  /** 1-based; incremented on each retry re-enqueue. */
+  attempt: number;
+  /** Total attempts allowed, resolved at first enqueue. */
+  attempts: number;
+  /** Epoch ms of the FIRST enqueue, preserved across retries. */
+  enqueuedAt: number;
+  orderingKey?: string;
+}
+
+interface MountedQueue {
+  name: string;
+  controller: AbortController;
+  listening: Promise<void>;
+  pool: WorkerPool;
 }
 
 interface QueueRegistry {
   /** Producer handles, keyed by name; what `getQueue()` resolves. */
   byName: Map<string, MochiQueue<unknown>>;
-  /** Every producer/consumer resource, for `closeAllQueueResources` to drain on shutdown. */
-  closeables: Set<Closeable>;
-  /** First `dataPath` seen; bunqueue ignores later differing paths in the same process. */
-  dataPath: string | null | undefined;
+  /** Live listen loops + pools, for `closeAllQueueResources` to drain on shutdown. */
+  mounted: Set<MountedQueue>;
 }
 
 // Pinned so every duplicate bundled copy of this module shares one registry, since `closeAllQueueResources` must see
 // every resource to drain it whichever copy created it.
 const registry = pinGlobal<QueueRegistry>('__mochi_queue_registry__', () => ({
   byName: new Map(),
-  closeables: new Set(),
-  dataPath: undefined,
+  mounted: new Set(),
 }));
 
-function rememberDataPath(dataPath: string | undefined): void {
-  if (registry.dataPath === undefined) {
-    registry.dataPath = dataPath ?? null;
-    return;
+function backoffDelayMs(backoff: MochiBackoffOptions | undefined, failedAttempt: number): number {
+  if (!backoff) {
+    return 0;
   }
-  const prior = registry.dataPath ?? '(in-memory)';
-  const next = dataPath ?? '(in-memory)';
-  if (prior !== next) {
-    logger.warn(`[queue] dataPath "${next}" ignored — bunqueue locks the embedded store to the first path used this process ("${prior}"). Use one dataPath per process.`);
-  }
+  const delay = backoff.type === 'exponential' ? backoff.delay * 2 ** (failedAttempt - 1) : backoff.delay;
+  return backoff.maxDelay !== undefined ? Math.min(delay, backoff.maxDelay) : delay;
 }
 
-function toMochiJob<T>(job: Job<T>, queueName: string): MochiJob<T> {
+// The fedify enqueue contract wants a real Temporal.Duration; the polyfill's is duck-type-compatible (the drivers call
+// `.total()` rather than instanceof-checking) but not type-identical to the `esnext.temporal` lib type, hence the cast.
+function enqueueOptions<T>(env: MochiQueueEnvelope<T>, delayMs: number): MessageQueueEnqueueOptions {
   return {
-    id: job.id,
-    name: job.name,
-    data: job.data,
-    queue: queueName,
-    attempt: job.attemptsMade + 1,
-    enqueuedAt: job.timestamp,
+    delay: delayMs > 0 ? (Temporal.Duration.from({ milliseconds: Math.round(delayMs) }) as unknown as MessageQueueEnqueueOptions['delay']) : undefined,
+    orderingKey: env.orderingKey,
   };
 }
 
-function toBunJobOptions(opts: MochiJobOptions | undefined): JobOptions | undefined {
-  if (!opts) {
-    return undefined;
-  }
-  const { priority, delay, attempts, jobId, bunqueue } = opts;
-  return { priority, delay, attempts, jobId, ...bunqueue };
+function toMochiJob<T>(env: MochiQueueEnvelope<T>, queueName: string): MochiJob<T> {
+  return {
+    id: env.id,
+    name: env.name,
+    data: env.data,
+    queue: queueName,
+    attempt: env.attempt,
+    enqueuedAt: env.enqueuedAt,
+  };
 }
 
 /**
- * bunqueue defaults a job's lock to 30s and renews it from the worker heartbeat over TCP only; Mochi's embedded
- * heartbeat calls `jobHeartbeat(id)` without a token, refreshing stall detection but never the lock. The lock therefore
- * always expires on schedule, and a job outliving it is requeued mid-flight, its eventual success rejected with
- * "Invalid or expired lock token", reported as a failure, and retried — double-firing whatever it already did. A single
- * SMTP send has taken 58s in production, so the ceiling is raised to bunqueue's own 30-minute cap.
- *
- * That cap is also why this is the highest useful value: bunqueue's `cleanOrphanedProcessingEntries` drops any entry
- * processing for over 30 minutes whatever the lock says. Lowering it still matters, though a crashed worker's jobs come
- * back through stall detection off the heartbeat, independently of the lock.
- */
-export const DEFAULT_LOCK_DURATION_MS = 30 * 60_000;
-
-/**
- * Build a bunqueue `Queue` (producer) and `Worker` (consumer) from one config, registering the producer under `name` for
- * `getQueue` and both resources for shutdown draining. Called only by `Mochi.serve`, where a queue is declared once with
+ * Resolve the backend, register the producer under `name` for `getQueue`, and start the consumer listen loop feeding
+ * `process` through a concurrency-capped worker pool. Called only by `Mochi.serve`, where a queue is declared once with
  * its processor co-located.
  */
-export function createQueue<T = unknown, R = unknown>(
+export async function createQueue<T = unknown, R = unknown>(
   name: string,
   process: MochiProcessor<T, R>,
   options?: MochiQueueRuntimeOptions,
   listeners?: Partial<MochiQueueListeners<T, R>>,
-): MochiQueue<T> {
-  rememberDataPath(options?.dataPath);
+): Promise<MochiQueue<T>> {
+  const { queue: transport } = await resolveBackend(name, options?.backend);
+  const defaults = options?.defaultJobOptions;
+  const backoff = options?.backoff;
 
-  const queue = new Queue<T>(name, {
-    embedded: true,
-    dataPath: options?.dataPath,
-    defaultJobOptions: toBunJobOptions(options?.defaultJobOptions),
-    ...options?.bunqueue,
+  const toEnvelope = (jobName: string, data: T, opts?: MochiJobOptions): MochiQueueEnvelope<T> => ({
+    __mochi: 1,
+    id: crypto.randomUUID(),
+    name: jobName,
+    data,
+    attempt: 1,
+    attempts: Math.max(1, opts?.attempts ?? defaults?.attempts ?? 1),
+    enqueuedAt: Date.now(),
+    orderingKey: opts?.orderingKey ?? defaults?.orderingKey,
   });
 
   const producer: MochiQueue<T> = {
     name,
     async add(jobName, data, jobOpts) {
-      const job = await queue.add(jobName, data, toBunJobOptions(jobOpts));
-      mochiEvents.emit('queue:added', { queue: name, jobId: job.id, jobName: job.name });
-      return { id: job.id, name: job.name };
+      const env = toEnvelope(jobName, data, jobOpts);
+      await transport.enqueue(env, enqueueOptions(env, jobOpts?.delay ?? defaults?.delay ?? 0));
+      mochiEvents.emit('queue:added', { queue: name, jobId: env.id, jobName: env.name });
+      return { id: env.id, name: env.name };
     },
     async addBulk(jobs) {
-      const created = await queue.addBulk(jobs.map((j) => ({ name: j.name, data: j.data, opts: toBunJobOptions(j.opts) })));
-      for (const job of created) {
-        mochiEvents.emit('queue:added', { queue: name, jobId: job.id, jobName: job.name });
+      // `enqueueMany` takes one options object for the whole batch, so jobs are grouped by effective (delay, orderingKey).
+      const groups = new Map<string, { delayMs: number; envelopes: MochiQueueEnvelope<T>[] }>();
+      for (const job of jobs) {
+        const env = toEnvelope(job.name, job.data, job.opts);
+        const delayMs = job.opts?.delay ?? defaults?.delay ?? 0;
+        const key = delayMs + '\u0000' + (env.orderingKey ?? '');
+        const group = groups.get(key);
+        if (group) {
+          group.envelopes.push(env);
+        } else {
+          groups.set(key, { delayMs, envelopes: [env] });
+        }
       }
-      return created.map((job) => ({ id: job.id, name: job.name }));
+      const refs: MochiJobRef[] = [];
+      for (const { delayMs, envelopes } of groups.values()) {
+        const [first] = envelopes;
+        if (!first) {
+          continue;
+        }
+        const opts = enqueueOptions(first, delayMs);
+        if (typeof transport.enqueueMany === 'function') {
+          await transport.enqueueMany(envelopes, opts);
+        } else {
+          for (const env of envelopes) {
+            await transport.enqueue(env, opts);
+          }
+        }
+        for (const env of envelopes) {
+          mochiEvents.emit('queue:added', { queue: name, jobId: env.id, jobName: env.name });
+          refs.push({ id: env.id, name: env.name });
+        }
+      }
+      return refs;
+    },
+    async depth() {
+      if (typeof transport.getDepth !== 'function') {
+        return undefined;
+      }
+      const depth = await transport.getDepth();
+      return { queued: depth.queued, ready: depth.ready, delayed: depth.delayed };
     },
   };
 
@@ -184,9 +244,6 @@ export function createQueue<T = unknown, R = unknown>(
     failed: new Set(),
     error: new Set(),
   };
-  // Seed caller listeners (from `Mochi.queue({ on })`) BEFORE constructing the
-  // worker, which starts draining immediately. Wiring them after would let a job
-  // already queued complete in the gap and miss the `completed`/`active` handler.
   if (listeners) {
     for (const key of Object.keys(listeners) as (keyof MochiQueueListeners<T, R>)[]) {
       const listener = listeners[key];
@@ -196,69 +253,80 @@ export function createQueue<T = unknown, R = unknown>(
     }
   }
 
-  // Filtered per queue after whatever the queue declared for itself, through the first-class option or the raw
-  // `bunqueue` passthrough, so the result is applied last rather than spread over. A deployment can then move the lock
-  // for every queue at once and still see via `explicit` which ones chose a value themselves.
-  const declaredLock = options?.lockDuration ?? (typeof options?.bunqueue?.lockDuration === 'number' ? options.bunqueue.lockDuration : undefined);
-  const lockDuration = applyFilter('queue:lockDurationMs', declaredLock ?? DEFAULT_LOCK_DURATION_MS, {
-    queue: name,
-    explicit: declaredLock !== undefined,
-  });
+  const pool = new WorkerPool(Math.max(1, options?.concurrency ?? 1));
 
-  const worker = new Worker<T, R>(name, (job) => process(toMochiJob(job as Job<T>, name)), {
-    embedded: true,
-    dataPath: options?.dataPath,
-    concurrency: options?.concurrency,
-    ...options?.bunqueue,
-    lockDuration,
-  });
-
-  // bunqueue's `finishedOn`/`processedOn` are unreliable on the public job at event time, so duration is measured here
-  // from the `active` event. Entries clear on completed/failed, and the map stays bounded by in-flight jobs.
-  const startedAt = new Map<string, number>();
-  const durationFor = (jobId: string): number => {
-    const start = startedAt.get(jobId);
-    startedAt.delete(jobId);
-    return start === undefined ? 0 : performance.now() - start;
+  const runJob = async (env: MochiQueueEnvelope<T>): Promise<void> => {
+    const job = toMochiJob(env, name);
+    mochiEvents.emit('queue:active', { queue: name, jobId: env.id, jobName: env.name, attempt: env.attempt });
+    for (const l of sinks.active) {
+      l(job);
+    }
+    const startedAt = performance.now();
+    try {
+      const result = await process(job);
+      mochiEvents.emit('queue:completed', { queue: name, jobId: env.id, jobName: env.name, attempt: env.attempt, duration: performance.now() - startedAt });
+      for (const l of sinks.completed) {
+        l(job, result);
+      }
+    } catch (err) {
+      const error = err instanceof Error ? err : new Error(String(err));
+      const willRetry = env.attempt < env.attempts;
+      mochiEvents.emit('queue:failed', {
+        queue: name,
+        jobId: env.id,
+        jobName: env.name,
+        attempt: env.attempt,
+        duration: performance.now() - startedAt,
+        error: error.message,
+        willRetry,
+      });
+      for (const l of sinks.failed) {
+        l(job, error);
+      }
+      if (willRetry) {
+        try {
+          const retryEnv: MochiQueueEnvelope<T> = { ...env, attempt: env.attempt + 1 };
+          await transport.enqueue(retryEnv, enqueueOptions(retryEnv, backoffDelayMs(backoff, env.attempt)));
+        } catch (requeueErr) {
+          const message = requeueErr instanceof Error ? requeueErr.message : String(requeueErr);
+          logger.error(`[queue] ${name}: failed to re-enqueue job ${env.id} for retry — ${message}`);
+          mochiEvents.emit('queue:error', { queue: name, error: message });
+          for (const l of sinks.error) {
+            l(requeueErr instanceof Error ? requeueErr : new Error(message));
+          }
+        }
+      }
+    }
   };
 
-  worker.on('active', (job) => {
-    startedAt.set(job.id, performance.now());
-    mochiEvents.emit('queue:active', { queue: name, jobId: job.id, jobName: job.name, attempt: job.attemptsMade + 1 });
-    const mj = toMochiJob(job as Job<T>, name);
-    for (const l of sinks.active) {
-      l(mj);
-    }
-  });
-
-  worker.on('completed', (job, result) => {
-    mochiEvents.emit('queue:completed', { queue: name, jobId: job.id, jobName: job.name, attempt: job.attemptsMade + 1, duration: durationFor(job.id) });
-    const mj = toMochiJob(job as Job<T>, name);
-    for (const l of sinks.completed) {
-      l(mj, result);
-    }
-  });
-
-  worker.on('failed', (job, error) => {
-    mochiEvents.emit('queue:failed', { queue: name, jobId: job.id, jobName: job.name, attempt: job.attemptsMade + 1, duration: durationFor(job.id), error: error.message });
-    const mj = toMochiJob(job as Job<T>, name);
-    for (const l of sinks.failed) {
-      l(mj, error);
-    }
-  });
-
-  worker.on('error', (error) => {
-    mochiEvents.emit('queue:error', { queue: name, error: error.message });
-    for (const l of sinks.error) {
-      l(error);
-    }
-  });
+  const controller = new AbortController();
+  // The handler resolves once a pool slot is free and the job has STARTED, so the transport's listen loop can hand over
+  // the next message while up to `concurrency` jobs run; it also never throws, so driver-native retry never engages and
+  // Mochi's retry semantics stay uniform across backends.
+  const listening = transport
+    .listen(
+      (message: unknown) => {
+        const env = message as MochiQueueEnvelope<T>;
+        if (typeof env !== 'object' || env === null || env.__mochi !== 1) {
+          mochiEvents.emit('queue:error', { queue: name, error: `Dropped a non-Mochi message from the backend store: ${JSON.stringify(message)?.slice(0, 200)}` });
+          return;
+        }
+        return pool.run(() => runJob(env));
+      },
+      { signal: controller.signal },
+    )
+    .catch((err: unknown) => {
+      // A dead listen loop means the consumer is gone while producers keep enqueueing — surface loudly.
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error(`[queue] ${name}: listener stopped unexpectedly — ${message}`);
+      mochiEvents.emit('queue:error', { queue: name, error: message });
+      for (const l of sinks.error) {
+        l(err instanceof Error ? err : new Error(message));
+      }
+    });
 
   registry.byName.set(name, producer as MochiQueue<unknown>);
-  // bunqueue's Queue.close() is synchronous (returns void) — only Worker.close()
-  // is async — so the queue's closeable just wraps the sync call.
-  registry.closeables.add({ kind: 'queue', close: async () => void queue.close() });
-  registry.closeables.add({ kind: 'worker', close: () => worker.close() });
+  registry.mounted.add({ name, controller, listening, pool });
   return producer;
 }
 
@@ -302,8 +370,7 @@ export const DEFAULT_RECOVERY_STALL_WARNING_MS = 30_000;
  * every process that boots, so an N-instance deploy (or a rolling restart where
  * old and new overlap) has N processes re-enqueueing the same work from the same
  * store — N copies of every stranded job. Today only single-instance apps are
- * safe, which the embedded-mode-only note in the queues docs already implies but
- * doesn't state.
+ * safe, which the queues docs already imply but don't state.
  *
  * The intended shape, in order:
  *   1. Sleep a random jitter before touching the store — default 0–5000ms, with
@@ -313,8 +380,9 @@ export const DEFAULT_RECOVERY_STALL_WARNING_MS = 30_000;
  *      boot-latency tradeoff, and 0/0 must remain a clean opt-out.
  *   2. Try to acquire a lease named for the queue through a cross-process
  *      persistence layer that DOES NOT EXIST YET — it has to outlive any single
- *      process, so neither `pinGlobal` nor bunqueue's embedded store qualifies.
- *      Designing that store is the actual blocking work here.
+ *      process, so `pinGlobal` doesn't qualify (a shared postgres backend could
+ *      carry one, but memory/sqlite deployments need an answer too). Designing
+ *      that store is the actual blocking work here.
  *   3. Run `recover()` only if the lease was won; otherwise skip it and say so
  *      at debug level. The lease needs a TTL so a process that dies mid-recovery
  *      doesn't lock the queue out of recovery forever — same reasoning as the
@@ -355,27 +423,20 @@ export async function runQueueRecovery(entries: Array<[string, { recover?: (queu
 }
 
 /**
- * Drain every queue resource — workers first (stop pulling new jobs), then
- * queues. Idempotent and never throws, so it's safe on both the serve shutdown
- * path and the build drain path.
+ * Drain every queue resource: stop the listen loops, wait for in-flight jobs to
+ * settle, then close the backing stores. Idempotent and never throws, so it's
+ * safe on both the serve shutdown path and the build drain path.
  */
 export async function closeAllQueueResources(): Promise<void> {
-  const closeables = [...registry.closeables];
-  // Workers first so they stop pulling new jobs (and drain in-flight ones)
-  // before the queues backing them close out from under them.
-  await Promise.allSettled(closeables.filter((c) => c.kind === 'worker').map((c) => c.close()));
-  await Promise.allSettled(closeables.filter((c) => c.kind === 'queue').map((c) => c.close()));
-  // Embedded mode keeps a process-global manager (open SQLite handle + several
-  // un-unref'd background intervals). Closing individual handles doesn't touch
-  // it, so without this the SQLite file stays locked (Windows rm -> EBUSY) and
-  // the intervals keep the event loop alive (the process never exits). Sync and
-  // idempotent, so it's safe on the double-call path.
-  shutdownManager();
-  // The manager is gone, so the embedded store's first-path lock is released too;
-  // reset the remembered path so a fresh queue created afterwards starts clean
-  // rather than warning against a stale path. Clear the resources too so a fresh
-  // serve in this process (e.g. a test that restarts) can re-mount its queues.
+  const mounted = [...registry.mounted];
+  // Listen loops first so no new message is handed over, then the pools so running jobs settle — a retry re-enqueued
+  // mid-drain still finds its store open, since the stores close only after.
+  for (const m of mounted) {
+    m.controller.abort();
+  }
+  await Promise.allSettled(mounted.map((m) => m.listening));
+  await Promise.allSettled(mounted.map((m) => m.pool.drain()));
+  await closeBackendResources();
   registry.byName.clear();
-  registry.closeables.clear();
-  registry.dataPath = undefined;
+  registry.mounted.clear();
 }

--- a/packages/mochi/src/queue/backends.ts
+++ b/packages/mochi/src/queue/backends.ts
@@ -1,0 +1,158 @@
+import type { MessageQueue } from '@fedify/fedify';
+import type { Database } from 'bun:sqlite';
+import type { Sql } from 'postgres';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { pinGlobal } from '../utils/globalState';
+import { MemoryMessageQueue } from './memoryQueue';
+
+/**
+ * Where a queue's messages live. `'memory'` (the default) is in-process and lost on restart; `sqlite` / `postgres`
+ * persist through the fedify drivers; any object implementing fedify's `MessageQueue` (Redis, AMQP, a custom driver)
+ * plugs in directly. The `fedify` object is the escape hatch: it is spread verbatim over the options Mochi passes to
+ * the driver constructor, so any `SqliteMessageQueueOptions` / `PostgresMessageQueueOptions` field can be overridden.
+ */
+export type MochiQueueBackend = 'memory' | { sqlite: string; fedify?: Record<string, unknown> } | { postgres: string; fedify?: Record<string, unknown> } | MessageQueue;
+
+interface BackendRegistry {
+  /** Shared `bun:sqlite` handles keyed by resolved db path — one file can back many queues (one table each). */
+  sqliteDbs: Map<string, Database>;
+  /** Shared postgres.js clients keyed by connection URL. */
+  postgresSql: Map<string, Sql>;
+  /** Sanitized table name → queue name, to reject two queue names that collapse to the same table. */
+  tableNames: Map<string, string>;
+  /** User-provided raw instances; a second queue on the same instance would steal its sibling's messages. */
+  rawInstances: Set<MessageQueue>;
+  memoryQueues: Set<MemoryMessageQueue>;
+}
+
+// Pinned for the same reason as the queue registry: shutdown must find every handle whichever bundled copy created it.
+const backendRegistry = pinGlobal<BackendRegistry>('__mochi_queue_backends__', () => ({
+  sqliteDbs: new Map(),
+  postgresSql: new Map(),
+  tableNames: new Map(),
+  rawInstances: new Set(),
+  memoryQueues: new Set(),
+}));
+
+function isMessageQueueInstance(value: unknown): value is MessageQueue {
+  return typeof value === 'object' && value !== null && typeof (value as MessageQueue).enqueue === 'function' && typeof (value as MessageQueue).listen === 'function';
+}
+
+function tableNameFor(queueName: string): string {
+  const tableName = `mochi_queue_${queueName.replace(/[^A-Za-z0-9_]/g, '_')}`;
+  const prior = backendRegistry.tableNames.get(tableName);
+  if (prior !== undefined && prior !== queueName) {
+    throw new Error(`Queue "${queueName}" and queue "${prior}" both map to backend table "${tableName}". Rename one so the sanitized names (letters, digits, underscores) differ.`);
+  }
+  backendRegistry.tableNames.set(tableName, queueName);
+  return tableName;
+}
+
+export interface ResolvedBackend {
+  queue: MessageQueue;
+}
+
+/**
+ * Resolve a `MochiQueueBackend` to a live fedify `MessageQueue` for one named queue. Driver packages are imported
+ * lazily so an app that never touches sqlite/postgres pays nothing for them. Store DDL runs here (`initialize()`)
+ * so a bad path or unreachable database fails the mount, not the first job — postgres.js in particular never opens a
+ * connection until the first query.
+ */
+export async function resolveBackend(queueName: string, backend: MochiQueueBackend | undefined): Promise<ResolvedBackend> {
+  if (backend === undefined || backend === 'memory') {
+    const queue = new MemoryMessageQueue();
+    backendRegistry.memoryQueues.add(queue);
+    return { queue };
+  }
+
+  if (isMessageQueueInstance(backend)) {
+    if (backendRegistry.rawInstances.has(backend)) {
+      throw new Error(
+        `Queue "${queueName}": this MessageQueue instance already backs another queue. A raw instance supports a single listener — construct one instance per queue.`,
+      );
+    }
+    backendRegistry.rawInstances.add(backend);
+    return { queue: backend };
+  }
+
+  if ('sqlite' in backend) {
+    const [{ SqliteMessageQueue }, { Database: SqliteDatabase }] = await Promise.all([import('@fedify/sqlite'), import('bun:sqlite')]);
+    const dbPath = path.resolve(backend.sqlite);
+    let db = backendRegistry.sqliteDbs.get(dbPath);
+    if (!db) {
+      mkdirSync(path.dirname(dbPath), { recursive: true });
+      db = new SqliteDatabase(dbPath);
+      backendRegistry.sqliteDbs.set(dbPath, db);
+    }
+    // tsc resolves the driver's `#sqlite` import map to the node:sqlite types (the "bun" condition only applies at
+    // runtime, where it takes a bun:sqlite Database — verified empirically), hence the cast.
+    const platformDb = db as unknown as ConstructorParameters<typeof SqliteMessageQueue>[0];
+    // The driver's 5s pollInterval default is tuned for federation traffic; 500ms keeps local jobs snappy.
+    const queue = new SqliteMessageQueue(platformDb, {
+      tableName: tableNameFor(queueName),
+      pollInterval: { milliseconds: 500 },
+      ...backend.fedify,
+    });
+    if (backend.fedify?.initialized !== true) {
+      queue.initialize();
+    }
+    return { queue };
+  }
+
+  if ('postgres' in backend) {
+    const [{ PostgresMessageQueue }, { default: postgres }] = await Promise.all([import('@fedify/postgres'), import('postgres')]);
+    let sql = backendRegistry.postgresSql.get(backend.postgres);
+    if (!sql) {
+      sql = postgres(backend.postgres);
+      backendRegistry.postgresSql.set(backend.postgres, sql);
+    }
+    const tableName = tableNameFor(queueName);
+    // Per-queue channel: the driver default is one shared NOTIFY channel, which would wake every queue on any enqueue.
+    const queue = new PostgresMessageQueue(sql, {
+      tableName,
+      channelName: `${tableName}_channel`,
+      ...backend.fedify,
+    } as ConstructorParameters<typeof PostgresMessageQueue>[1]);
+    if (backend.fedify?.initialized !== true) {
+      await queue.initialize();
+    }
+    return { queue };
+  }
+
+  throw new Error(`Queue "${queueName}": unrecognized backend ${JSON.stringify(backend)}. Use 'memory', { sqlite: path }, { postgres: url }, or a MessageQueue instance.`);
+}
+
+/**
+ * Close every backend resource Mochi itself opened — memory queues (their delay timers hold the process open), shared
+ * sqlite handles, shared postgres clients — and reset the maps so a fresh mount in this process starts clean.
+ * User-provided raw `MessageQueue` instances are deliberately not closed: Mochi didn't open them.
+ */
+export async function closeBackendResources(): Promise<void> {
+  for (const queue of backendRegistry.memoryQueues) {
+    queue.close();
+  }
+  const sqliteDbs = [...backendRegistry.sqliteDbs.values()];
+  if (sqliteDbs.length > 0) {
+    // The sqlite driver's enqueue notification spawns fire-and-forget polls that the awaited listen() promise does not
+    // cover, and its SQLITE_BUSY retry ladder can keep one asleep for ~3.1s; closing the handle under such a straggler
+    // throws an uncatchable rejection. Close only after the ladder has fully run out — unref'd, so process exit is
+    // never held up (the OS reclaims the handle at exit anyway, and WAL recovers on the next open).
+    const close = setTimeout(() => {
+      for (const db of sqliteDbs) {
+        try {
+          db.close();
+        } catch {
+          // Already closed; shutdown must not throw.
+        }
+      }
+    }, 4000);
+    close.unref?.();
+  }
+  await Promise.allSettled([...backendRegistry.postgresSql.values()].map((sql) => sql.end({ timeout: 5 })));
+  backendRegistry.memoryQueues.clear();
+  backendRegistry.sqliteDbs.clear();
+  backendRegistry.postgresSql.clear();
+  backendRegistry.tableNames.clear();
+  backendRegistry.rawInstances.clear();
+}

--- a/packages/mochi/src/queue/memoryQueue.ts
+++ b/packages/mochi/src/queue/memoryQueue.ts
@@ -1,0 +1,90 @@
+import type { MessageQueue, MessageQueueDepth, MessageQueueEnqueueOptions, MessageQueueListenOptions } from '@fedify/fedify';
+
+// `delay` is typed as Temporal.Duration but duck-typed here (like the fedify drivers do), so any polyfill copy works.
+function delayToMs(delay: MessageQueueEnqueueOptions['delay']): number {
+  if (!delay) {
+    return 0;
+  }
+  if (typeof (delay as { total?: unknown }).total === 'function') {
+    return (delay as { total: (opts: { unit: string }) => number }).total({ unit: 'milliseconds' });
+  }
+  return Number((delay as { milliseconds?: number }).milliseconds ?? 0);
+}
+
+/**
+ * The default queue backend: a fedify-compatible in-process `MessageQueue` with no persistence. Kept in-house rather
+ * than using fedify's `InProcessMessageQueue` because importing that from `@fedify/fedify` drags the entire ActivityPub
+ * runtime into the process; the drivers' `@fedify/fedify` peer stays type-only this way.
+ */
+export class MemoryMessageQueue implements MessageQueue {
+  readonly nativeRetrial = false;
+
+  private readonly ready: unknown[] = [];
+  private readonly timers = new Set<ReturnType<typeof setTimeout>>();
+  private delayedCount = 0;
+  private wake: (() => void) | null = null;
+  private closed = false;
+
+  async enqueue(message: unknown, options?: MessageQueueEnqueueOptions): Promise<void> {
+    if (this.closed) {
+      throw new Error('MemoryMessageQueue is closed.');
+    }
+    const ms = delayToMs(options?.delay);
+    if (ms > 0) {
+      this.delayedCount++;
+      const timer = setTimeout(() => {
+        this.timers.delete(timer);
+        this.delayedCount--;
+        this.push(message);
+      }, ms);
+      this.timers.add(timer);
+      return;
+    }
+    this.push(message);
+  }
+
+  async enqueueMany(messages: readonly unknown[], options?: MessageQueueEnqueueOptions): Promise<void> {
+    for (const message of messages) {
+      await this.enqueue(message, options);
+    }
+  }
+
+  private push(message: unknown): void {
+    if (this.closed) {
+      return;
+    }
+    this.ready.push(message);
+    this.wake?.();
+  }
+
+  async getDepth(): Promise<MessageQueueDepth> {
+    return { queued: this.ready.length + this.delayedCount, ready: this.ready.length, delayed: this.delayedCount };
+  }
+
+  async listen(handler: (message: unknown) => Promise<void> | void, options: MessageQueueListenOptions = {}): Promise<void> {
+    const { signal } = options;
+    while (!signal?.aborted && !this.closed) {
+      if (this.ready.length > 0) {
+        await handler(this.ready.shift());
+        continue;
+      }
+      await new Promise<void>((resolve) => {
+        this.wake = resolve;
+        signal?.addEventListener('abort', () => resolve(), { once: true });
+      });
+      this.wake = null;
+    }
+  }
+
+  /** Clears pending delay timers (which are ref'd and would otherwise hold the process open) and wakes the listen loop. */
+  close(): void {
+    this.closed = true;
+    for (const timer of this.timers) {
+      clearTimeout(timer);
+    }
+    this.timers.clear();
+    this.delayedCount = 0;
+    this.ready.length = 0;
+    this.wake?.();
+  }
+}

--- a/packages/mochi/src/queue/workerPool.ts
+++ b/packages/mochi/src/queue/workerPool.ts
@@ -1,0 +1,30 @@
+/**
+ * Concurrency gate for a queue's handler invocations, mirroring fedify's `ParallelMessageQueue` semantics: `run()`
+ * resolves once the task has *started* (not finished), so the driver's listen loop can fetch the next message while up
+ * to `limit` jobs are in flight, and blocks (back-pressure) once the cap is reached.
+ */
+export class WorkerPool {
+  private active = 0;
+  private readonly waiters: Array<() => void> = [];
+  private readonly inFlight = new Set<Promise<void>>();
+
+  constructor(private readonly limit: number) {}
+
+  async run(task: () => Promise<void>): Promise<void> {
+    while (this.active >= this.limit) {
+      await new Promise<void>((resolve) => this.waiters.push(resolve));
+    }
+    this.active++;
+    const job = task().finally(() => {
+      this.active--;
+      this.inFlight.delete(job);
+      this.waiters.shift()?.();
+    });
+    this.inFlight.add(job);
+  }
+
+  /** Await every in-flight job; used by shutdown so stores close only after running handlers settle. */
+  async drain(): Promise<void> {
+    await Promise.allSettled([...this.inFlight]);
+  }
+}

--- a/packages/mochi/src/queuePostgres.test.ts
+++ b/packages/mochi/src/queuePostgres.test.ts
@@ -1,0 +1,155 @@
+import { afterAll, afterEach, beforeAll, describe, expect, test } from 'bun:test';
+import { createQueue, closeAllQueueResources } from './queue';
+import type { MochiJob, MochiQueueBackend } from './queue';
+import type { MochiQueueFailedEvent } from './events';
+import { mochiEvents } from './events';
+import { resetStartupMilestones } from './lifecycle';
+import { startTestPostgres } from './__fixtures__/postgres/startTestPostgres';
+import type { TestPostgres } from './__fixtures__/postgres/startTestPostgres';
+
+// End-to-end coverage of the postgres queue backend against the in-process PGlite fixture (real wire protocol, no
+// external service). Set MOCHI_TEST_PG_URL=postgresql://user:pass@host:5432/db to run against a real server instead.
+// Note PGlite's socket bridge multiplexes one session, so NOTIFY push never reaches the listener — delivery rides the
+// driver's polling, which is the path these tests exercise (hence the short pollInterval).
+const REAL_PG_URL = process.env.MOCHI_TEST_PG_URL;
+
+let fixture: TestPostgres | null = null;
+let pgUrl: string;
+
+// PGlite's WASM boot can take ~10s on slow machines — well past the default hook budget.
+beforeAll(async () => {
+  if (REAL_PG_URL) {
+    pgUrl = REAL_PG_URL;
+    return;
+  }
+  fixture = await startTestPostgres();
+  pgUrl = fixture.url;
+}, 60_000);
+
+afterAll(async () => {
+  await fixture?.close();
+}, 20_000);
+
+let counter = 0;
+const uniqueName = (): string => `pg_q_${counter++}`;
+
+const backend = (): MochiQueueBackend => ({ postgres: pgUrl, fedify: { pollInterval: { milliseconds: 100 } } });
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+afterEach(async () => {
+  mochiEvents.all.clear();
+  resetStartupMilestones();
+  await closeAllQueueResources();
+}, 20_000);
+
+describe('Mochi queue (postgres)', () => {
+  test('roundtrips a job from producer to consumer', async () => {
+    const name = uniqueName();
+    const seen = deferred<MochiJob<{ to: string }>>();
+
+    const queue = await createQueue<{ to: string }>(
+      name,
+      async (job) => {
+        seen.resolve(job);
+        return { sent: true };
+      },
+      { backend: backend() },
+    );
+
+    const ref = await queue.add('send', { to: 'alice@example.com' });
+    const job = await seen.promise;
+    expect(job.data).toEqual({ to: 'alice@example.com' });
+    expect(job.id).toBe(ref.id);
+    expect(job.attempt).toBe(1);
+  }, 15_000);
+
+  test('retries a failing job with willRetry flags', async () => {
+    const name = uniqueName();
+    const failures: MochiQueueFailedEvent[] = [];
+    const exhausted = deferred<void>();
+
+    mochiEvents.on('queue:failed', (e) => {
+      failures.push(e);
+      if (!e.willRetry) {
+        exhausted.resolve();
+      }
+    });
+
+    const queue = await createQueue<{ n: number }>(
+      name,
+      async (job) => {
+        throw new Error(`fail #${job.attempt}`);
+      },
+      { backend: backend(), backoff: { type: 'fixed', delay: 10 } },
+    );
+
+    await queue.add('retry-me', { n: 1 }, { attempts: 2 });
+    await exhausted.promise;
+    expect(failures.map((f) => f.attempt)).toEqual([1, 2]);
+    expect(failures.map((f) => f.willRetry)).toEqual([true, false]);
+  }, 20_000);
+
+  test('depth() reports waiting messages', async () => {
+    const name = uniqueName();
+    const queue = await createQueue(name, async () => null, { backend: backend() });
+
+    await queue.add('someday', { v: 1 }, { delay: 60_000 });
+
+    const depth = await queue.depth();
+    expect(depth).toBeDefined();
+    expect(depth!.queued).toBe(1);
+    expect(depth!.delayed).toBe(1);
+  }, 15_000);
+
+  test('a persisted job survives a close and remount', async () => {
+    const name = uniqueName();
+
+    const before = await createQueue(name, async () => null, { backend: backend() });
+    // Far enough out that the first mount cannot deliver it before we close.
+    await before.add('survivor', { v: 1 }, { delay: 1500 });
+    await closeAllQueueResources();
+
+    const seen = deferred<MochiJob<unknown>>();
+    await createQueue(
+      name,
+      async (job) => {
+        seen.resolve(job);
+      },
+      { backend: backend() },
+    );
+
+    const job = await seen.promise;
+    expect(job.name).toBe('survivor');
+    expect(job.data).toEqual({ v: 1 });
+  }, 20_000);
+
+  test('closeAllQueueResources drains and closes the shared client', async () => {
+    const name = uniqueName();
+    const started = deferred<void>();
+    let finished = false;
+
+    const queue = await createQueue(
+      name,
+      async () => {
+        started.resolve();
+        await Bun.sleep(120);
+        finished = true;
+      },
+      { backend: backend() },
+    );
+
+    await queue.add('slow', { v: 1 });
+    await started.promise;
+    await closeAllQueueResources();
+    expect(finished).toBe(true);
+    // A second close is a no-op even though the sql client is already ended.
+    await closeAllQueueResources();
+  }, 20_000);
+});

--- a/packages/mochi/src/runtime/rateLimit.postgres.integration.test.ts
+++ b/packages/mochi/src/runtime/rateLimit.postgres.integration.test.ts
@@ -31,14 +31,15 @@ describe('rateLimit postgresStore backend', () => {
       },
     });
     base = `http://localhost:${server.port}`;
-  });
+    // PGlite's WASM boot can take ~10s on slow machines — well past the default hook budget.
+  }, 60_000);
 
   afterAll(async () => {
-    server.stop(true);
-    await store.shutdown?.();
-    await pg.close();
+    server?.stop(true);
+    await store?.shutdown?.();
+    await pg?.close();
     rmSync(outDir, { recursive: true, force: true });
-  });
+  }, 20_000);
 
   test('blocks with 429 once the limit is exhausted', async () => {
     expect((await fetch(`${base}/api/limited`)).status).toBe(200);

--- a/packages/mochi/src/serveQueues.test.ts
+++ b/packages/mochi/src/serveQueues.test.ts
@@ -29,8 +29,8 @@ describe('Mochi.queue descriptor', () => {
     const completed = (): void => {};
     const recover = (): void => {};
     const config = Mochi.queue({ process: async () => null, concurrency: 1, on: { completed }, recover });
-    // Anything left in `options` is forwarded verbatim to bunqueue, so these
-    // three must not leak through.
+    // Anything left in `options` is the runtime options handed to createQueue at
+    // mount, so these three must not leak through.
     expect(config.options).toEqual({ concurrency: 1 });
     expect(config.on?.completed).toBe(completed);
     expect(config.recover).toBe(recover);

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -7,7 +7,7 @@ import type { MochiProxyOptions } from './runtime/proxy';
 import type { LocalImageAsset, MochiImageOptions } from './image/types';
 import type { MochiEmailOptions } from './email/types';
 import type { MochiCaptchaOptions } from './captcha/types';
-import type { MochiProcessor, MochiQueue, MochiQueueListeners, MochiQueueRuntimeOptions } from './queue';
+import type { MochiProcessor, MochiQueue, MochiQueueBackend, MochiQueueListeners, MochiQueueRuntimeOptions } from './queue';
 import type { MochiRateLimitOptions } from './runtime/rateLimit';
 import type { MochiSvelteCompiler } from './compiler/svelteCompilerBackend';
 
@@ -419,6 +419,11 @@ export interface MochiServeOptions {
    * Add jobs from route code via `Mochi.getQueue(name).add(...)`. Queues drain gracefully on shutdown.
    */
   queues?: Record<string, MochiQueueConfig>;
+  /**
+   * Default backend for every queue in `queues` — `'memory'` (default), `{ sqlite: path }`, `{ postgres: url }`, or a
+   * fedify `MessageQueue` instance. A queue's own `backend` option overrides it.
+   */
+  queueBackend?: MochiQueueBackend;
   fetch?: (req: Request, server: Server<undefined>) => Response | Promise<Response>;
   htmlShell?: string;
   /**

--- a/packages/msgpackr-extract-stub/README.md
+++ b/packages/msgpackr-extract-stub/README.md
@@ -1,5 +1,11 @@
 # @mochi-framework/msgpackr-extract-stub
 
+> **Historical.** `mochi-framework` no longer depends on `msgpackr` (its queue
+> moved from bunqueue to fedify `MessageQueue` backends), so current versions of
+> the framework and the `create-mochi` templates ship without this override.
+> The package stays published so projects scaffolded by older `create-mochi`
+> versions keep installing cleanly.
+
 This is **not** the real [`msgpackr-extract`](https://www.npmjs.com/package/msgpackr-extract).
 It's an empty stub meant to be substituted for it via a `package.json`
 `overrides` field:
@@ -8,8 +14,8 @@ It's an empty stub meant to be substituted for it via a `package.json`
 "overrides": { "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@^0.0.1" }
 ```
 
-`msgpackr` (pulled in transitively by `bunqueue`) lists `msgpackr-extract` as an
-**optional** dependency — a native C++ accelerator that also drags in
+`msgpackr` (formerly pulled in transitively by `bunqueue`) lists `msgpackr-extract`
+as an **optional** dependency — a native C++ accelerator that also drags in
 platform-specific `@msgpackr-extract/*` prebuilt binaries. We don't want those
 binaries in the install, so we replace the package with this stub.
 

--- a/packages/site/src/demos/queue/queue.server.ts
+++ b/packages/site/src/demos/queue/queue.server.ts
@@ -22,7 +22,7 @@ const settle = (e: { queue: string }) => {
 mochiEvents.on('queue:completed', settle);
 mochiEvents.on('queue:failed', settle);
 
-// In-memory so the demo writes no SQLite file into the site working dir; pass `dataPath` to persist.
+// In-memory so the demo writes no SQLite file into the site working dir; pass `backend: { sqlite: '.mochi/queue.sqlite' }` to persist.
 export const notificationQueue: MochiQueueConfig = Mochi.queue<NotificationJob>({
   concurrency: 2,
   process: async (job) => {

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -24,8 +24,5 @@
     "@types/bun": "1.3.14",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
-  },
-  "overrides": {
-    "msgpackr-extract": "npm:@mochi-framework/msgpackr-extract-stub@*"
   }
 }

--- a/packages/support/src/db.server.ts
+++ b/packages/support/src/db.server.ts
@@ -96,7 +96,7 @@ export function markEmailSent(id: number): void {
   sentStmt.run(Date.now(), id);
 }
 
-// Terminal: bunqueue has exhausted its attempts and won't retry on its own.
+// Terminal: the queue has exhausted its attempts and won't retry on its own.
 export function markEmailFailed(id: number, error: string): void {
   failedStmt.run(error.slice(0, 1000), id);
 }

--- a/packages/support/src/jobs.server.ts
+++ b/packages/support/src/jobs.server.ts
@@ -7,7 +7,7 @@ export const SUPPORT_TO = process.env.SUPPORT_TO || 'support@mochi.fast';
 export const SUPPORT_EMAIL_QUEUE = 'support-emails';
 
 // Shared by defaultJobOptions and the processor, which needs to know whether the
-// attempt it is failing is the last one bunqueue will make.
+// attempt it is failing is the last one the queue will make.
 const MAX_ATTEMPTS = 3;
 
 export interface SupportEmailJob {
@@ -19,7 +19,7 @@ export interface SupportEmailJob {
 export const supportEmailQueue: MochiQueueConfig = Mochi.queue<SupportEmailJob>({
   concurrency: 2,
   defaultJobOptions: { attempts: MAX_ATTEMPTS },
-  bunqueue: { backoff: { type: 'exponential', delay: 5000 } },
+  backoff: { type: 'exponential', delay: 5000 },
   recover: async (queue) => {
     const stranded = undeliveredSubmissionIds();
     if (stranded.length === 0) {
@@ -52,7 +52,7 @@ export const supportEmailQueue: MochiQueueConfig = Mochi.queue<SupportEmailJob>(
         text: [`From: ${name || '(no name)'} <${email}>`, '', message].join('\n'),
       });
     } catch (err) {
-      // Recorded before rethrowing so the admin panel shows why while bunqueue retries — only the last attempt is terminal, so a restart mid-backoff leaves the row for `recover` instead of stranding it as `failed`.
+      // Recorded before rethrowing so the admin panel shows why while the queue retries — only the last attempt is terminal, so a restart mid-backoff leaves the row for `recover` instead of stranding it as `failed`.
       const reason = err instanceof Error ? err.message : String(err);
       if (job.attempt >= MAX_ATTEMPTS) {
         markEmailFailed(submission.id, reason);

--- a/packages/support/src/recover.test.ts
+++ b/packages/support/src/recover.test.ts
@@ -105,7 +105,7 @@ test('recovery logs a `requeued` entry for each row it puts back', () => {
   expect(events[0]).toBe('requeued');
 });
 
-test('a failing attempt that bunqueue will retry leaves the row recoverable', async () => {
+test('a failing attempt that the queue will retry leaves the row recoverable', async () => {
   // Mid-backoff the row must stay `pending`: marking it `failed` here is what
   // used to drop it out of the set recover() re-enqueues.
   await waitFor(() => (emailLogsBySubmission()[stranded.poisoned] ?? []).some((e) => e.event === 'failed'));


### PR DESCRIPTION
## What

Replaces the queue transport (bunqueue embedded mode) with the [fedify `MessageQueue`](https://fedify.dev/manual/mq) model, giving `Mochi.queue()` three backends — **memory** (default), **SQLite**, **PostgreSQL** — plus a bring-your-own-driver escape hatch. Retry, backoff, concurrency, and the `queue:*` events stay in Mochi's own worker layer; the fedify drivers are pure transports and never see a failure.

## API

```ts
await Mochi.serve({
  queueBackend: { sqlite: '.mochi/queue.sqlite' }, // server-wide default
  queues: {
    emails: Mochi.queue({ process: sendEmail, backoff: { type: 'exponential', delay: 5000 } }),
    critical: Mochi.queue({ process: charge, backend: { postgres: process.env.DATABASE_URL } }),
  },
});
```

- **Backends**: `'memory'` · `{ sqlite: path }` · `{ postgres: url }` · any fedify `MessageQueue` instance (Redis/AMQP/custom). `fedify: {...}` is the catch-all — forwarded verbatim to the driver constructor (replaces the old raw `bunqueue` passthrough). Serve-level `queueBackend` sets the default; per-queue `backend` overrides.
- **New capabilities**: per-job `delay` and `orderingKey`, `queue.depth()`, and a `willRetry` flag on `queue:failed`. Backoff (`fixed`/`exponential` + `maxDelay`) is now a first-class option.
- **Internals** (`packages/mochi/src/queue/`): `memoryQueue.ts` (in-house fedify-compatible default — we never runtime-import `@fedify/fedify`, whose `InProcessMessageQueue` would drag in the whole ActivityPub runtime), `backends.ts` (lazy driver imports, refcounted shared handles, one driver/table per named queue), `workerPool.ts` (concurrency gate mirroring `ParallelMessageQueue`).

## Testing

- `queue.test.ts` rewritten, parameterized over memory + sqlite (roundtrip, addBulk, concurrency, all five events, retry-with-backoff asserting `willRetry`, delay, ordering, `depth()`, drain-on-close, sqlite persistence across remount).
- **`queuePostgres.test.ts` — real end-to-end postgres coverage**, running unconditionally on the PR #242 PGlite fixture (no Docker, no env var; `MOCHI_TEST_PG_URL` overrides to a real server). Needed two fixture fixes: `maxConnections: 16` so the driver's dedicated LISTEN socket coexists with postgres.js's pooled query connections, and explicit `beforeAll` hook timeouts for PGlite's ~10s WASM boot (this also fixes PR #242's own rate-limit integration test, which was timing out on slow runners).
- `packages/support` migrated (bunqueue backoff passthrough → first-class `backoff`); memory backend + `recover` unchanged.
- msgpackr-extract override removed from all package.jsons (bunqueue was its only source); the stub package stays published for older scaffolds.

## Breaking changes

- **Delivery is now at-most-once** — sqlite/postgres remove the message before the handler runs; no lock-based stalled-job reclaim. `recover` is the sanctioned durability story (documented with a danger callout).
- Removed: `priority`, `jobId`, `lockDuration`, `dataPath` options; the raw `bunqueue` passthrough; the `queue:lockDurationMs` filter; the `DEFAULT_LOCK_DURATION_MS` export.

## Verification

`bun run checks` green (lint + format + typecheck + test across all workspaces); browser smoke of the queue demo; cross-process sqlite persistence confirmed manually.

Docs: `packages/docs/115-queues.md` rewritten; `queue:lockDurationMs` section removed from `162-extensions.md`.
