### PR TITLE
fix(site): register a font for the charts demo PNG so text renders on Alpine

### DIFF
--- a/packages/site/src/demos/charts/serverChart.ts
+++ b/packages/site/src/demos/charts/serverChart.ts
@@ -1,12 +1,20 @@
 import path from 'node:path';
 import { compile, compileModule } from 'svelte/compiler';
-import { createCanvas, Path2D } from '@napi-rs/canvas';
+import { createCanvas, Path2D, GlobalFonts } from '@napi-rs/canvas';
 import { traffic } from './data.ts';
 
 // renderChart draws the marks with Path2D and expects it on globalThis.
 if (typeof globalThis.Path2D === 'undefined') {
   (globalThis as { Path2D?: unknown }).Path2D = Path2D;
 }
+
+// layerchart's canvas renderer falls back to the `sans-serif` family, which Alpine (the
+// production base image) can't resolve because it ships no fonts — so axis labels rasterize
+// blank. Register the site's UI font under that family name so text renders everywhere.
+function fontFile(pkg: string, file: string): string {
+  return path.resolve(path.dirname(Bun.resolveSync(`${pkg}/package.json`, import.meta.dir)), 'files', file);
+}
+GlobalFonts.registerFromPath(fontFile('@fontsource/public-sans', 'public-sans-latin-400-normal.woff2'), 'sans-serif');
 
 export type ChartFormat = 'png' | 'jpeg';
 


### PR DESCRIPTION
## Problem

On https://mochi.fast/demos/charts/traffic.png the axis tick labels (`0k`–`3k`, `Jan`–`Dec`) are missing in production but render fine on macOS local dev.

## Root cause

The chart PNG is rasterized by **`@napi-rs/canvas`** (via layerchart's server renderer), **not** Satori/resvg. Text is drawn with `ctx.fillText` and the font family defaults to the CSS generic **`sans-serif`** (`layerchart/dist/utils/canvas.js` → `resolvedStyles.fontFamily || 'sans-serif'`), but **no font is ever registered**.

`@napi-rs/canvas` resolves `sans-serif` through system fonts. The production image is **Alpine** (`oven/bun:*-alpine`; the only `apk add` is `ncdu`), which ships **zero fonts** — so there is nothing to match and nothing to fall back to, and glyphs draw blank (invisible on the white canvas → "white/missing text"). macOS and CI/dev containers have system fonts, so the same code renders — masking the bug. The tick color (`fill="rgba(71,85,105,0.9)"`, dark slate) was never the problem.

## Fix

Register the site's existing UI font — `@fontsource/public-sans` (already a dependency; no new package or bundled asset) — with `GlobalFonts` under the exact `sans-serif` family layerchart falls back to, before any render:

```ts
import { createCanvas, Path2D, GlobalFonts } from '@napi-rs/canvas';

function fontFile(pkg: string, file: string): string {
  return path.resolve(path.dirname(Bun.resolveSync(`${pkg}/package.json`, import.meta.dir)), 'files', file);
}
GlobalFonts.registerFromPath(fontFile('@fontsource/public-sans', 'public-sans-latin-400-normal.woff2'), 'sans-serif');
```

The `files/…woff2` lives in root `node_modules`, which **is** copied into the production image; resolution from the source location lands there (not the build cache). This also fixes non-Mac local dev and CI, not just the deployed image.

## Verification

- Dev server renders a valid PNG with dark Public Sans axis labels + the blue spline (viewed directly).
- Confirmed empirically that registering a font under a family name makes napi render text with it when it is the match/only candidate — and that on this machine text only renders because napi falls back to system fonts, which Alpine lacks.
- `bun run checks` green: typecheck 0 errors across all workspaces, tests 145/145 (mochi) + 9/9 (site).
- ⚠️ The literal fontless-Alpine run couldn't be executed in the dev environment (no Docker; napi ignores fontconfig overrides so system fonts can't be stripped locally). Worth a final confirm via a preview deploy / Alpine Docker build.