### PR TITLE
feat(site): add a TanStack Table tutorial demo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -210,6 +210,7 @@
         "@lucide/svelte": "^1.28.0",
         "@napi-rs/canvas": "^1.0.3",
         "@portabletext/svelte": "^3.0.1",
+        "@tanstack/svelte-table": "^9.0.0",
         "@tmcp/adapter-valibot": "0.1.6",
         "@tmcp/transport-http": "0.8.6",
         "hast-util-to-html": "^9.0.5",
@@ -531,6 +532,14 @@
     "@tailwindcss/oxide-win32-arm64-msvc": ["@tailwindcss/oxide-win32-arm64-msvc@4.3.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ=="],
 
     "@tailwindcss/oxide-win32-x64-msvc": ["@tailwindcss/oxide-win32-x64-msvc@4.3.3", "", { "os": "win32", "cpu": "x64" }, "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw=="],
+
+    "@tanstack/store": ["@tanstack/store@0.11.1", "", {}, "sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA=="],
+
+    "@tanstack/svelte-store": ["@tanstack/svelte-store@0.12.1", "", { "dependencies": { "@tanstack/store": "0.11.1" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-ZFj8gyIWHZRYLv8RHp5jhnMhvw15g86KinotrUp9RfY7ygjkU3CcaMUytIdMJ4Xzq/9GqVlAphV9gFIGKRXWSw=="],
+
+    "@tanstack/svelte-table": ["@tanstack/svelte-table@9.0.0", "", { "dependencies": { "@tanstack/svelte-store": "^0.12.0", "@tanstack/table-core": "9.0.0" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-hQBEup5JppVhYJZ1436b43MC7L2oL5wuSa/Yy5e1NS82WosLqHG7Bq/qhyk1sxw4BQHxTF0/9RzAIKRyBE0w9g=="],
+
+    "@tanstack/table-core": ["@tanstack/table-core@9.0.0", "", { "dependencies": { "@tanstack/store": "^0.11.0" } }, "sha512-IyKCc4D7d/+I9euQntlVDQ7lnilmFRKpIROBeI5/866adFy+65xWvCFPz76NZ5j2lXe/RFDvFVV7bfETmwHEMA=="],
 
     "@tmcp/adapter-valibot": ["@tmcp/adapter-valibot@0.1.6", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@valibot/to-json-schema": "^1.3.0", "valibot": "^1.1.0" }, "peerDependencies": { "tmcp": "^1.17.0" } }, "sha512-drirZeNinhYLiRSMksN+m//u0ImFxtGRk1Vp425Xp/7CbBXFQdjAG+f7grssyHAukbVTGzmWsMMP6ejrGVErUA=="],
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -21,6 +21,7 @@
     "@lucide/svelte": "^1.28.0",
     "@napi-rs/canvas": "^1.0.3",
     "@portabletext/svelte": "^3.0.1",
+    "@tanstack/svelte-table": "^9.0.0",
     "@tmcp/adapter-valibot": "0.1.6",
     "@tmcp/transport-http": "0.8.6",
     "hast-util-to-html": "^9.0.5",

--- a/packages/site/src/demos/tanstack-table/BasicTable.svelte
+++ b/packages/site/src/demos/tanstack-table/BasicTable.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { createTable, FlexRender, tableFeatures } from '@tanstack/svelte-table';
+  import type { ColumnDef } from '@tanstack/svelte-table';
+  import { people, type Person } from './data.ts';
+
+  const features = tableFeatures({});
+
+  const columns: ColumnDef<typeof features, Person>[] = [
+    { accessorKey: 'firstName', header: 'First name', cell: (info) => info.getValue() },
+    { accessorKey: 'lastName', header: 'Last name', cell: (info) => info.getValue() },
+    { accessorKey: 'age', header: 'Age', cell: (info) => info.getValue() },
+  ];
+
+  const table = createTable({
+    features,
+    columns,
+    get data() {
+      return people;
+    },
+  });
+</script>
+
+<div class="table-wrap">
+  <table>
+    <thead>
+      {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
+        <tr>
+          {#each headerGroup.headers as header (header.id)}
+            <th>
+              {#if !header.isPlaceholder}
+                <FlexRender {header} />
+              {/if}
+            </th>
+          {/each}
+        </tr>
+      {/each}
+    </thead>
+    <tbody>
+      {#each table.getRowModel().rows as row (row.id)}
+        <tr>
+          {#each row.getAllCells() as cell (cell.id)}
+            <td><FlexRender {cell} /></td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md, 8px);
+    background: var(--surface);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    color: var(--text);
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.55rem 0.85rem;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+
+  th {
+    font-weight: 600;
+    color: var(--text-muted);
+    background: var(--surface-muted);
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+</style>

--- a/packages/site/src/demos/tanstack-table/SortableTable.svelte
+++ b/packages/site/src/demos/tanstack-table/SortableTable.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import { createSortedRowModel, createTable, FlexRender, rowSortingFeature, sortFns, tableFeatures } from '@tanstack/svelte-table';
+  import type { ColumnDef } from '@tanstack/svelte-table';
+  import { people, type Person } from './data.ts';
+
+  const features = tableFeatures({
+    rowSortingFeature,
+    sortedRowModel: createSortedRowModel(),
+    sortFns,
+  });
+
+  const columns: ColumnDef<typeof features, Person>[] = [
+    { accessorKey: 'firstName', header: 'First name', cell: (info) => info.getValue() },
+    { accessorKey: 'lastName', header: 'Last name', cell: (info) => info.getValue() },
+    { accessorKey: 'age', header: 'Age', cell: (info) => info.getValue() },
+  ];
+
+  const table = createTable({
+    features,
+    columns,
+    get data() {
+      return people;
+    },
+  });
+</script>
+
+<div class="table-wrap">
+  <table>
+    <thead>
+      {#each table.getHeaderGroups() as headerGroup (headerGroup.id)}
+        <tr>
+          {#each headerGroup.headers as header (header.id)}
+            <th>
+              {#if !header.isPlaceholder}
+                <button
+                  type="button"
+                  class="sort"
+                  class:active={header.column.getIsSorted() !== false}
+                  disabled={!header.column.getCanSort()}
+                  onclick={header.column.getToggleSortingHandler()}
+                >
+                  <FlexRender {header} />
+                  <span class="arrow" aria-hidden="true">
+                    {#if header.column.getIsSorted() === 'asc'}
+                      ▲
+                    {:else if header.column.getIsSorted() === 'desc'}
+                      ▼
+                    {/if}
+                  </span>
+                </button>
+              {/if}
+            </th>
+          {/each}
+        </tr>
+      {/each}
+    </thead>
+    <tbody>
+      {#each table.getRowModel().rows as row (row.id)}
+        <tr>
+          {#each row.getAllCells() as cell (cell.id)}
+            <td><FlexRender {cell} /></td>
+          {/each}
+        </tr>
+      {/each}
+    </tbody>
+  </table>
+</div>
+
+<style>
+  .table-wrap {
+    overflow-x: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md, 8px);
+    background: var(--surface);
+  }
+
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+    color: var(--text);
+  }
+
+  th,
+  td {
+    text-align: left;
+    padding: 0.2rem 0.35rem;
+    border-bottom: 1px solid var(--border);
+    white-space: nowrap;
+  }
+
+  td {
+    padding: 0.55rem 0.85rem;
+  }
+
+  th {
+    background: var(--surface-muted);
+  }
+
+  .sort {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    width: 100%;
+    padding: 0.35rem 0.5rem;
+    background: none;
+    border: none;
+    border-radius: 5px;
+    font: inherit;
+    font-weight: 600;
+    color: var(--text-muted);
+    cursor: pointer;
+    transition: color 0.12s ease;
+  }
+
+  .sort:not(:disabled):hover {
+    color: var(--text);
+  }
+
+  .sort.active {
+    color: var(--accent);
+  }
+
+  .sort:disabled {
+    cursor: default;
+  }
+
+  .arrow {
+    font-size: 0.7em;
+    min-width: 0.8em;
+  }
+
+  tbody tr:last-child td {
+    border-bottom: none;
+  }
+</style>

--- a/packages/site/src/demos/tanstack-table/TanStackTable.svelte
+++ b/packages/site/src/demos/tanstack-table/TanStackTable.svelte
@@ -1,0 +1,125 @@
+<script>
+  import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
+  import BasicTable from './BasicTable.svelte';
+  import SortableTable from './SortableTable.svelte';
+  import { loadSources } from '../../components/utils.ts';
+  import { highlightCode } from '../../lib/highlight.server';
+  import { files } from './files.ts';
+
+  const sources = await loadSources(files);
+
+  const codeInstall = await highlightCode('bun add @tanstack/svelte-table', 'bash');
+  const codeUsage = await highlightCode(
+    `import { createTable, FlexRender, tableFeatures } from '@tanstack/svelte-table';
+
+const table = createTable({
+  features: tableFeatures({}), // opt into features (sorting, filtering…) as you need them
+  columns,
+  get data() {
+    return people; // a getter keeps the table in sync with your $state
+  },
+});
+// then render table.getHeaderGroups() / table.getRowModel() with <FlexRender />`,
+    'typescript',
+  );
+</script>
+
+<DemoPage
+  title="Tables with TanStack Table"
+  description="TanStack Table is a headless table library. A read-only table renders entirely on the server and ships zero JavaScript; interactive features like sorting opt into a mochi:hydrate island."
+  {sources}
+>
+  <div class="intro">
+    <p>
+      TanStack Table needs no special setup — it's a headless, framework-agnostic table library with a Svelte 5 runes adapter. You install it and import from <code
+        >@tanstack/svelte-table</code
+      >; in Mochi it bundles straight into whichever island imports it.
+    </p>
+    <CodeSnippet html={codeInstall} />
+    <p>
+      Declare which features you need with <code>tableFeatures</code>, pass your <code>columns</code> and
+      <code>data</code>, then render the header/cell definitions with <code>&lt;FlexRender /&gt;</code>:
+    </p>
+    <CodeSnippet html={codeUsage} />
+    <p>
+      Full API at <a href="https://tanstack.com/table" target="_blank" rel="noopener noreferrer">tanstack.com/table</a>.
+    </p>
+  </div>
+
+  <section class="card">
+    <header>
+      <h2>Read-only table — server-rendered, zero JS</h2>
+      <p>
+        The whole table is plain server HTML: no <code>mochi:hydrate</code>, so nothing ships to the browser. This only makes sense when you don't need sorting, filtering, or any
+        client interaction — otherwise reach for an island.
+      </p>
+    </header>
+    <BasicTable />
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>Sortable table — <code>mochi:hydrate</code></h2>
+      <p>
+        Registering <code>rowSortingFeature</code> makes the headers clickable — cycle ascending → descending → unsorted. Sorting runs on the client, so this card is a hydrated island.
+      </p>
+    </header>
+    <SortableTable mochi:hydrate />
+  </section>
+</DemoPage>
+
+<style>
+  .intro {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0 0 1.75rem;
+  }
+
+  .intro p {
+    margin: 0 0 0.75rem;
+  }
+
+  .intro a {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+
+  .intro > p:last-child {
+    margin-bottom: 0;
+  }
+
+  .intro p code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
+  .card {
+    margin-bottom: 2rem;
+  }
+
+  .card header {
+    margin-bottom: 0.9rem;
+  }
+
+  .card header p {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0.25rem 0 0;
+  }
+
+  .card header code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+</style>

--- a/packages/site/src/demos/tanstack-table/data.ts
+++ b/packages/site/src/demos/tanstack-table/data.ts
@@ -1,0 +1,9 @@
+export type Person = { firstName: string; lastName: string; age: number };
+
+export const people: Person[] = [
+  { firstName: 'tanner', lastName: 'linsley', age: 24 },
+  { firstName: 'tandy', lastName: 'miller', age: 40 },
+  { firstName: 'joe', lastName: 'dirte', age: 45 },
+  { firstName: 'kevin', lastName: 'vandy', age: 33 },
+  { firstName: 'nora', lastName: 'reed', age: 29 },
+];

--- a/packages/site/src/demos/tanstack-table/files.ts
+++ b/packages/site/src/demos/tanstack-table/files.ts
@@ -1,0 +1,10 @@
+import type { SourceSpec } from '../../components/utils.ts';
+
+export const files: SourceSpec[] = [
+  { label: 'TanStackTable.svelte', path: './src/demos/tanstack-table/TanStackTable.svelte' },
+  { label: 'BasicTable.svelte', path: './src/demos/tanstack-table/BasicTable.svelte' },
+  { label: 'SortableTable.svelte', path: './src/demos/tanstack-table/SortableTable.svelte' },
+  { label: 'data.ts', path: './src/demos/tanstack-table/data.ts' },
+  { label: 'routes.ts', path: './src/demos/tanstack-table/routes.ts' },
+  { label: 'index.ts', path: './src/demoIndex.ts' },
+];

--- a/packages/site/src/demos/tanstack-table/routes.ts
+++ b/packages/site/src/demos/tanstack-table/routes.ts
@@ -1,0 +1,6 @@
+import { Mochi } from 'mochi-framework';
+import type { MochiRouteValue } from 'mochi-framework';
+
+export const routes: Record<string, MochiRouteValue> = {
+  '/demos/tanstack-table': Mochi.page('./src/demos/tanstack-table/TanStackTable.svelte'),
+};

--- a/packages/site/src/lib/demoIcons.ts
+++ b/packages/site/src/lib/demoIcons.ts
@@ -55,6 +55,7 @@ import Recycle from '@lucide/svelte/icons/recycle';
 import ChartSpline from '@lucide/svelte/icons/chart-spline';
 import Atom from '@lucide/svelte/icons/atom';
 import TextQuote from '@lucide/svelte/icons/text-quote';
+import Table from '@lucide/svelte/icons/table';
 
 export interface DemoIconMeta {
   icon: Component;
@@ -118,4 +119,5 @@ export const demoIconFor: Record<string, DemoIconMeta> = {
   'File Routes': { icon: FileDown, label: 'Serve a file from disk with Mochi.file()' },
   'Charts with LayerChart': { icon: ChartSpline, label: 'A third-party Svelte chart library, SSR + islands' },
   'Portable Text': { icon: TextQuote, label: 'Render Portable Text JSON with your own Svelte components' },
+  'Tables with TanStack Table': { icon: Table, label: 'A headless table library, SSR + a hydrated sortable island' },
 };

--- a/packages/site/src/lib/demos.ts
+++ b/packages/site/src/lib/demos.ts
@@ -50,6 +50,7 @@ import { files as serverIsland } from '../demos/server-island/files.ts';
 import { files as serverProps } from '../demos/server-props/files.ts';
 import { files as sharedState } from '../demos/shared-state/files.ts';
 import { files as streams } from '../demos/streams/files.ts';
+import { files as tanstackTable } from '../demos/tanstack-table/files.ts';
 import { files as url } from '../demos/url/files.ts';
 import { files as viewTransitions } from '../demos/view-transitions/files.ts';
 
@@ -521,6 +522,14 @@ export const demos: Demo[] = [
     files: runed,
     title: 'Runed Utilities',
     hook: "How third-party Svelte 5 libraries run in islands — Runed's reactive utilities (Debounced, StateHistory, PersistedState, PressedKeys, AnimationFrames, FiniteStateMachine, resource…) hydrated inside Mochi.",
+    category: 'hydration',
+  },
+  {
+    href: '/demos/tanstack-table/',
+    slug: 'tanstack-table',
+    files: tanstackTable,
+    title: 'Tables with TanStack Table',
+    hook: 'How a headless table library works in Mochi — TanStack Table server-rendered to a read-only table with zero JavaScript, then a mochi:hydrate island for interactive sorting.',
     category: 'hydration',
   },
 ];

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -72,6 +72,7 @@ import { routes as shotRoutes } from './shot/routes';
 import { routes as serverPropsRoutes } from './demos/server-props/routes';
 import { routes as sharedStateRoutes } from './demos/shared-state/routes';
 import { routes as streamsRoutes } from './demos/streams/routes';
+import { routes as tanstackTableRoutes } from './demos/tanstack-table/routes';
 import { routes as urlRoutes } from './demos/url/routes';
 import { routes as viewTransitionsRoutes } from './demos/view-transitions/routes';
 import { routes as customTransitionsRoutes } from './demos/custom-transitions/routes';
@@ -352,6 +353,7 @@ export const routes: Record<string, MochiRouteValue> = {
   ...shotRoutes,
   ...sharedStateRoutes,
   ...streamsRoutes,
+  ...tanstackTableRoutes,
   ...urlRoutes,
   ...viewTransitionsRoutes,
   ...customTransitionsRoutes,


### PR DESCRIPTION
## What

A short, minimal tutorial demo showing how to use **TanStack Table** (`@tanstack/svelte-table@9`) inside Mochi, at **`/demos/tanstack-table/`**. It follows the existing library-demo conventions (`runed`, `charts`).

It teaches two things at once — how to wire TanStack Table in Svelte 5, and Mochi's selective hydration — with two cards:

1. **Read-only table — server-rendered, zero JS.** A plain `createTable` + `<FlexRender>` table rendered **without** `mochi:hydrate`. It ships no JavaScript; the copy notes this only makes sense when you don't need sorting, filtering, or any client interaction.
2. **Sortable table — `mochi:hydrate` island.** The same data plus `rowSortingFeature` + `createSortedRowModel()`; clicking a header sorts on the client, so it's a hydrated island.

## Files

- New `packages/site/src/demos/tanstack-table/` — `TanStackTable.svelte` (entry), `BasicTable.svelte` (SSR-only), `SortableTable.svelte` (island), `data.ts`, `routes.ts`, `files.ts`.
- Wired the four registration points: `src/routes.ts`, `src/lib/demos.ts`, `src/lib/demoIcons.ts` (new `Table` Lucide icon), and `packages/site/package.json` (adds `@tanstack/svelte-table`). The `/demos/tanstack-table/llms.txt` route is generated automatically.

## Verification

- SSR: both tables render fully server-side (basic table has plain-text headers; sortable table renders 3 sort buttons in the SSR HTML). `/demos/tanstack-table/llms.txt` serves all sources.
- Browser (chrome-devtools): the sortable island hydrates with **zero console errors/warnings**; the debug bar shows **Islands 1** (the basic table ships no JS). Clicking a header reorders rows with an active sort indicator.
- `lint:fix` / `format` / `typecheck` pass (0 type errors); `demoRegistry.test.ts` passes. The two `sitemap.test.ts` timeouts are pre-existing and reproduce identically on `main` without this change (cold `buildSitemapXml()` under load), so they're unrelated.