### PR TITLE
feat: add a preconfigured PostgreSQL server to the dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -55,6 +55,23 @@ ENV LANG=en_US.UTF-8
 ENV LANGUAGE=en_US.UTF-8
 ENV LC_ALL=en_US.UTF-8
 
+# PostgreSQL 15 (bookworm), installed AFTER locale-gen so the auto-created
+# 'main' cluster is en_US.UTF-8, not C. Credentials + host access baked here;
+# the cluster is started on each container boot by start-postgres.sh.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  postgresql postgresql-contrib \
+  && apt-get clean && rm -rf /var/lib/apt/lists/* \
+  && PG_VER="$(pg_lsclusters -h | awk '{print $1; exit}')" \
+  && install -d -o postgres -g postgres -m 2775 /var/run/postgresql \
+  && sed -i "s/^#\?listen_addresses.*/listen_addresses = '*'/" \
+    "/etc/postgresql/$PG_VER/main/postgresql.conf" \
+  && echo "host all all all scram-sha-256" \
+    >> "/etc/postgresql/$PG_VER/main/pg_hba.conf" \
+  && pg_ctlcluster --skip-systemctl-redirect "$PG_VER" main start \
+  && runuser -u postgres -- psql -v ON_ERROR_STOP=1 \
+    -c "ALTER USER postgres PASSWORD 'postgres';" \
+  && pg_ctlcluster --skip-systemctl-redirect "$PG_VER" main stop
+
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \
   chown -R node:node /usr/local/share

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
     }
   },
   "runArgs": ["--add-host=host.docker.internal:host-gateway"],
-  "forwardPorts": [3333, 3334, 3335, 3336],
+  "forwardPorts": [3333, 3334, 3335, 3336, 5432],
   "portsAttributes": {
     "3333": {
       "label": "site",
@@ -27,6 +27,10 @@
     },
     "3336": {
       "label": "support",
+      "onAutoForward": "notify"
+    },
+    "5432": {
+      "label": "postgres",
       "onAutoForward": "notify"
     }
   },
@@ -60,12 +64,18 @@
   "containerEnv": {
     "NODE_OPTIONS": "--max-old-space-size=4096",
     "CLAUDE_CONFIG_DIR": "/home/node/.claude",
-    "POWERLEVEL9K_DISABLE_GITSTATUS": "true"
+    "POWERLEVEL9K_DISABLE_GITSTATUS": "true",
+    "DATABASE_URL": "postgres://postgres:postgres@localhost:5432/postgres",
+    "PGHOST": "localhost",
+    "PGPORT": "5432",
+    "PGUSER": "postgres",
+    "PGPASSWORD": "postgres",
+    "PGDATABASE": "postgres"
   },
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "mkdir -p /home/node/.claude && [ -s /home/node/.claude/settings.json ] || echo '{}' > /home/node/.claude/settings.json && tmp=$(jq -s '.[0] * .[1] * {statusLine: {type: \"command\", command: \"bash /home/node/statusline.sh\"}}' /home/node/claude-settings.json /home/node/.claude/settings.json) && printf '%s\\n' \"$tmp\" > /home/node/.claude/settings.json",
-  "postStartCommand": "bash -c \"bun install; mkdir -p ~/.local/share/code-server/User && cp -f \\\"$PWD/.devcontainer/code-server-settings.json\\\" ~/.local/share/code-server/User/settings.json 2>/dev/null; export SHELL=\\\"${SHELL:-/bin/bash}\\\"; pgrep -f 'code-server.*8080' >/dev/null 2>&1 || nohup code-server --bind-addr 0.0.0.0:8080 --auth none --disable-workspace-trust \\\"$PWD\\\" >/tmp/code-server.log 2>&1 &\"",
+  "postStartCommand": "bash -c \"bash \\\"$PWD/.devcontainer/start-postgres.sh\\\"; bun install; mkdir -p ~/.local/share/code-server/User && cp -f \\\"$PWD/.devcontainer/code-server-settings.json\\\" ~/.local/share/code-server/User/settings.json 2>/dev/null; export SHELL=\\\"${SHELL:-/bin/bash}\\\"; pgrep -f 'code-server.*8080' >/dev/null 2>&1 || nohup code-server --bind-addr 0.0.0.0:8080 --auth none --disable-workspace-trust \\\"$PWD\\\" >/tmp/code-server.log 2>&1 &\"",
   "waitFor": "postStartCommand",
   "features": {
     "ghcr.io/coder/devcontainer-features/code-server:1": {
@@ -75,5 +85,5 @@
     },
     "./codebay-tmux": {}
   },
-  "appPort": ["127.0.0.1:8005:8080", "127.0.0.1:8007:3333", "127.0.0.1:8008:3334", "127.0.0.1:8009:3335", "127.0.0.1:8010:3336"]
+  "appPort": ["127.0.0.1:8005:8080", "127.0.0.1:8007:3333", "127.0.0.1:8008:3334", "127.0.0.1:8009:3335", "127.0.0.1:8010:3336", "127.0.0.1:8045:5432"]
 }

