### PR TITLE
ci: pin caprover CLI to 2.3.1 for CapRover deploy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -230,10 +230,17 @@ jobs:
             caprover_token_secret: APP_TOKEN_SUPPORT_S1
 
     steps:
+      # caprover CLI pinned to 2.3.1: the caprover/deploy-from-github action
+      # installs npm `latest` unpinned, and 2.4.0 crashes on load
+      # (caprover-cli#126, duplicate `-t` short flag), so we invoke the CLI
+      # directly against a known-good version instead of via the action.
       - name: Deploy on CapRover
-        uses: caprover/deploy-from-github@v1.2.0
-        with:
-          server: '${{ secrets.APP_SERVER_S1 }}'
-          app: ${{ matrix.caprover_app }}
-          token: '${{ secrets[matrix.caprover_token_secret] }}'
-          image: '${{ matrix.image }}:main'
+        env:
+          APP_TOKEN: ${{ secrets[matrix.caprover_token_secret] }}
+        run: |
+          npm i -g caprover@2.3.1
+          caprover deploy \
+            --caproverUrl "${{ secrets.APP_SERVER_S1 }}" \
+            --appToken "$APP_TOKEN" \
+            --appName "${{ matrix.caprover_app }}" \
+            --imageName "${{ matrix.image }}:main"


### PR DESCRIPTION
## What

Replaces the `caprover/deploy-from-github@v1.2.0` step in the `deploy` job with an inline step that installs a pinned `caprover@2.3.1` and calls `caprover deploy` directly.

## Why

Deploys started failing with **no change on our side**. The action installs the CLI with an unpinned `npm i -g caprover`, and **caprover `2.4.0` (published 2026-08-05 04:35 UTC)** crashes on load:

```
Error: Cannot add option '-t, --appToken <value>' to command 'deploy' due to
conflicting flag '-t' - already used by option '-t, --tarFile <value>'
    at Command._registerOption (.../commander/lib/command.js:602:13)
```

The `deploy` command registers `-t` for both `--tarFile` and `--appToken`, and Commander 12 throws at command-build time — before any argument is parsed. Tracked upstream in [caprover-cli#159](https://github.com/caprover/caprover-cli/issues/159) / [#126](https://github.com/caprover/caprover-cli/issues/126).

Pinning the *action* to a SHA wouldn't help — the CLI is re-fetched unpinned at image-build time. So we control the version at the install site instead.

## Verification

- `npx caprover@2.4.0 deploy --help` → reproduces the crash.
- `npx caprover@2.3.1 deploy --help` → loads clean; has `--caproverUrl`, `--appToken`, `--appName`, `--imageName`.

Note: `build.yml` only runs on push to `main`, so the real deploy is exercised after merge, not on this PR.