### PR TITLE
test(mochi): tighten assertions and fix isolation issues found by mutation audit

### DIFF
--- a/packages/mochi/src/apiEvent.test.ts
+++ b/packages/mochi/src/apiEvent.test.ts
@@ -52,9 +52,11 @@ describe('Mochi.api event surface', () => {
       headers: { cookie: 'session=tok' },
     });
     expect(res.status).toBe(200);
-    const body = (await res.json()) as { session: string | null };
+    const body = (await res.json()) as { method: string; session: string | null };
+    expect(body.method).toBe('GET');
     expect(body.session).toBe('tok');
     const setCookie = res.headers.get('set-cookie') ?? '';
-    expect(setCookie).toContain('seen=42');
+    expect(setCookie).toMatch(/^seen=42; /);
+    expect(setCookie).toContain('Path=/');
   });
 });

--- a/packages/mochi/src/cache/cache-storage-file.test.ts
+++ b/packages/mochi/src/cache/cache-storage-file.test.ts
@@ -79,7 +79,7 @@ describe('FileStorage', () => {
     const file = readdirSync(dir).find((n) => n.endsWith('.json'));
     expect(file).toBeDefined();
     await Bun.write(join(dir, file!), '{ not json');
-    await expect(storage.getItem('k')).rejects.toBeDefined();
+    await expect(storage.getItem('k')).rejects.toThrow(SyntaxError);
 
     // Wired through MochiCache, a read error degrades to a `miss` + recompute.
     const cache = new MochiCache({ storage });

--- a/packages/mochi/src/cache/cache.test.ts
+++ b/packages/mochi/src/cache/cache.test.ts
@@ -155,7 +155,8 @@ describe('MochiCache events', () => {
     await cache.fetch('k', async () => ++calls);
     await wait(20);
 
-    expect(seen).toContain('k');
+    // Exactly one emission for the single stale read.
+    expect(seen).toEqual(['k']);
   });
 });
 