--- a/.devcontainer/start-postgres.sh
+++ b/.devcontainer/start-postgres.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PG_VER="$(pg_lsclusters -h | awk '{print $1; exit}')"
+
+# /run may be a fresh tmpfs on each container start; recreate the socket/lock
+# dir with the ownership PostgreSQL expects. Idempotent.
+sudo install -d -o postgres -g postgres -m 2775 /var/run/postgresql
+
+if ! sudo pg_ctlcluster --skip-systemctl-redirect "$PG_VER" main status >/dev/null 2>&1; then
+  sudo pg_ctlcluster --skip-systemctl-redirect "$PG_VER" main start
+fi
+
+until pg_isready -q -h 127.0.0.1 -p 5432; do sleep 0.5; done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,16 @@ Default to Bun instead of Node.js:
 - `Bun.file` over `node:fs` readFile/writeFile.
 - Bun auto-loads `.env` — don't add `dotenv`.
 
+## PostgreSQL (dev container)
+
+A PostgreSQL 15 server runs by default inside the dev container for building Postgres-based features — started on each boot by `.devcontainer/start-postgres.sh` (Debian cluster tooling: `sudo pg_lsclusters`, `sudo pg_ctlcluster 15 main {start,stop,status}`).
+
+- **In-container**: connect at `postgres://postgres:postgres@localhost:5432/postgres`. That URL is already exported as `DATABASE_URL` (plus `PGHOST`/`PGPORT`/`PGUSER`/`PGPASSWORD`/`PGDATABASE`), so bare `psql` connects with no args and apps read `process.env.DATABASE_URL` — Bun's `bun:sql` picks it up automatically (`import { sql } from 'bun'`).
+- **Credentials**: user `postgres`, password `postgres`, database `postgres`, port `5432`.
+- **Host GUI** (TablePlus/DBeaver, from your machine): `127.0.0.1:8045`, same `postgres`/`postgres` credentials.
+- **Ephemeral**: data survives container restarts but is reset on a full rebuild — recreate schema via migrations.
+- **Tests don't use this server.** The suite runs against in-process PGlite (`packages/mochi/src/__fixtures__/postgres/startTestPostgres.ts`); never point a test at `localhost:5432`.
+
 ## Dependencies
 
 - **Avoid the SSR build's `external` list.** When a dep won't bundle in `ComponentRegistry.ts`'s `Bun.build`, swap it for a cleanly-packaged (ideally CJS) alternative rather than externalizing — `external` deps must resolve at runtime from the consumer's compiled-chunk location, which is fragile across `workspace:*` packages. Concrete precedent: `@msgpack/msgpack` (unbundleable) → `@ably/msgpack-js` (bundles clean, same byte output). Externalizing "fixed" the build but broke `mochi-minimal` at runtime.


### PR DESCRIPTION
## What

Adds a PostgreSQL 15 server to the dev container, **running by default** with preconfigured `postgres`/`postgres` credentials, so future Postgres-based framework features can be developed and exercised against a live server.

Today the repo only touches Postgres through in-process **PGlite** in tests (`packages/mochi/src/__fixtures__/postgres/startTestPostgres.ts`) — there was no persistent server to develop against. The connection convention already used across code and docs (`postgres://postgres:postgres@localhost:5432/postgres`, apps reading `process.env.DATABASE_URL`) is preserved.

## Changes

- **`.devcontainer/Dockerfile`** — install `postgresql` + `postgresql-contrib` in a `RUN` placed *after* `locale-gen` (so the auto-created `main` cluster is `en_US.UTF-8`, not `C`); open `listen_addresses`/`pg_hba` for the host-published case; bake the `postgres` password into the image. Uses `pg_lsclusters` for version detection, `runuser`, and `--skip-systemctl-redirect` (no systemd in a container).
- **`.devcontainer/start-postgres.sh`** (new) — recreates the `/var/run/postgresql` socket dir (tmpfs-safe), starts the `main` cluster idempotently on each boot, and waits on `pg_isready`.
- **`.devcontainer/devcontainer.json`** — runs the boot script first in `postStartCommand` (via `;` so a DB hiccup can't abort code-server), forwards `5432` (host `8045`, loopback), and exports `DATABASE_URL` + `PG*` in `containerEnv`.
- **`CLAUDE.md`** — new "PostgreSQL (dev container)" section: connection string, credentials, host-GUI access, ephemeral-data note, and a warning that the test suite uses PGlite, not this server.

## Behavior

- **In-container**: `psql` and `process.env.DATABASE_URL` (Bun's `bun:sql`) connect with zero config.
- **Host GUI** (TablePlus/DBeaver): `127.0.0.1:8045`, `postgres`/`postgres`.
- **Ephemeral**: data survives restarts, reset on a full rebuild.

## Verification

Installed and exercised the exact Dockerfile/boot commands in a disposable container:

- `start-postgres.sh` → cluster up, `pg_isready` passes
- `psql` connects as `postgres` → db `postgres` on `localhost:5432`
- `server_encoding = UTF8`, PostgreSQL **15.18**
- `bun:sql` app path (`import { sql } from "bun"`, reading `DATABASE_URL`) returns `[{ ok: 1 }]` — confirms SCRAM auth round-trips over the wire

> Takes effect after a **Rebuild Container**.