@@ -229,8 +230,27 @@ describe('MochiCache.set', () => {
   });
 
   test('never leaves the key absent, unlike delete + fetch', async () => {
-    const cache = new MochiCache({ minTimeToStale: 1_000, maxTimeToLive: 5_000 });
-    await cache.set('k', 'v1');
+    // An async backend with a gap before each write, so a non-atomic (remove-then-write) set would expose a null window.
+    const store = new Map<string, unknown>();
+    const storage: Storage = {
+      async getItem(key) {
+        await wait(1);
+        return store.get(key) ?? null;
+      },
+      async setItem(key, value) {
+        await wait(1);
+        store.set(key, value);
+      },
+      async removeItem(key) {
+        await wait(1);
+        store.delete(key);
+      },
+      async clear() {
+        store.clear();
+      },
+    };
+    const cache = new MochiCache({ storage, minTimeToStale: 1_000, maxTimeToLive: 5_000 });
+    await cache.set('k', 'v0');
 
     let sawMiss = false;
     let stop = false;
@@ -239,16 +259,33 @@ describe('MochiCache.set', () => {
         if ((await cache.peek('k')) === null) {
           sawMiss = true;
         }
-        await Promise.resolve();
       }
     })();
-    for (let i = 0; i < 50; i++) {
+    for (let i = 1; i <= 20; i++) {
       await cache.set('k', `v${i}`);
     }
     stop = true;
     await reader;
-
     expect(sawMiss).toBe(false);
+
+    // The contrast: delete + fetch leaves the key absent long enough for a concurrent reader to observe a miss.
+    let sawMissDuringReplace = false;
+    let replaceDone = false;
+    const probe = (async () => {
+      while (!replaceDone) {
+        if ((await cache.peek('k')) === null) {
+          sawMissDuringReplace = true;
+        }
+      }
+    })();
+    await cache.delete('k');
+    await cache.fetch('k', async () => {
+      await wait(10);
+      return 'replaced';
+    });
+    replaceDone = true;
+    await probe;
+    expect(sawMissDuringReplace).toBe(true);
   });
 
   test('supersedes a registered in-flight recompute rather than being clobbered by it', async () => {

--- a/packages/mochi/src/captcha/captcha.test.ts
+++ b/packages/mochi/src/captcha/captcha.test.ts
@@ -2,13 +2,13 @@ import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { createHash } from 'node:crypto';
 import { mintCaptcha, verifyCaptcha, consumeCaptcha, solveCaptcha } from './captcha';
 import { CAPTCHA_STEPS, chainInput, powInput, leadingZeroBits, sha256Hex, solvePowSlice } from './pow';
-import { DEFAULT_CAPTCHA_BITS } from './config';
+import { DEFAULT_CAPTCHA_BITS, DEFAULT_CAPTCHA_DRIFT_ALLOWANCE_MS } from './config';
 import { DEFAULT_CAPTCHA_SOLVE_BUDGET_MS } from './pow';
 import { encryptPayload, decryptPayload } from '../islands/payloadCrypto';
 import { initExtensions } from '../extensions';
 import { mochiEvents } from '../events';
 import type { MochiCaptchaVerifyEvent } from '../events';
-import type { MochiCaptchaOptions } from './types';
+import type { CaptchaResult, MochiCaptchaOptions } from './types';
 
 const GLOBAL_CONFIG_KEY = '__mochi_config__';
 const GLOBAL_RUNTIME_KEY = '__mochi_captcha_runtime__';
@@ -259,7 +259,7 @@ describe('clock-drift allowance', () => {
     const out = { iat: 0 };
     const first = await verifyAged(10_000, out);
     expect(first.ok).toBe(true);
-    expect(first.ok && first.expiresAt).toBe(out.iat + 1000 + 30_000);
+    expect(first.ok && first.expiresAt).toBe(out.iat + 1000 + DEFAULT_CAPTCHA_DRIFT_ALLOWANCE_MS);
     expect(first.ok && first.expiresAt > Date.now()).toBe(true);
     expect((await verifyAged(10_000, out)).ok).toBe(true); // different nonce, unaffected
 
@@ -406,15 +406,17 @@ describe('failure reason', () => {
     const solved = solveCaptcha(mintCaptcha());
     await verifyCaptcha(fields(solved));
     const replayed = await verifyCaptcha(fields(solved));
+    const rejected = await verifyCaptcha(fields({ captcha_token: 'nope', captcha_pow: '1' }));
 
-    expect(replayed.ok).toBe(false);
-    if (replayed.ok) {
+    expect(replayed).toMatchObject({ ok: false, reason: 'replay' });
+    expect(rejected).toMatchObject({ ok: false, reason: 'rejected' });
+    if (replayed.ok || rejected.ok) {
       return;
     }
-    expect(replayed.reason).toBe('replay');
-    // The shape an app's action branches on.
-    const message = replayed.reason === 'replay' ? 'Already sent — grab a fresh form.' : replayed.error;
-    expect(message).toBe('Already sent — grab a fresh form.');
+    // The mapping an app's action branches on — both arms must be reachable.
+    const message = (r: Extract<CaptchaResult, { ok: false }>) => (r.reason === 'replay' ? 'Already sent — grab a fresh form.' : r.error);
+    expect(message(replayed)).toBe('Already sent — grab a fresh form.');
+    expect(message(rejected)).toBe('Verification failed — reload the page and try again.');
   });
 });
 

--- a/packages/mochi/src/cli/buildForwardsErrorPage.test.ts
+++ b/packages/mochi/src/cli/buildForwardsErrorPage.test.ts
@@ -47,14 +47,15 @@ describe('mochi-framework build forwards errorPage off the entry (subprocess)', 
   });
 
   test('the build succeeds', () => {
-    expect(result.exitCode).toBe(0);
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
     // Deliberately not an empty-stderr assertion: an unrelated toolchain
     // warning there says nothing about this build.
     expect(result.stderr).not.toContain('error');
   });
 
   test('the custom error page is in the manifest, not the built-in one', () => {
-    // Reports the failed build rather than throwing on `Object.keys(undefined)`.
+    // Reports the failed build (with its stderr) rather than throwing on `Object.keys(undefined)`.
+    expect(result.exitCode, result.stderr || result.stdout).toBe(0);
     expect(manifest).toBeDefined();
     const components = Object.keys(manifest.components);
     expect(components).toContain('src/Oops.svelte');

--- a/packages/mochi/src/cli/checkEnvironment.test.ts
+++ b/packages/mochi/src/cli/checkEnvironment.test.ts
@@ -22,4 +22,6 @@ test('compareVersions handles equal, higher, lower, and prerelease suffixes', ()
   expect(compareVersions('5.56.0', '5.55.1')).toBe(true);
   expect(compareVersions('5.54.9', '5.55.1')).toBe(false);
   expect(compareVersions('1.3.14-canary.5', '1.3.14')).toBe(true);
+  expect(compareVersions('1.3.15-canary.1', '1.3.14')).toBe(true);
+  expect(compareVersions('1.3.13-canary.9', '1.3.14')).toBe(false);
 });

--- a/packages/mochi/src/cli/cli.test.ts
+++ b/packages/mochi/src/cli/cli.test.ts
@@ -104,6 +104,7 @@ describe('mochi-framework update-skill (subprocess)', () => {
 
       expect(exitCode).toBe(1);
       expect(stderr).toContain('HTTP 404');
+      expect(stderr).toContain('The hosted skill may not be published yet.');
       expect(existsSync(path.join(cwd, '.claude', 'skills', 'mochi', 'SKILL.md'))).toBe(false);
     } finally {
       server.stop(true);
@@ -131,7 +132,11 @@ describe('mochi-framework generate-key (subprocess)', () => {
     const exitCode = await proc.exited;
 
     expect(exitCode).toBe(0);
-    expect(await Bun.file(path.join(cwd, '.env')).text()).not.toContain('MOCHI_KEY=old');
+    const env = await Bun.file(path.join(cwd, '.env')).text();
+    expect(env).not.toContain('MOCHI_KEY=old');
+    const key = env.match(/^MOCHI_KEY=(.+)$/m)?.[1];
+    expect(key).toBeDefined();
+    expect(Buffer.from(key!, 'base64url').length).toBe(32);
   });
 
   it('lists generate-key in --help', async () => {

--- a/packages/mochi/src/compiler/cssImports.test.ts
+++ b/packages/mochi/src/compiler/cssImports.test.ts
@@ -63,8 +63,10 @@ describe('CSS imports — happy path', () => {
       getClientAddress: () => null,
     };
     const result = await requestContext.run(ctx, () => registry.renderComponent(FIXTURE_PAGE));
-    const importCssUrl = result.cssUrls.find((u) => u.includes('/import-css/styles-'));
-    expect(importCssUrl).toBeDefined();
+    const cssOutput = registry.getClientStats()?.outputs.find((o) => o.name.startsWith('styles-'));
+    expect(cssOutput).toBeDefined();
+    const importCssUrls = result.cssUrls.filter((u) => u.includes('/import-css/styles-'));
+    expect(importCssUrls).toEqual([`/_mochi/import-css/${cssOutput!.name}`]);
   });
 
   // Also the idempotence check for the source-path codec: a manifest that
@@ -127,12 +129,14 @@ describe('CSS imports — error path', () => {
   });
 
   test('a missing CSS import causes the SSR build to throw', async () => {
-    await expect(registry.compile(FIXTURE_MISSING_PAGE)).rejects.toThrow();
+    await expect(registry.compile(FIXTURE_MISSING_PAGE)).rejects.toThrow(/Could not resolve.*missing\.css/);
   });
 
   test('a bundle-failed CSS import is recorded as a css-bundle-failed error', async () => {
     await registry.compile(FIXTURE_BAD_CSS_PAGE);
     const cssErrors = registry.getErrors().filter((e) => e.kind === 'css-bundle-failed');
-    expect(cssErrors.length).toBeGreaterThan(0);
+    expect(cssErrors.length).toBe(1);
+    expect(cssErrors[0]!.cssPath).toContain('bad.css');
+    expect(cssErrors[0]!.message).toContain('nonexistent-bad-target.css');
   });
 });

--- a/packages/mochi/src/compiler/deferClientBundle.test.ts
+++ b/packages/mochi/src/compiler/deferClientBundle.test.ts
@@ -44,8 +44,8 @@ describe('compileAll({ deferClientBundle }) + finalizeClientBundle', () => {
     expect(registry.getIslandBootstrapUrl()).not.toBeNull();
     const stats = registry.getClientStats();
     const entryNames = (stats?.outputs ?? []).map((o) => o.name);
-    expect(entryNames.some((n) => n.includes('WidgetA'))).toBe(true);
-    expect(entryNames.some((n) => n.includes('WidgetB'))).toBe(true);
+    expect(entryNames.filter((n) => n.includes('WidgetA'))).toHaveLength(1);
+    expect(entryNames.filter((n) => n.includes('WidgetB'))).toHaveLength(1);
   });
 
   test('finalize with no hydratables is a no-op', async () => {

--- a/packages/mochi/src/compiler/imageAssetLoader.test.ts
+++ b/packages/mochi/src/compiler/imageAssetLoader.test.ts
@@ -6,7 +6,7 @@ import { createImageAssetLoader, IMAGE_FILE_FILTER } from './imageAssetLoader';
 import { getLocalImageAsset } from '../image/localAssetRegistry';
 import { toPosixPath } from '../utils';
 import { initExtensions } from '../extensions';
-import type { MochiHookContext } from '../extensions';
+import type { MochiFilterContext, MochiHookContext } from '../extensions';
 import type { LocalImageAsset } from '../image/types';
 
 const GLOBAL_KEY = '__mochi_local_image_assets__';
@@ -146,12 +146,12 @@ describe('image extension points', () => {
     const dir = mkdir();
     const outDir = mkdir();
     const fixture = writeFixture(dir, 'hero.png', PNG_40x30);
+    // Capture ctx and assert after the load, so a never-invoked filter fails loudly.
+    let seenCtx: MochiFilterContext['image:localAssetFilename'] | undefined;
     initExtensions({
       filters: {
         'image:localAssetFilename': (name, ctx) => {
-          expect(ctx.sourcePath).toBe(fixture);
-          expect(ctx.ext).toBe('png');
-          expect(ctx.format).toBe('png');
+          seenCtx = ctx;
           return `custom-${name}`;
         },
       },
@@ -160,6 +160,10 @@ describe('image extension points', () => {
     const loader = createImageAssetLoader({ outDir, assetPrefix: '/_mochi', assets });
     const obj = parseModule((await loader({ path: fixture })).contents);
 
+    expect(seenCtx).toBeDefined();
+    expect(seenCtx!.sourcePath).toBe(fixture);
+    expect(seenCtx!.ext).toBe('png');
+    expect(seenCtx!.format).toBe('png');
     expect(obj.src).toMatch(/^\/_mochi\/asset\/custom-hero-[a-z0-9]+\.png$/);
     const asset = assets.get(obj.src);
     expect(asset!.diskPath).toContain('/assets/custom-hero-');
@@ -181,11 +185,14 @@ describe('image extension points', () => {
     const dir = mkdir();
     const outDir = mkdir();
     const fixture = writeFixture(dir, 'hero.png', PNG_40x30);
+    // Capture url + ctx and assert after the load, so a never-invoked filter fails loudly.
+    let seenUrl: string | undefined;
+    let seenCtx: MochiFilterContext['image:localAssetUrl'] | undefined;
     initExtensions({
       filters: {
         'image:localAssetUrl': (url, ctx) => {
-          expect(url).toBe(`/_mochi/asset/${ctx.filename}`);
-          expect(ctx.assetPrefix).toBe('/_mochi');
+          seenUrl = url;
+          seenCtx = ctx;
           return `https://cdn.example.com/${ctx.filename}`;
         },
       },
@@ -194,6 +201,9 @@ describe('image extension points', () => {
     const loader = createImageAssetLoader({ outDir, assetPrefix: '/_mochi', assets });
     const obj = parseModule((await loader({ path: fixture })).contents);
 
+    expect(seenCtx).toBeDefined();
+    expect(seenUrl).toBe(`/_mochi/asset/${seenCtx!.filename}`);
+    expect(seenCtx!.assetPrefix).toBe('/_mochi');
     expect(obj.src).toMatch(/^https:\/\/cdn\.example\.com\/hero-[a-z0-9]+\.png$/);
     // The rewritten URL is the key in both the build map and the request-time registry.
     expect(assets.get(obj.src)).toBeDefined();

--- a/packages/mochi/src/compiler/imageImportCompile.test.ts
+++ b/packages/mochi/src/compiler/imageImportCompile.test.ts
@@ -53,8 +53,11 @@ describe('local image import through the compiler', () => {
   test('round-trips through toManifest / fromManifest and repopulates the global registry', async () => {
     const manifest = registry.toManifest();
     expect(manifest.localImageAssets).toBeDefined();
-    const [url] = Object.keys(manifest.localImageAssets!);
-    expect(url).toBeDefined();
+    const keys = Object.keys(manifest.localImageAssets!);
+    expect(keys.length).toBe(1);
+    const [url] = keys;
+    expect(url).toMatch(/^\/_mochi\/asset\/hero-[a-z0-9]+\.png$/);
+    expect(registry.getLocalImageAssets().has(url!)).toBe(true);
 
     const manifestPath = path.join(outDir, 'manifest.json');
     writeFileSync(manifestPath, JSON.stringify(manifest));
@@ -64,7 +67,12 @@ describe('local image import through the compiler', () => {
     expect(getLocalImageAsset(url!)).toBeUndefined();
 
     const restored = await ComponentRegistry.fromManifest(manifestPath, false);
-    expect(restored.getLocalImageAssets().has(url!)).toBe(true);
+    const restoredAsset = restored.getLocalImageAssets().get(url!);
+    expect(restoredAsset).toBeDefined();
+    expect(restoredAsset!.width).toBe(48);
+    expect(restoredAsset!.height).toBe(24);
+    expect(restoredAsset!.format).toBe('png');
+    expect(restoredAsset!.contentType).toBe('image/png');
     const info = getLocalImageAsset(url!);
     expect(info).toBeDefined();
     expect(info!.contentType).toBe('image/png');

--- a/packages/mochi/src/compiler/metafileWalk.test.ts
+++ b/packages/mochi/src/compiler/metafileWalk.test.ts
@@ -51,9 +51,12 @@ describe('metafile walk — transitive attribution at depth 2', () => {
       getClientAddress: () => null,
     };
     const result = await requestContext.run(ctx, () => registry.renderComponent(FIXTURE_PAGE));
-    const deepComponentCss = result.cssUrls.find((u) => u.includes('/css/Deep-'));
-    expect(deepComponentCss).toBeDefined();
-    const deepImportedCss = result.cssUrls.find((u) => u.includes('/import-css/deep-'));
-    expect(deepImportedCss).toBeDefined();
+    expect(result.cssUrls).toHaveLength(2);
+    const deepComponentCss = result.cssUrls.filter((u) => u.startsWith('/_mochi/css/Deep-'));
+    expect(deepComponentCss).toHaveLength(1);
+    expect(deepComponentCss[0]).toMatch(/^\/_mochi\/css\/Deep-[a-z0-9]+\.css$/);
+    const deepImportedCss = result.cssUrls.filter((u) => u.startsWith('/_mochi/import-css/deep-'));
+    expect(deepImportedCss).toHaveLength(1);
+    expect(deepImportedCss[0]).toMatch(/^\/_mochi\/import-css\/deep-[a-z0-9]+\.css$/);
   });
 });

--- a/packages/mochi/src/compiler/preprocessCache.test.ts
+++ b/packages/mochi/src/compiler/preprocessCache.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
 import path from 'node:path';
 import { __resetPreprocessMemCache, cachedPreprocessHydratable, createPreprocessCacheStats, evictPreprocessCacheEntry } from './preprocessCache';
 import { mochiEvents } from '../events';
@@ -129,8 +129,15 @@ describe('preprocess-cache event emission', () => {
     // be gated on subscriber presence.
     mochiEvents.off('preprocess-cache:hit', onHit);
     mochiEvents.off('preprocess-cache:miss', onMiss);
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
-    cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
-    expect(received).toEqual([]);
+    // Spying on emit itself proves the hasSubscribers gate short-circuits —
+    // `received` alone would stay empty even without the gate.
+    const emitSpy = spyOn(mochiEvents, 'emit');
+    try {
+      cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+      cachedPreprocessHydratable(ISLAND_SOURCE, '/test/A.svelte');
+      expect(emitSpy).not.toHaveBeenCalled();
+    } finally {
+      emitSpy.mockRestore();
+    }
   });
 });

--- a/packages/mochi/src/compiler/recompileBundle.test.ts
+++ b/packages/mochi/src/compiler/recompileBundle.test.ts
@@ -1,6 +1,6 @@
 // Previously .isolated.test.ts — all tests now run in isolated processes.
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { ComponentRegistry } from './ComponentRegistry';
 import { mochiEvents } from '../events';
@@ -115,7 +115,7 @@ describe('recompile* batches into one compileAll + one buildClientBundle per cyc
     await registry.compileAll([PAGE_A, PAGE_B]);
     expect(compileAllCalls).toBe(1);
     expect(bundleCalls).toBe(1); // single trailing buildClientBundle for the cohort
-    expect(registry.getPageCount()).toBe(2);
+    expect(registry.getPageCount()).toBe(2); // stub-derived sanity precondition, not a real-compile claim
   });
 
   test('recompileAll re-runs the entire cohort in one compileAll and bundles once', async () => {
@@ -306,5 +306,88 @@ describe('recompile* batches into one compileAll + one buildClientBundle per cyc
     const afterEntry = internals.compiledComponents.get(PAGE_A);
     expect(afterEntry).toBeDefined();
     expect(afterEntry).not.toBe(beforeEntry);
+  });
+});
+
+// Integration anchor for the stubbed suite above: exercises recompileChanged /
+// compileAll against the REAL Svelte + Bun.build pipeline so the stub's contract
+// assumptions (path resolution, cached-entry filtering, entryDeps seeding, one
+// trailing client bundle per cycle) stay tied to production behavior.
+describe('recompile* against the real compileAll', () => {
+  let dir: string;
+  let registry: ComponentRegistry;
+  let compileStarts: string[];
+  let bundleEvents: number;
+  let pageDep: string;
+  let pageSolo: string;
+  let sharedTs: string;
+
+  const onCompileStart = ({ path: p }: { path: string }) => {
+    compileStarts.push(p);
+  };
+  const onBundle = () => {
+    bundleEvents += 1;
+  };
+
+  beforeEach(() => {
+    dir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-recompile-real-'));
+    registry = new ComponentRegistry({ development: true, outDir: path.join(dir, '.mochi') });
+    sharedTs = path.join(dir, 'shared.ts');
+    pageDep = path.join(dir, 'PageDep.svelte');
+    pageSolo = path.join(dir, 'PageSolo.svelte');
+    writeFileSync(sharedTs, "export const label = 'from-shared';\n");
+    writeFileSync(path.join(dir, 'Widget.svelte'), '<button>widget</button>\n');
+    writeFileSync(
+      pageDep,
+      '<script lang="ts">\n' +
+        "  import { label } from './shared';\n" +
+        "  import Widget from './Widget.svelte';\n" +
+        '</script>\n\n<main>{label}<Widget mochi:hydrate /></main>\n',
+    );
+    writeFileSync(pageSolo, '<div>solo</div>\n');
+    compileStarts = [];
+    bundleEvents = 0;
+    mochiEvents.on('compile:start', onCompileStart);
+    mochiEvents.on('client-bundle:complete', onBundle);
+  });
+
+  afterEach(() => {
+    mochiEvents.off('compile:start', onCompileStart);
+    mochiEvents.off('client-bundle:complete', onBundle);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('recompileChanged walks the real dep graph and bundles once per cycle', async () => {
+    await registry.compileAll([pageDep, pageSolo]);
+    expect(new Set(compileStarts)).toEqual(new Set([pageDep, pageSolo]));
+    expect(bundleEvents).toBe(1); // one trailing bundle for the whole cohort
+
+    compileStarts = [];
+    bundleEvents = 0;
+
+    const summary = await registry.recompileChanged(sharedTs);
+    expect(summary.pages).toEqual(new Set([pageDep])); // PageSolo's real dep graph excludes shared.ts
+    expect(summary.clientBundleCount).toBe(1);
+    expect(compileStarts).toEqual([pageDep]);
+    expect(bundleEvents).toBe(1);
+
+    const noop = await registry.recompileChanged(path.join(dir, 'unrelated.ts'));
+    expect(noop.pages.size).toBe(0);
+    expect(noop.clientBundleCount).toBe(0);
+  });
+
+  test('relative and absolute registrations resolve to one cached entry', async () => {
+    const rel = path.relative(process.cwd(), pageSolo);
+    await registry.compileAll([rel]);
+    expect(compileStarts).toEqual([pageSolo]); // emitted paths are resolved absolute
+
+    compileStarts = [];
+    await registry.compileAll([pageSolo]);
+    expect(compileStarts).toEqual([]); // cached under the resolved key → filtered out
+
+    // The entry's own resolved path is in its dep set, so entry-as-changed-path rebuilds it.
+    const summary = await registry.recompileChanged(pageSolo);
+    expect(summary.pages).toEqual(new Set([pageSolo]));
+    expect(compileStarts).toEqual([pageSolo]);
   });
 });

--- a/packages/mochi/src/compiler/serverOnlyScan.test.ts
+++ b/packages/mochi/src/compiler/serverOnlyScan.test.ts
@@ -32,6 +32,8 @@ describe('scanServerOnlyExports', () => {
     const src = `export { foo, bar as baz } from './other';`;
     const r = scanServerOnlyExports(src);
     expect(r.named.sort()).toEqual(['baz', 'foo']);
+    expect(r.hasDefault).toBe(false);
+    expect(r.warnings).toEqual([]);
   });
 
   test('detects default export', () => {
@@ -117,9 +119,9 @@ describe('buildServerOnlyStubModule', () => {
     expect(stub).toContain('export default __default');
     const mod = (await import(`data:text/javascript;base64,${Buffer.from(stub).toString('base64')}`)) as { default: unknown };
     const d = mod.default as ((...a: unknown[]) => unknown) & (new () => unknown) & { foo?: unknown };
-    expect(() => d()).toThrow(/server-only/);
-    expect(() => d.foo).toThrow(/server-only/);
-    expect(() => new d()).toThrow(/server-only/);
+    expect(() => d()).toThrow(/was called on the client/);
+    expect(() => d.foo).toThrow(/wrap usage in hydratable/);
+    expect(() => new d()).toThrow(/was called on the client/);
   });
 
   test('stub throws when invoked', async () => {
@@ -129,7 +131,7 @@ describe('buildServerOnlyStubModule', () => {
       warnings: [],
     });
     const mod = (await import(`data:text/javascript;base64,${Buffer.from(stub).toString('base64')}`)) as { parseText: unknown };
-    expect(() => (mod.parseText as () => unknown)()).toThrow(/server-only/);
+    expect(() => (mod.parseText as () => unknown)()).toThrow(/was called on the client/);
   });
 
   test('stub throws on property access', async () => {
@@ -139,7 +141,7 @@ describe('buildServerOnlyStubModule', () => {
       warnings: [],
     });
     const mod = (await import(`data:text/javascript;base64,${Buffer.from(stub).toString('base64')}`)) as { db: { query: unknown } };
-    expect(() => mod.db.query).toThrow(/server-only/);
+    expect(() => mod.db.query).toThrow(/wrap usage in hydratable/);
   });
 
   test('stub throws when used with `new`', async () => {
@@ -149,7 +151,7 @@ describe('buildServerOnlyStubModule', () => {
       warnings: [],
     });
     const mod = (await import(`data:text/javascript;base64,${Buffer.from(stub).toString('base64')}`)) as { Klass: new () => unknown };
-    expect(() => new mod.Klass()).toThrow(/server-only/);
+    expect(() => new mod.Klass()).toThrow(/was called on the client/);
   });
 });
 

--- a/packages/mochi/src/compiler/svelteAstPreprocess.test.ts
+++ b/packages/mochi/src/compiler/svelteAstPreprocess.test.ts
@@ -312,7 +312,7 @@ describe('preprocessHydratable', () => {
     const { transformed } = preprocessHydratable(source, '/test/File.svelte');
 
     expect(transformed).toContain('disabled: true');
-    expect(transformed).toContain('disabled');
+    expect(transformed).toContain('<Comp disabled />');
   });
 
   test('mixed prop types in single component', () => {

--- a/packages/mochi/src/compiler/svelteCompilerBackend.test.ts
+++ b/packages/mochi/src/compiler/svelteCompilerBackend.test.ts
@@ -1,5 +1,6 @@
-import { afterEach, describe, expect, it } from 'bun:test';
+import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { compile as svelteCompile } from 'svelte/compiler';
+import { logger } from '../utils/log';
 import { backendId, isBackend, loadRsvelte, officialBackend, resetSvelteCompilerCache, resolveSvelteCompiler } from './svelteCompilerBackend';
 
 const ENV_VAR = 'MOCHI_SVELTE_COMPILER';
@@ -46,8 +47,21 @@ describe('resolveSvelteCompiler', () => {
   });
 
   it('memoizes resolution', async () => {
-    process.env[ENV_VAR] = 'rsvelte';
-    expect(await resolveSvelteCompiler('rsvelte')).toBe(await resolveSvelteCompiler('rsvelte'));
+    // Break the real adapter import so every underlying load is observable as one warn — a
+    // second warn would mean the second call re-ran loadRsvelte instead of hitting the cache.
+    mock.module('@mochi-framework/rsvelte', () => {
+      throw new Error('unavailable in this test');
+    });
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      process.env[ENV_VAR] = 'rsvelte';
+      const first = await resolveSvelteCompiler('rsvelte');
+      expect(first).toBe(officialBackend);
+      expect(await resolveSvelteCompiler('rsvelte')).toBe(first);
+      expect(warn).toHaveBeenCalledTimes(1);
+    } finally {
+      warn.mockRestore();
+    }
   });
 });
 

--- a/packages/mochi/src/compiler/svelteShaker.test.ts
+++ b/packages/mochi/src/compiler/svelteShaker.test.ts
@@ -76,10 +76,14 @@ describe('shakeApp', () => {
     expect(slimmed).toBeDefined();
     expect(slimmed).toContain('mochi:hydrate');
     expect(slimmed).toContain('mochi:defer:visible');
+    // Regular attributes survive too — distinguishes a directive-only drop from an all-attribute drop.
+    expect(slimmed).toContain('label="hello"');
+    expect(slimmed).toContain('label="world"');
   });
 
   test('returns an empty map for a directory with no .svelte files', async () => {
     dir = mkdtempSync(path.join(tmpdir(), 'shake-app-empty-'));
+    writeFileSync(path.join(dir, 'notes.ts'), 'export const x = 1;');
     const { shaken } = await shakeApp(dir);
     expect(shaken.size).toBe(0);
   });

--- a/packages/mochi/src/compiler/tailwind.test.ts
+++ b/packages/mochi/src/compiler/tailwind.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { compile } from '@tailwindcss/node';
 import { createBunResolver } from './tailwind';
@@ -7,9 +7,28 @@ import { createBunResolver } from './tailwind';
 describe('createBunResolver', () => {
   test('resolves a real module id to a clean absolute path', async () => {
     const resolver = createBunResolver();
-    const resolved = await resolver('@tailwindcss/node', import.meta.dir);
-    expect(resolved).toBeTruthy();
-    expect(path.isAbsolute(resolved as string)).toBe(true);
+    const resolved = (await resolver('@tailwindcss/node', import.meta.dir)) as string;
+    expect(path.isAbsolute(resolved)).toBe(true);
+    expect(resolved.split(path.sep).join('/')).toContain('/@tailwindcss/node/');
+    // "Clean" means no enhanced-resolve `\0#` escape artifacts — the path must be readable as-is.
+    expect(resolved).not.toContain('\0');
+    expect(existsSync(resolved)).toBe(true);
+  });
+
+  test('resolves a relative @import inside compile() from a base dir containing # and space', async () => {
+    const hashDir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-tw-# hash-'));
+    try {
+      writeFileSync(path.join(hashDir, 'imported.css'), '.from-imported { color: rebeccapurple; }\n');
+      const compiled = await compile(`@import './imported.css';\n`, {
+        base: hashDir,
+        from: path.join(hashDir, 'input.css'),
+        onDependency: () => {},
+        customCssResolver: createBunResolver(),
+      });
+      expect(compiled.build([])).toContain('rebeccapurple');
+    } finally {
+      rmSync(hashDir, { recursive: true, force: true });
+    }
   });
 
   test('returns undefined (never throws) for an unresolvable id', async () => {

--- a/packages/mochi/src/compiler/unresolvedIsland.test.ts
+++ b/packages/mochi/src/compiler/unresolvedIsland.test.ts
@@ -134,6 +134,6 @@ describe('named-export islands', () => {
   });
 
   test('renderComponent throws a descriptive error for a missing export', async () => {
-    expect(requestContext.run(makeCtx(), () => registry.renderComponent(BARREL, {}, { exportName: 'Nope' }))).rejects.toThrow(/no export "Nope"/);
+    await expect(requestContext.run(makeCtx(), () => registry.renderComponent(BARREL, {}, { exportName: 'Nope' }))).rejects.toThrow(/no export "Nope"/);
   });
 });

--- a/packages/mochi/src/components/RawScript.test.ts
+++ b/packages/mochi/src/components/RawScript.test.ts
@@ -6,6 +6,9 @@ import { HYDRATABLE_CONTEXT_KEY } from '../islands/isHydratable';
 
 const COMPONENT_PATH = path.join(import.meta.dir, 'RawScript.svelte');
 
+// Multi-line with HTML-sensitive characters so a verbatim check catches escaping, wrapping, or truncation.
+const SCRIPT_CONTENT = 'console.log("hello from raw");\nif (1 < 2 && "q") console.log(\'<b>&amp;</b>\');\n';
+
 describe('RawScript', () => {
   let outDir: string;
   let scriptFile: string;
@@ -14,7 +17,7 @@ describe('RawScript', () => {
   beforeAll(async () => {
     outDir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-rawscript-test-'));
     scriptFile = path.join(outDir, 'snippet.js');
-    writeFileSync(scriptFile, 'console.log("hello from raw");\n');
+    writeFileSync(scriptFile, SCRIPT_CONTENT);
     registry = new ComponentRegistry({ development: true, outDir });
     await registry.compile(COMPONENT_PATH);
   });
@@ -25,7 +28,7 @@ describe('RawScript', () => {
 
   test('inlines the file contents verbatim into the body (absolute src)', async () => {
     const { body } = await registry.renderComponent(COMPONENT_PATH, { src: scriptFile });
-    expect(body).toContain('console.log("hello from raw");');
+    expect(body).toBe(SCRIPT_CONTENT);
   });
 
   test('resolves a relative src against the working directory', async () => {

--- a/packages/mochi/src/components/ViewTransitions.test.ts
+++ b/packages/mochi/src/components/ViewTransitions.test.ts
@@ -61,7 +61,8 @@ describe('ViewTransitions', () => {
 
   test('duration is interpolated into the animation', async () => {
     const { head } = await render({ duration: 500 });
-    expect(head).toContain('500ms');
+    expect(head).toContain('mochi-vt-out 500ms');
+    expect(head).toContain('mochi-vt-in 500ms');
   });
 
   test('custom wraps the supplied bodies in keyframes and the rules still reference them', async () => {

--- a/packages/mochi/src/email/buildEmailTemplates.test.ts
+++ b/packages/mochi/src/email/buildEmailTemplates.test.ts
@@ -181,8 +181,8 @@ describe('email templates under src/emails are precompiled into the manifest', (
   test('the rendered email carries the props and its inlined CSS', () => {
     expect(sends[0]?.html).toContain('Hello Ada');
     // Proves the scoped CSS survived the manifest round-trip and reached
-    // css-inline — not merely that the SSR module loaded.
-    expect(sends[0]?.html).toMatch(/style="[^"]*#639/);
+    // css-inline — inlined onto the greeting element itself, not just anywhere.
+    expect(sends[0]?.html).toMatch(/<h1[^>]*style="[^"]*#639[^"]*"[^>]*>Hello Ada</);
   });
 
   test('an app with no src/emails directory still builds', () => {
@@ -203,9 +203,10 @@ describe('email templates under src/emails are precompiled into the manifest', (
 
   test('it sends with the Svelte sources deleted', async () => {
     // Nothing short of this rules out a compile-from-source fallback.
+    const before = sends.length;
     rmSync(path.join(roots[0]!, 'src', 'emails'), RM_OPTS);
     await Mochi.email({ to: 'ada@example.com', subject: 'Hi', component: './src/emails/Welcome.svelte', props: { name: 'Grace' } });
-    expect(sends).toHaveLength(2);
-    expect(sends[1]?.html).toContain('Hello Grace');
+    expect(sends).toHaveLength(before + 1);
+    expect(sends.at(-1)?.html).toContain('Hello Grace');
   });
 });

--- a/packages/mochi/src/email/templates.test.ts
+++ b/packages/mochi/src/email/templates.test.ts
@@ -53,8 +53,7 @@ describe('scanEmailTemplates', () => {
   test('is sorted, so a rebuild of unchanged sources keeps entrypoint order stable', () => {
     const root = scaffold([`${EMAIL_TEMPLATE_DIR}/Zeta.svelte`, `${EMAIL_TEMPLATE_DIR}/alpha.svelte`, `${EMAIL_TEMPLATE_DIR}/Mid.svelte`]);
     try {
-      const found = scanEmailTemplates(root);
-      expect(found).toEqual([...found].sort());
+      expect(scanEmailTemplates(root)).toEqual(['src/emails/Mid.svelte', 'src/emails/Zeta.svelte', 'src/emails/alpha.svelte']);
     } finally {
       rmSync(root, { recursive: true, force: true });
     }
@@ -63,7 +62,9 @@ describe('scanEmailTemplates', () => {
   test('yields forward-slash paths on every platform', () => {
     const root = scaffold([`${EMAIL_TEMPLATE_DIR}/receipts/Receipt.svelte`]);
     try {
-      expect(scanEmailTemplates(root).every((p) => !p.includes('\\'))).toBe(true);
+      const found = scanEmailTemplates(root);
+      expect(found).toEqual(['src/emails/receipts/Receipt.svelte']);
+      expect(found.join('')).not.toContain('\\');
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/packages/mochi/src/events.test.ts
+++ b/packages/mochi/src/events.test.ts
@@ -11,9 +11,8 @@ describe('mochiEvents', () => {
 
   test('re-importing the module returns the same instance', async () => {
     const a = (await import('./events')).mochiEvents;
-    const b = (await import('./events')).mochiEvents;
-    expect(a).toBe(b);
     expect(a).toBe(mochiEvents);
+    expect(a).toBe(globalSlot());
   });
 
   test('roundtrip emit/subscribe works for captcha:verify', () => {
@@ -42,17 +41,19 @@ describe('mochiEvents', () => {
   });
 
   test('queue:completed is part of the event map', () => {
-    let received: { queue: string; jobName: string; attempt: number } | null = null;
-    const handler = (e: { queue: string; jobName: string; attempt: number; duration: number }) => {
-      received = { queue: e.queue, jobName: e.jobName, attempt: e.attempt };
+    let received: unknown = null;
+    const handler = (e: unknown) => {
+      received = e;
     };
     mochiEvents.on('queue:completed', handler);
     mochiEvents.emit('queue:completed', { queue: 'emails', jobId: 'j1', jobName: 'send', attempt: 1, duration: 12 });
     mochiEvents.off('queue:completed', handler);
-    expect(received as { queue: string; jobName: string; attempt: number } | null).toEqual({
+    expect(received).toEqual({
       queue: 'emails',
+      jobId: 'j1',
       jobName: 'send',
       attempt: 1,
+      duration: 12,
     });
   });
 });

--- a/packages/mochi/src/head.dev.test.ts
+++ b/packages/mochi/src/head.dev.test.ts
@@ -50,6 +50,9 @@ describe('HEAD requests (development)', () => {
     expect(get.status).toBe(200);
     expect(await get.text()).toBe(ROBOTS_BODY);
 
+    // Pin the concrete type so a header dropped from both responses can't pass tautologically.
+    expect(get.headers.get('Content-Type')).toContain('text/plain');
+
     const head = await fetch(`${base}/robots.txt`, { method: 'HEAD' });
     expect(head.status).toBe(200);
     expect(head.headers.get('Content-Type')).toBe(get.headers.get('Content-Type'));

--- a/packages/mochi/src/image/config.test.ts
+++ b/packages/mochi/src/image/config.test.ts
@@ -69,7 +69,7 @@ describe('config hash', () => {
 describe('getSize', () => {
   test('returns the resolved size for a known name and undefined otherwise', () => {
     const options = resolveImageOptions({ sizes: { thumb: BASE } });
-    expect(getSize('thumb', options)?.name).toBe('thumb');
+    expect(getSize('thumb', options)).toMatchObject({ name: 'thumb', width: 100, height: 80, format: 'webp', quality: 80 });
     expect(getSize('nope', options)).toBeUndefined();
     expect(getSize(undefined, options)).toBeUndefined();
   });

--- a/packages/mochi/src/image/imageCache.test.ts
+++ b/packages/mochi/src/image/imageCache.test.ts
@@ -132,8 +132,11 @@ describe('ImageCache.getOriginal', () => {
     const a = cache.getOriginal(SRC, fetchFn);
     const b = cache.getOriginal(SRC, fetchFn);
     release();
-    await Promise.all([a, b]);
+    const [ra, rb] = await Promise.all([a, b]);
     expect(calls).toBe(1);
+    expect(ra.status).toBe('miss');
+    expect(Array.from(ra.entry.bytes)).toEqual([7]);
+    expect(Array.from(rb.entry.bytes)).toEqual([7]);
   });
 
   test('bytes persist through storage across a fresh cache instance', async () => {
@@ -326,7 +329,7 @@ describe('ImageCache.keys / inspect (dev debug bar)', () => {
 
     const keys = await cache.keys();
     const origKey = keys.find((k) => k.includes(SRC));
-    expect(origKey).toBeDefined();
+    expect(origKey).toBe(`MochiImage:Original:${SRC}`);
 
     const entry = (await cache.inspect(origKey!)) as { value: unknown; createdAt: number };
     expect(entry).not.toBeNull();

--- a/packages/mochi/src/image/imageCodec.test.ts
+++ b/packages/mochi/src/image/imageCodec.test.ts
@@ -32,8 +32,9 @@ describe('packImageRequest + unpackImageRequest', () => {
     expect(roundTrip(r)).toEqual(r);
   });
 
-  test('round-trips a src containing bytes that look like control flags', () => {
-    const r: ImageRequest = { src: 'https://example.com/a.png?x=1&y=2#frag', size: 'p' };
+  test('round-trips a size name containing bytes that look like control flags', () => {
+    // \x01\x02\x04\x08 mirror ORIGINAL/HAS_SIZE/HTTPS_PREFIX/HTTP_PREFIX inside the length-prefixed field.
+    const r: ImageRequest = { src: 'https://example.com/a.png?x=1&y=2#frag', size: 'p\x01\x02\x04\x08q' };
     expect(roundTrip(r)).toEqual(r);
   });
 

--- a/packages/mochi/src/image/resize.test.ts
+++ b/packages/mochi/src/image/resize.test.ts
@@ -6,6 +6,8 @@ import type { ImageSize, ResolvedImageOptions } from './types';
 
 // 1x1 red PNG
 const PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==', 'base64');
+// 4x2 red PNG — non-square so a 90° rotate observably swaps the output dimensions
+const WIDE_PNG = Buffer.from('iVBORw0KGgoAAAANSUhEUgAAAAQAAAACCAYAAAB/qH1jAAAAFElEQVR4nGP8z8BQz4AEmJA5IDYAMCcBgiMx7hUAAAAASUVORK5CYII=', 'base64');
 
 function build(def: ImageSize, overrides: Record<string, unknown> = {}): { opts: ResolvedImageOptions; size: ResolvedImageOptions['sizes'][string] } {
   const resolved = resolveImageOptions({ sizes: { p: def }, ...overrides });
@@ -24,6 +26,7 @@ describe('runPipeline', () => {
   test('derives width from aspect ratio for height-only sizes', async () => {
     const { opts, size } = build({ height: 3, format: 'png' });
     const result = await runPipeline(new Uint8Array(PNG), size, opts);
+    expect(result.width).toBe(3);
     expect(result.height).toBe(3);
   });
 
@@ -40,16 +43,21 @@ describe('runPipeline', () => {
   });
 
   test('applies rotate/flip/flop/modulate without throwing', async () => {
-    const { opts, size } = build({ width: 4, height: 4, rotate: 90, flip: true, flop: true, modulate: { brightness: 1.1 } });
-    const result = await runPipeline(new Uint8Array(PNG), size, opts);
+    // No width/height: a resize would dictate the final dimensions and hide whether rotate ran.
+    const { opts, size } = build({ rotate: 90, flip: true, flop: true, modulate: { brightness: 1.1 }, format: 'png' });
+    const result = await runPipeline(new Uint8Array(WIDE_PNG), size, opts);
     expect(result.bytes.byteLength).toBeGreaterThan(0);
+    // The 90° rotate must swap the 4x2 source's dimensions.
+    expect(result.width).toBe(2);
+    expect(result.height).toBe(4);
   });
 
   test('withoutEnlargement caps a request bigger than the source', async () => {
     const { opts, size } = build({ width: 1000, height: 1000, fit: 'fill', withoutEnlargement: true });
     const result = await runPipeline(new Uint8Array(PNG), size, opts);
     // The 1x1 source must not be enlarged to 1000x1000.
-    expect(result.width).toBeLessThan(1000);
+    expect(result.width).toBe(1);
+    expect(result.height).toBe(1);
   });
 
   test('computePlaceholder returns a data URL', async () => {

--- a/packages/mochi/src/image/sweeper.test.ts
+++ b/packages/mochi/src/image/sweeper.test.ts
@@ -62,6 +62,7 @@ describe('startImageCacheSweeper', () => {
 
     expect(events.length).toBeGreaterThanOrEqual(1);
     expect(events[0]).toMatchObject({ removedVariants: 3, removedOriginals: 2, removedOther: 1 });
-    expect(events[0]!.durationMs).toBeGreaterThanOrEqual(0);
+    expect(typeof events[0]!.durationMs).toBe('number');
+    expect(Number.isFinite(events[0]!.durationMs)).toBe(true);
   });
 });

--- a/packages/mochi/src/islands/buildNestedServerIslands.test.ts
+++ b/packages/mochi/src/islands/buildNestedServerIslands.test.ts
@@ -36,8 +36,10 @@ describe('build precompiles nested server islands', () => {
       expect.stringMatching(/^Level2_\w+$/),
       expect.stringMatching(/^Level3_\w+$/),
     ]);
-    for (const islandPath of Object.values(manifest.serverIslandPaths ?? {})) {
-      expect(manifest.components[islandPath], `expected components entry for ${islandPath}`).toBeDefined();
+    const islandPaths = Object.values(manifest.serverIslandPaths ?? {});
+    expect(islandPaths).toHaveLength(3);
+    for (const islandPath of islandPaths) {
+      expect(manifest.components[islandPath]?.ssrModule, `expected components entry for ${islandPath}`).toMatch(/\.js$/);
     }
   });
 });

--- a/packages/mochi/src/islands/buildServerIslandManifest.test.ts
+++ b/packages/mochi/src/islands/buildServerIslandManifest.test.ts
@@ -40,6 +40,8 @@ describe('build precompiles server islands into the manifest', () => {
   });
 
   test('each server-island source path has a standalone components entry whose ssrModule exists', async () => {
+    // Guard against a vacuous pass: an empty manifest would skip the loop entirely.
+    expect(islandPaths.length).toBe(2);
     for (const islandPath of islandPaths) {
       const entry = manifest.components[islandPath];
       expect(entry, `expected manifest.components["${islandPath}"]`).toBeDefined();

--- a/packages/mochi/src/islands/payloadCrypto.fuzz.test.ts
+++ b/packages/mochi/src/islands/payloadCrypto.fuzz.test.ts
@@ -60,6 +60,20 @@ describe('payloadCrypto — property-based fuzzing', () => {
     );
   });
 
+  // Random text rarely deflates smaller, so the threshold test above can skip the compressed
+  // branch entirely — repetitive input forces it, proven by the token beating compress:false.
+  test('compressible input provably takes the deflate branch and round-trips', () => {
+    fc.assert(
+      fc.property(fc.string({ minLength: 1, maxLength: 20 }), fc.integer({ min: 200, max: 400 }), (chunk, n) => {
+        const s = chunk.repeat(n);
+        const token = encryptPayload(s);
+        expect(token.length).toBeLessThan(encryptPayload(s, { compress: false }).length);
+        expect(decryptPayload(token)).toBe(s);
+      }),
+      RUNS,
+    );
+  });
+
   test('bytes round-trip for arbitrary buffers', () => {
     fc.assert(
       fc.property(fc.uint8Array(), (bytes) => {
@@ -94,13 +108,16 @@ describe('payloadCrypto — property-based fuzzing', () => {
   });
 
   test('decryptPayload never throws on arbitrary garbage tokens', () => {
+    // Forging AES-SIV's 128-bit tag by chance is negligible, so garbage must yield null
+    // (any throw fails fc.assert on its own).
     fc.assert(
       fc.property(fc.string(), (token) => {
-        const out = decryptPayload(token);
-        expect(out === null || typeof out === 'string').toBe(true);
+        expect(decryptPayload(token)).toBeNull();
       }),
       RUNS,
     );
+    // Guards against decryptPayload trivially returning null for everything.
+    expect(decryptPayload(encryptPayload('sanity'))).toBe('sanity');
   });
 });
 

--- a/packages/mochi/src/islands/serverIslandCrypto.test.ts
+++ b/packages/mochi/src/islands/serverIslandCrypto.test.ts
@@ -123,7 +123,7 @@ describe('encryptProps debug bar recording', () => {
     );
   });
 
-  test('does not record when debugBarData is undefined (prod)', () => {
+  test('encrypt round-trips when debugBarData is undefined (prod)', () => {
     installConfig();
     withCtx((ctx) => {
       const json = devalueStringify({ islandId: 'mochi-test-0', x: 1 });
@@ -133,7 +133,19 @@ describe('encryptProps debug bar recording', () => {
     });
   });
 
-  test('does not record when called outside request context', () => {
+  test('does not create a serverProps sink when debugBarData lacks one', () => {
+    installConfig();
+    const ctx = makeCtx();
+    ctx.debugBarData = { route: '/', pathname: '/', params: {} };
+    requestContext.run(ctx, () => {
+      const json = devalueStringify({ islandId: 'mochi-test-0', x: 1 });
+      const token = encryptProps(json, COMP);
+      expect(ctx.debugBarData!.serverProps).toBeUndefined();
+      expect(decryptProps(token, COMP)).toBe(json);
+    });
+  });
+
+  test('encrypt works when called outside a request context', () => {
     installConfig();
     const json = devalueStringify({ islandId: 'mochi-test-0' });
     let token: string | undefined;

--- a/packages/mochi/src/islands/serverIslandCss.test.ts
+++ b/packages/mochi/src/islands/serverIslandCss.test.ts
@@ -56,6 +56,8 @@ describe('server island CSS collection', () => {
   });
 
   test('a CSS-less island yields no cssUrls (so the endpoint omits the header)', async () => {
+    // Guard the premise: if the shared Echo fixture ever gains a <style> block, this test no longer means "CSS-less".
+    expect(await Bun.file(ECHO).text()).not.toContain('<style');
     const result = await requestContext.run(makeCtx(), () => registry.renderComponent(ECHO, { name: 'x' }));
     expect(result.cssUrls).toHaveLength(0);
   });

--- a/packages/mochi/src/middleware/compress.test.ts
+++ b/packages/mochi/src/middleware/compress.test.ts
@@ -4,6 +4,17 @@ import { brotliDecompressSync } from 'node:zlib';
 import type { MochiEvent } from '../runtime/hooks';
 import { compress } from './compress';
 
+// compress() reads dev mode from the Mochi.serve() config singleton; fake it via its global key.
+async function withMochiConfig<T>(development: boolean, fn: () => Promise<T>): Promise<T> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g['__mochi_config__'] = { options: { development }, secretKey: Buffer.alloc(32) };
+  try {
+    return await fn();
+  } finally {
+    delete g['__mochi_config__'];
+  }
+}
+
 function makeEvent(req: Request): MochiEvent {
   return {
     request: req,
@@ -105,6 +116,8 @@ describe('compress()', () => {
 
     expect(response.headers.get('Content-Encoding')).toBe('gzip');
     expect(response.headers.get('Content-Length')).toBeNull();
+    const restored = new TextDecoder().decode(Bun.gunzipSync(new Uint8Array(await response.arrayBuffer())));
+    expect(restored).toBe(body);
   });
 
   test('compresses JSON responses', async () => {
@@ -217,6 +230,21 @@ describe('compress()', () => {
     expect(response.headers.get('Content-Encoding')).toBe('br');
   });
 
+  test('Accept-Encoding: * picks the first configured method (gzip-first order)', async () => {
+    const handle = compress({ methods: ['gzip', 'brotli'] });
+    const body = 'x'.repeat(1024);
+    const req = new Request('http://localhost/', {
+      headers: { 'Accept-Encoding': '*' },
+    });
+
+    const response = await handle({
+      event: makeEvent(req),
+      resolve: async () => new Response(body, { headers: { 'Content-Type': 'text/plain' } }),
+    });
+
+    expect(response.headers.get('Content-Encoding')).toBe('gzip');
+  });
+
   test('skips compression when methods exclude what the client offers', async () => {
     const handle = compress({ methods: ['gzip'] });
     const body = '<p>hello</p>';
@@ -265,5 +293,44 @@ describe('compress()', () => {
     expect(response.headers.get('Content-Encoding')).toBe('br');
     const restored = new TextDecoder().decode(brotliDecompressSync(new Uint8Array(await response.arrayBuffer())));
     expect(restored).toBe(body);
+  });
+
+  test('skips compression entirely in dev mode', async () => {
+    await withMochiConfig(true, async () => {
+      const handle = compress();
+      const body = '<!doctype html>' + 'hello '.repeat(500);
+      const req = new Request('http://localhost/', {
+        headers: { 'Accept-Encoding': 'gzip, br' },
+      });
+      const upstream = new Response(body, { headers: { 'Content-Type': 'text/html' } });
+
+      const response = await handle({
+        event: makeEvent(req),
+        resolve: async () => upstream,
+      });
+
+      expect(response).toBe(upstream);
+      expect(response.headers.get('Content-Encoding')).toBeNull();
+      expect(await response.text()).toBe(body);
+    });
+  });
+
+  test('compresses when config is initialized with development: false', async () => {
+    await withMochiConfig(false, async () => {
+      const handle = compress();
+      const body = '<!doctype html>' + 'hello '.repeat(500);
+      const req = new Request('http://localhost/', {
+        headers: { 'Accept-Encoding': 'gzip' },
+      });
+
+      const response = await handle({
+        event: makeEvent(req),
+        resolve: async () => new Response(body, { headers: { 'Content-Type': 'text/html' } }),
+      });
+
+      expect(response.headers.get('Content-Encoding')).toBe('gzip');
+      const restored = new TextDecoder().decode(Bun.gunzipSync(new Uint8Array(await response.arrayBuffer())));
+      expect(restored).toBe(body);
+    });
   });
 });

--- a/packages/mochi/src/queue.test.ts
+++ b/packages/mochi/src/queue.test.ts
@@ -363,7 +363,6 @@ describe('Mochi queue', () => {
     // After draining, the handle is gone from the registry.
     expect(() => getQueue(name)).toThrow(/queues are not mounted yet/);
     // A second call must not throw even though the registry is already empty.
-    await closeAllQueueResources();
-    expect(true).toBe(true);
+    await expect(closeAllQueueResources()).resolves.toBeUndefined();
   });
 });

--- a/packages/mochi/src/runtime/cookies.fuzz.test.ts
+++ b/packages/mochi/src/runtime/cookies.fuzz.test.ts
@@ -13,8 +13,11 @@ describe('MochiCookieJar — property-based fuzzing', () => {
   test('constructing from an arbitrary Cookie header never throws; peekAll is always an array', () => {
     fc.assert(
       fc.property(fc.string(), (header) => {
-        const jar = new MochiCookieJar(header);
-        expect(Array.isArray(jar.peekAll())).toBe(true);
+        let jar: MochiCookieJar | undefined;
+        expect(() => {
+          jar = new MochiCookieJar(header);
+        }).not.toThrow();
+        expect(Array.isArray(jar!.peekAll())).toBe(true);
       }),
       RUNS,
     );

--- a/packages/mochi/src/runtime/csrf.fuzz.test.ts
+++ b/packages/mochi/src/runtime/csrf.fuzz.test.ts
@@ -47,6 +47,7 @@ describe('csrfCheck — property-based fuzzing', () => {
   const proxy = { origin: 'http://localhost:3333' };
 
   test('never throws; always returns null or a Response for arbitrary requests', () => {
+    let checked = 0;
     fc.assert(
       fc.property(fc.constantFrom('POST', 'GET', 'PUT', 'PATCH', 'DELETE', 'OPTIONS', 'HEAD'), fc.string(), fc.string(), (method, origin, contentType) => {
         let request: Request;
@@ -57,7 +58,32 @@ describe('csrfCheck — property-based fuzzing', () => {
         }
         const out = csrfCheck(request, url, undefined, proxy, false);
         expect(out === null || out instanceof Response).toBe(true);
+        checked++;
       }),
+      RUNS,
+    );
+    // Guard against the Request-constructor escape hatch swallowing every run.
+    expect(checked).toBeGreaterThan(0);
+  });
+
+  test('403s mismatched-origin protected form submissions and passes matching origins', () => {
+    fc.assert(
+      fc.property(
+        fc.constantFrom('POST', 'PUT', 'PATCH', 'DELETE'),
+        fc.constantFrom(...DEFAULT_FORM_CONTENT_TYPES),
+        fc
+          .webUrl()
+          .map((u) => new URL(u).origin)
+          .filter((o) => o !== proxy.origin),
+        (method, contentType, crossOrigin) => {
+          const blocked = csrfCheck(new Request(url, { method, headers: { origin: crossOrigin, 'content-type': contentType } }), url, undefined, proxy, false);
+          expect(blocked).toBeInstanceOf(Response);
+          expect((blocked as Response).status).toBe(403);
+
+          const allowed = csrfCheck(new Request(url, { method, headers: { origin: proxy.origin, 'content-type': contentType } }), url, undefined, proxy, false);
+          expect(allowed).toBeNull();
+        },
+      ),
       RUNS,
     );
   });

--- a/packages/mochi/src/runtime/csrf.integration.test.ts
+++ b/packages/mochi/src/runtime/csrf.integration.test.ts
@@ -52,12 +52,12 @@ describe('csrf wiring through Mochi.serve()', () => {
     expect(res.status).toBe(403);
   });
 
-  test('page handler: same-origin GET → not 403', async () => {
+  test('page handler: same-origin GET → 200', async () => {
     const res = await fetch(`${base}/page`, {
       method: 'GET',
       headers: { origin: base },
     });
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(200);
   });
 
   test('api handler: cross-origin form POST → 403', async () => {
@@ -119,11 +119,11 @@ describe('csrf wiring through Mochi.serve()', () => {
     expect(res.status).toBe(403);
   });
 
-  test('cross-origin GET to unrouted path → not 403 (exempt method)', async () => {
+  test('cross-origin GET to unrouted path → 404 (exempt method)', async () => {
     const res = await fetch(`${base}/__nonexistent__`, {
       method: 'GET',
       headers: { origin: 'http://evil.example' },
     });
-    expect(res.status).not.toBe(403);
+    expect(res.status).toBe(404);
   });
 });

--- a/packages/mochi/src/runtime/csrf.test.ts
+++ b/packages/mochi/src/runtime/csrf.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, spyOn, test, type Mock } from 'bun:test';
 import { csrfCheck, isFormContentType } from './csrf';
 import { initExtensions } from '../extensions';
 
@@ -218,8 +218,14 @@ describe('csrfCheck with filtered formContentTypes / protectedMethods', () => {
 });
 
 describe('csrfCheck in development mode', () => {
+  // Hook-managed spy so a failed assertion can't leak it into later tests.
+  let warn: Mock<typeof console.warn>;
+  beforeEach(() => {
+    warn = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => warn.mockRestore());
+
   test('cross-origin form POST returns null and warns', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {});
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
       origin: 'http://evil.example',
@@ -229,38 +235,31 @@ describe('csrfCheck in development mode', () => {
     const message = warn.mock.calls[0]!.join(' ');
     expect(message).toContain('would be blocked in production');
     expect(message).toContain('http://evil.example');
-    warn.mockRestore();
   });
 
   test('missing Origin on form POST returns null and warns', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {});
     const r = req('POST', { contentType: 'application/x-www-form-urlencoded' });
     expect(csrfCheck(r, sameUrl, undefined, PROD_PROXY, true)).toBeNull();
     expect(warn).toHaveBeenCalledTimes(1);
     expect(warn.mock.calls[0]!.join(' ')).toContain('<missing>');
-    warn.mockRestore();
   });
 
   test('same-origin form POST does not warn', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {});
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
       origin: SAME,
     });
     expect(csrfCheck(r, sameUrl, undefined, PROD_PROXY, true)).toBeNull();
     expect(warn).not.toHaveBeenCalled();
-    warn.mockRestore();
   });
 
   test('checkOrigin: false short-circuits before any warning', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {});
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
       origin: 'http://evil.example',
     });
     expect(csrfCheck(r, sameUrl, { checkOrigin: false }, PROD_PROXY, true)).toBeNull();
     expect(warn).not.toHaveBeenCalled();
-    warn.mockRestore();
   });
 
   test('production parity: development=false still returns 403', () => {
@@ -273,6 +272,13 @@ describe('csrfCheck in development mode', () => {
 });
 
 describe('csrfCheck with proxy options', () => {
+  // Hook-managed spy so a failed assertion can't leak it into later tests.
+  let warn: Mock<typeof console.warn>;
+  beforeEach(() => {
+    warn = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => warn.mockRestore());
+
   test('passes when Origin matches the explicit proxy.origin', () => {
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
@@ -311,7 +317,6 @@ describe('csrfCheck with proxy options', () => {
   });
 
   test('dev warning reflects the resolved expected origin', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {});
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
       origin: 'http://evil.example',
@@ -319,11 +324,17 @@ describe('csrfCheck with proxy options', () => {
     expect(csrfCheck(r, sameUrl, undefined, { origin: 'https://my.site' }, true)).toBeNull();
     const message = warn.mock.calls[0]!.join(' ');
     expect(message).toContain('allowed: https://my.site');
-    warn.mockRestore();
   });
 });
 
 describe('csrfCheck safe-by-default (no proxy config)', () => {
+  // Hook-managed spy so a failed assertion can't leak it into later tests.
+  let warn: Mock<typeof console.warn>;
+  beforeEach(() => {
+    warn = spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => warn.mockRestore());
+
   test('prod + no proxy config + same-origin form POST → 403 with both messages', async () => {
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
@@ -390,7 +401,6 @@ describe('csrfCheck safe-by-default (no proxy config)', () => {
   });
 
   test('dev + no proxy config + form POST → null and warns about missing config', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {});
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
       origin: SAME,
@@ -400,18 +410,15 @@ describe('csrfCheck safe-by-default (no proxy config)', () => {
     const message = warn.mock.calls[0]!.join(' ');
     expect(message).toContain('would be blocked in production');
     expect(message).toContain('proxy.origin');
-    warn.mockRestore();
   });
 
   test('dev + proxy.origin set + same-origin POST → null and does not warn', () => {
-    const warn = spyOn(console, 'warn').mockImplementation(() => {});
     const r = req('POST', {
       contentType: 'application/x-www-form-urlencoded',
       origin: SAME,
     });
     expect(csrfCheck(r, sameUrl, undefined, { origin: SAME }, true)).toBeNull();
     expect(warn).not.toHaveBeenCalled();
-    warn.mockRestore();
   });
 });
 

--- a/packages/mochi/src/runtime/enhance.client.test.ts
+++ b/packages/mochi/src/runtime/enhance.client.test.ts
@@ -103,12 +103,12 @@ describe('enhance attachment', () => {
   test('controller.abort() during in-flight fetch — result handler skipped, AbortError swallowed, onPending(false) still fires', async () => {
     const form = makeForm();
 
-    let signalAbortedAtReject = false;
+    let fetchSignal: AbortSignal | undefined;
     setFetch((_url, init) => {
       const signal = init?.signal as AbortSignal;
+      fetchSignal = signal;
       return new Promise((_resolve, reject) => {
         signal.addEventListener('abort', () => {
-          signalAbortedAtReject = signal.aborted;
           const err = new Error('aborted');
           (err as { name: string }).name = 'AbortError';
           reject(err);
@@ -118,10 +118,12 @@ describe('enhance attachment', () => {
 
     const pendingValues: boolean[] = [];
     let callbackInvoked = false;
+    let submitController: AbortController | undefined;
     const settled = deferred();
 
     const cleanup = attach(form, {
       submit: ({ controller }) => {
+        submitController = controller;
         // Abort once the fetch is in-flight (next macrotask).
         setTimeout(() => controller.abort(), 5);
         return () => {
@@ -140,7 +142,8 @@ describe('enhance attachment', () => {
     await settled.promise;
 
     expect(callbackInvoked).toBe(false);
-    expect(signalAbortedAtReject).toBe(true);
+    // The signal handed to fetch must be the very controller exposed to submit
+    expect(fetchSignal).toBe(submitController!.signal);
     expect(pendingValues).toEqual([true, false]);
     cleanup();
   });

--- a/packages/mochi/src/runtime/forms.fuzz.test.ts
+++ b/packages/mochi/src/runtime/forms.fuzz.test.ts
@@ -47,19 +47,21 @@ describe('form action results — property-based fuzzing', () => {
 });
 
 describe('isEnhanceRequest — property-based fuzzing', () => {
+  // Header-legal values only, so every run reaches isEnhanceRequest instead of being skipped by a Request constructor throw.
+  const acceptValue = fc.oneof(fc.stringMatching(/^[\x20-\x7e]*$/), fc.constantFrom('application/json', 'text/html', '*/*', 'text/html,application/json;q=0.9'));
+
   test('returns a boolean and never throws for arbitrary method / headers', () => {
     fc.assert(
-      fc.property(fc.constantFrom('POST', 'GET', 'PUT', 'HEAD'), fc.string(), fc.constantFrom('true', 'false', ''), (method, accept, actionHeader) => {
-        let request: Request;
-        try {
-          request = new Request('http://localhost:3333/submit', {
-            method,
-            headers: { accept, 'x-mochi-action': actionHeader },
-          });
-        } catch {
-          return; // unparseable header value — not isEnhanceRequest's concern
-        }
-        expect(typeof isEnhanceRequest(request)).toBe('boolean');
+      fc.property(fc.constantFrom('POST', 'GET', 'PUT', 'HEAD'), acceptValue, fc.constantFrom('true', 'false', ''), (method, accept, actionHeader) => {
+        const request = new Request('http://localhost:3333/submit', {
+          method,
+          headers: { accept, 'x-mochi-action': actionHeader },
+        });
+        let result: unknown;
+        expect(() => {
+          result = isEnhanceRequest(request);
+        }).not.toThrow();
+        expect(typeof result).toBe('boolean');
       }),
       RUNS,
     );

--- a/packages/mochi/src/runtime/handleError.redirect.test.ts
+++ b/packages/mochi/src/runtime/handleError.redirect.test.ts
@@ -36,6 +36,7 @@ describe('handleError returning Response.redirect', () => {
       handleError,
       routes: {
         '/redirect-me': Mochi.page(THROWING_PAGE),
+        '/no-override': Mochi.page(THROWING_PAGE),
       },
     });
     base = `http://localhost:${server.port}`;
@@ -50,5 +51,12 @@ describe('handleError returning Response.redirect', () => {
     const res = await fetch(`${base}/redirect-me/`, { redirect: 'manual' });
     expect(res.status).toBe(302);
     expect(res.headers.get('Location')).toBe(`${base}/landing`);
+  });
+
+  test('non-matching path falls through to the error page', async () => {
+    const res = await fetch(`${base}/no-override/`, { redirect: 'manual' });
+    expect(res.status).toBe(500);
+    expect(res.headers.get('Location')).toBeNull();
+    expect(res.headers.get('Content-Type')).toContain('text/html');
   });
 });

--- a/packages/mochi/src/runtime/publicDirMissingWarning.test.ts
+++ b/packages/mochi/src/runtime/publicDirMissingWarning.test.ts
@@ -3,7 +3,7 @@
 // manifest's build-time count the only witness. This exercises the boot check that reads it, in its own file because
 // one `Mochi.serve()` is allowed per process (publicDirProduction.test.ts covers the healthy-boot side).
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import type { Server } from 'bun';
 import { build } from '../cli/build';
@@ -28,6 +28,9 @@ describe('a deploy that left publicDir behind warns at boot', () => {
     outDir = tempDir('.mochi-public-missing-out-');
     writeFileSync(path.join(publicDir, 'robots.txt'), 'User-agent: *\nDisallow:\n');
     writeFileSync(path.join(publicDir, 'favicon.ico'), 'x');
+    // A nested file proves the recorded count is the recursive scan, not a top-level readdir.
+    mkdirSync(path.join(publicDir, 'assets'));
+    writeFileSync(path.join(publicDir, 'assets', 'logo.svg'), '<svg></svg>');
 
     await build({ routes, development: false, outDir, publicDir });
     manifest = JSON.parse(await Bun.file(path.join(outDir, 'manifest.json')).text());
@@ -55,13 +58,13 @@ describe('a deploy that left publicDir behind warns at boot', () => {
   });
 
   test('the build records how many static files it saw', () => {
-    expect(manifest.publicFileCount).toBe(2);
+    expect(manifest.publicFileCount).toBe(3);
   });
 
   test('boot warns once, with the count and something to do about it', () => {
     const hits = warnings.filter((w) => w.includes('every static file will 404'));
     expect(hits).toHaveLength(1);
-    expect(hits[0]).toContain('2 file(s)');
+    expect(hits[0]).toContain('3 file(s)');
     expect(hits[0]).toContain('COPY');
   });
 

--- a/packages/mochi/src/runtime/rateLimit.postgres.integration.test.ts
+++ b/packages/mochi/src/runtime/rateLimit.postgres.integration.test.ts
@@ -40,16 +40,15 @@ describe('rateLimit postgresStore backend', () => {
     rmSync(outDir, { recursive: true, force: true });
   });
 
-  test('blocks with 429 once the limit is exhausted', async () => {
+  test('blocks with 429 once the limit is exhausted and persists the counter to Postgres over the wire', async () => {
     expect((await fetch(`${base}/api/limited`)).status).toBe(200);
     expect((await fetch(`${base}/api/limited`)).status).toBe(200);
     expect((await fetch(`${base}/api/limited`)).status).toBe(429);
-  });
 
-  test('persists the counter to Postgres over the wire', async () => {
     const { rows } = await pg.query<{ key: string; count: number }>('SELECT key, count FROM hitlimit_hits');
     expect(rows).toHaveLength(1);
     const [row] = rows;
-    expect(Number(row?.count)).toBeGreaterThanOrEqual(2);
+    // hitlimit's hit() increments unconditionally, so the blocked third request still bumps the counter.
+    expect(Number(row?.count)).toBe(3);
   });
 });

--- a/packages/mochi/src/runtime/rateLimit.test.ts
+++ b/packages/mochi/src/runtime/rateLimit.test.ts
@@ -36,7 +36,8 @@ describe('createRouteLimiter', () => {
     }
     expect(third.retryAfterSeconds).toBeGreaterThan(0);
     expect(third.retryAfterSeconds).toBeLessThanOrEqual(60);
-    expect(third.headers['Retry-After']).toBeDefined();
+    expect(Number(third.headers['Retry-After'])).toBeGreaterThan(0);
+    expect(Number(third.headers['Retry-After'])).toBeLessThanOrEqual(60);
     expect(third.headers['RateLimit-Remaining']).toBe('0');
     expect(third.body.hitlimit).toBe(true);
     expect(third.body.remaining).toBe(0);

--- a/packages/mochi/src/runtime/rateLimit.warmup.test.ts
+++ b/packages/mochi/src/runtime/rateLimit.warmup.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import type { Server } from 'bun';
 import { Mochi } from '../Mochi';
-import { mochiEvents } from '../events';
+import { mochiEvents, type MochiRequestEvent } from '../events';
 
 const FIXTURE_PAGE = path.join(import.meta.dir, '..', '__fixtures__', 'css-imports', 'Page.svelte');
 
@@ -11,8 +11,15 @@ describe('rateLimit ignores warmup requests', () => {
   let server: Server<undefined>;
   let outDir: string;
   let base: string;
+  const warmupRequests: MochiRequestEvent[] = [];
+  const collectWarmupRequests = (event: MochiRequestEvent) => {
+    if (event.warmup) {
+      warmupRequests.push(event);
+    }
+  };
 
   beforeAll(async () => {
+    mochiEvents.on('request', collectWarmupRequests);
     const warmed = new Promise<void>((resolve) => {
       const handler = () => {
         mochiEvents.off('warmup:complete', handler);
@@ -36,11 +43,15 @@ describe('rateLimit ignores warmup requests', () => {
   });
 
   afterAll(() => {
+    mochiEvents.off('request', collectWarmupRequests);
     server.stop(true);
     rmSync(outDir, { recursive: true, force: true });
   });
 
   test('warmup does not consume the quota; real requests do', async () => {
+    const warmedRoot = warmupRequests.filter((event) => event.path === '/');
+    expect(warmedRoot).toHaveLength(1);
+    expect(warmedRoot[0]?.status).toBe(200);
     const firstResponse = await fetch(`${base}/`);
     expect(firstResponse.status).toBe(200);
     const secondResponse = await fetch(`${base}/`);

--- a/packages/mochi/src/runtime/requestSetup.test.ts
+++ b/packages/mochi/src/runtime/requestSetup.test.ts
@@ -94,8 +94,10 @@ describe('makeRequestContextBuilder', () => {
   test('kind: "sse" calls server.timeout(req, 0)', () => {
     const build = makeRequestContextBuilder(makeConfig());
     const { server, timeout } = mockServer();
-    build(mockReq('GET', '/'), server, { kind: 'sse', pattern: '/' });
+    const req = mockReq('GET', '/');
+    build(req, server, { kind: 'sse', pattern: '/' });
     expect(timeout).toHaveBeenCalledTimes(1);
+    expect(timeout).toHaveBeenCalledWith(req, 0);
   });
 
   test('kind: "ws" does not call server.timeout', () => {

--- a/packages/mochi/src/shutdownSignal.test.ts
+++ b/packages/mochi/src/shutdownSignal.test.ts
@@ -94,6 +94,8 @@ test('SIGTERM still exits once the grace period lapses', async () => {
   const elapsed = performance.now() - t0;
 
   expect(exitCode).toBe(0);
-  // Waited for the grace period rather than cutting the socket immediately.
+  // Waited for the grace period rather than cutting the socket immediately,
+  // but still exited shortly after it lapsed instead of lingering.
   expect(elapsed).toBeGreaterThanOrEqual(400);
+  expect(elapsed).toBeLessThan(4_000);
 }, 15_000);

--- a/packages/mochi/src/startupMemoization.test.ts
+++ b/packages/mochi/src/startupMemoization.test.ts
@@ -11,11 +11,14 @@ describe('startup memoization', () => {
   test('buildInlineWebComponent produces a correct, non-empty bundle', async () => {
     const script = await buildInlineWebComponent('./web-components/ServerIsland.ts');
     expect(script.length).toBeGreaterThan(0);
-    // The ServerIsland web component registers a custom element; the minified
-    // bundle must still reference the custom-element registry.
-    expect(script).toContain('customElements');
+    // The registration call and the tag-name literal both survive minification,
+    // so their presence proves the element is actually defined, not just referenced.
+    expect(script).toContain('customElements.define');
+    expect(script).toContain('mochi-server-island');
   });
 
+  // Relies on run-tests.ts per-file process isolation for fresh module-level
+  // memoization state; under a shared process a prior caller would have primed it.
   test('checkEnvironment returns the same promise across calls', () => {
     expect(checkEnvironment()).toBe(checkEnvironment());
   });


### PR DESCRIPTION
## Summary

A full-suite **mutation audit** ran across all 145 test files / 1,369 tests in `packages/mochi`: every test's primary assertion was semantically inverted and the file re-run, verifying each test actually fails when its claim is violated.

**Audit verdict: the suite is healthy.** 1,366/1,369 tests failed under inversion (99.8% kill rate), zero baseline failures, and no vacuous tests. The 3 "survivors" all failed correctly in isolation — they only survived the bulk run because of a real spy-leak isolation bug the audit exposed (see below).

The audit also flagged **81 quality issues** (0 high / 9 medium / 72 low) where a test verified less than its name or comment claimed. This PR applies the fixes across 52 files. Every substantive fix was teeth-checked: the new assertion was inverted, confirmed to fail, then restored.

## Key fixes (the 9 mediums)

- **`runtime/csrf.test.ts`** — moved the `console.warn` spy into `beforeEach`/`afterEach`. The old pattern called `warn.mockRestore()` as the last statement of each test body, so any failed assertion leaked the spy into subsequent tests (order-coupling that produced all 3 false mutation survivors).
- **`middleware/compress.test.ts`** — the `isDev()` skip-compression guard was entirely untested; now pinned in both directions (dev → passthrough, prod → gzip round-trip).
- **`islands/payloadCrypto.fuzz.test.ts`** — random fuzz strings rarely hit the deflate branch; added a provably-compressible case that asserts `FLAG_COMPRESSED` actually engaged.
- **`compiler/recompileBundle.test.ts`** — the batching suite stubs `compileAll`/`buildClientBundle`; added an integration block against the real compile pipeline so the stub's contract assumptions are anchored to reality.
- **`compiler/svelteCompilerBackend.test.ts`** — the memoization test was a tautology against the fallback singleton; now proves the cache via an exactly-one-load side effect.
- **`compiler/preprocessCache.test.ts`** — now spies on `mochiEvents.emit` directly, so removing the `hasSubscribers()` gate fails the test.
- **`cache/cache.test.ts`** — the atomic-set test couldn't observe a race with sync storage; rewritten against an async backend where a non-atomic set would be visible, plus the delete+fetch contrast the name promises.
- **`compiler/unresolvedIsland.test.ts`** — awaited a floating `.rejects.toThrow()` assertion.
- **`image/resize.test.ts`** — the aspect-ratio test now asserts the derived width, not just height.

Plus ~60 low-severity tightenings: boundary-anchored cookie matchers (`seen=42` no longer matches `seen=421`), `rejects.toThrow(SyntaxError)` over `rejects.toBeDefined()`, exact event-emission counts, source-derived constants instead of duplicated magic numbers, subprocess failures surfacing stderr, and tautological asserts replaced with both-branch coverage.

4 audit recommendations were deliberately not applied (auditor marked them optional, or the recommendation's premise was verified wrong against the fixture/git history).

## Test plan

- [x] `bun run checks` green: lint, format, typecheck (0 errors), all tests (145/145 mochi files + every other workspace)
- [x] Each substantive fix inverted once more post-fix to confirm it fails (teeth check)
- [x] Diff touches only `packages/mochi/src/**/*.test.ts` — no framework source changes