### PR TITLE
feat(site): add Varlock env-schema demo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -227,6 +227,7 @@
         "svelte-youtube-lite": "^1.3.0",
         "tmcp": "1.19.4",
         "valibot": "1.4.2",
+        "varlock": "1.16.0",
       },
       "devDependencies": {
         "@types/bun": "1.3.14",
@@ -1511,6 +1512,8 @@
     "util.promisify": ["util.promisify@1.1.3", "", { "dependencies": { "call-bind": "^1.0.8", "call-bound": "^1.0.3", "define-data-property": "^1.1.4", "define-properties": "^1.2.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "for-each": "^0.3.3", "get-intrinsic": "^1.2.6", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "object.getownpropertydescriptors": "^2.1.8", "safe-array-concat": "^1.1.3" } }, "sha512-GIEaZ6o86fj09Wtf0VfZ5XP7tmd4t3jM5aZCgmBi231D0DB1AEBa3Aa6MP48DMsAIi96WkpWLimIWVwOjbDMOw=="],
 
     "valibot": ["valibot@1.4.2", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-gjdCvJ6d3RyHAneqxMYMW9QMCwYMb3jpOO0IyHZV1bnRHFBHrX3VkIILt5XYR0WhwHiH7Mty8ovuPZ/O3gamrg=="],
+
+    "varlock": ["varlock@1.16.0", "", { "bin": { "varlock": "bin/cli.js" } }, "sha512-iDc3DHXDHL5753B+5QrFZNM3z7tafMr6iz7oR3xoXnnSw9Is+YCwKK4cnhVLn5tj5iLBhYYPuSM+T8QkVCeiuA=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "bun": ">=1.3.14"
   },
+  "varlock": {
+    "loadPath": "./src/demos/varlock/.env.schema"
+  },
   "scripts": {
     "build": "bun scripts/prebuild.ts && mochi-framework build",
     "start": "bun src/index.ts",
@@ -37,7 +40,8 @@
     "svelte-meta-tags": "^5.0.2",
     "svelte-youtube-lite": "^1.3.0",
     "tmcp": "1.19.4",
-    "valibot": "1.4.2"
+    "valibot": "1.4.2",
+    "varlock": "1.16.0"
   },
   "devDependencies": {
     "@types/bun": "1.3.14",

--- a/packages/site/src/demos/varlock/.env.schema
+++ b/packages/site/src/demos/varlock/.env.schema
@@ -1,0 +1,18 @@
+# @defaultSensitive=false @defaultRequired=infer @currentEnv=$APP_ENV
+# ---
+
+# Which environment we're running in — drives automatic loading of `.env.<env>` files.
+# @type=enum(development, preview, production)
+APP_ENV=development
+
+# The port the API listens on — coerced from string to a number.
+# @type=port
+API_PORT=8080
+
+# Built by expanding another variable — `${API_PORT}` is resolved at load time.
+# @type=url
+API_URL=http://localhost:${API_PORT}
+
+# A secret: required, redacted from logs, and validated to start with `sk-`.
+# @required @sensitive @type=string(startsWith=sk-)
+OPENAI_API_KEY=sk-demo-000000000000

--- a/packages/site/src/demos/varlock/.env.schema
+++ b/packages/site/src/demos/varlock/.env.schema
@@ -1,18 +1,18 @@
-# @defaultSensitive=false @defaultRequired=infer @currentEnv=$APP_ENV
+# @defaultSensitive=false @defaultRequired=infer @currentEnv=$DEMO_APP_ENV
 # ---
 
 # Which environment we're running in — drives automatic loading of `.env.<env>` files.
 # @type=enum(development, preview, production)
-APP_ENV=development
+DEMO_APP_ENV=development
 
 # The port the API listens on — coerced from string to a number.
 # @type=port
-API_PORT=8080
+DEMO_API_PORT=8080
 
-# Built by expanding another variable — `${API_PORT}` is resolved at load time.
+# Built by expanding another variable — `${DEMO_API_PORT}` is resolved at load time.
 # @type=url
-API_URL=http://localhost:${API_PORT}
+DEMO_API_URL=http://localhost:${DEMO_API_PORT}
 
 # A secret: required, redacted from logs, and validated to start with `sk-`.
 # @required @sensitive @type=string(startsWith=sk-)
-OPENAI_API_KEY=sk-demo-000000000000
+DEMO_SECRET_KEY=sk-demo-000000000000

--- a/packages/site/src/demos/varlock/Varlock.svelte
+++ b/packages/site/src/demos/varlock/Varlock.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+  import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
+  import Badge from '../../components/Badge.svelte';
+  import { loadSources } from '../../components/utils.ts';
+  import { highlightCode } from '../../lib/highlight.server';
+  import { files } from './files.ts';
+  import type { VarlockConfig } from './env.ts';
+
+  let { config }: { config: VarlockConfig } = $props();
+
+  const sources = await loadSources(files);
+
+  const codeInstall = await highlightCode('bun add varlock', 'bash');
+  const codeUsage = await highlightCode(
+    `import { load } from 'varlock';
+import { ENV } from 'varlock/env';
+
+await load(); // parse + validate .env.schema once at boot
+const port = ENV.API_PORT; // typed + coerced: a number, not a string`,
+    'typescript',
+  );
+</script>
+
+<DemoPage
+  title="Varlock env schemas"
+  description="Load a validated, typed .env schema with Varlock and read live config through the ENV proxy on every SSR render — with types, coercion, variable expansion, and redacted secrets."
+  {sources}
+>
+  <div class="intro">
+    <p>
+      <a href="https://varlock.dev" target="_blank" rel="noopener noreferrer">Varlock</a> turns your
+      <code>.env</code> into a validated, typed schema — a <code>.env.schema</code> annotated with JSDoc-style decorators (<code>@type</code>, <code>@required</code>,
+      <code>@sensitive</code>). Mochi renders every page on the server on each request, so there's nothing to prerender or statically inline: you <code>load()</code> the schema
+      once at boot, then read live values through the typed <code>ENV</code> proxy during SSR.
+    </p>
+    <CodeSnippet html={codeInstall} />
+    <p>Point <code>package.json</code>'s <code>varlock.loadPath</code> at your schema, then:</p>
+    <CodeSnippet html={codeUsage} />
+    <p>See the full decorator DSL at <a href="https://varlock.dev" target="_blank" rel="noopener noreferrer">varlock.dev</a>.</p>
+  </div>
+
+  <section class="card">
+    <header>
+      <h2>Resolved on this request</h2>
+      <p>These values were parsed, coerced, and validated by <code>varlock</code> during this page's SSR render.</p>
+    </header>
+    <table class="config">
+      <thead>
+        <tr><th>Variable</th><th>Value</th><th>Reads as</th></tr>
+      </thead>
+      <tbody>
+        {#each config.items as item (item.key)}
+          <tr>
+            <td class="var">
+              <code>{item.key}</code>
+              {#if item.isSensitive}<Badge kind="danger">@sensitive</Badge>{/if}
+            </td>
+            <td>
+              {#if item.isSensitive}
+                <span class="masked">••••••••</span>
+              {:else}
+                <code>{item.value}</code>
+              {/if}
+            </td>
+            <td><code>{item.jsType}</code></td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+    <p class="note">
+      <code>API_PORT</code> arrives as a JavaScript <code>number</code> ({config.apiPort}), and
+      <code>API_URL</code> already has its <code>{'${API_PORT}'}</code> reference expanded to
+      <code>{config.apiUrl}</code>. The <code>@sensitive</code> key never leaves the server — it's masked before it reaches the props, and <code>patchGlobalConsole()</code> keeps it
+      out of your logs.
+    </p>
+  </section>
+</DemoPage>
+
+<style>
+  .intro {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0 0 1.75rem;
+  }
+
+  .intro p {
+    margin: 0 0 0.75rem;
+  }
+
+  .intro a {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+
+  .intro > p:last-child {
+    margin-bottom: 0;
+  }
+
+  .intro p code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
+  .card {
+    margin-bottom: 2rem;
+  }
+
+  .card header {
+    margin-bottom: 0.9rem;
+  }
+
+  .card header p {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0.25rem 0 0;
+  }
+
+  .card header code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
+  .config {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9rem;
+  }
+
+  .config th {
+    text-align: left;
+    font-weight: 600;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    padding: 0.4rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .config td {
+    padding: 0.55rem 0.75rem;
+    border-bottom: 1px solid var(--border);
+    vertical-align: middle;
+  }
+
+  .config td.var {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .config code {
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    color: var(--text);
+  }
+
+  .masked {
+    font-family: var(--font-mono);
+    letter-spacing: 0.15em;
+    color: var(--text-muted);
+  }
+
+  .note {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    margin: 1rem 0 0;
+    line-height: 1.6;
+  }
+
+  .note code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+</style>

--- a/packages/site/src/demos/varlock/Varlock.svelte
+++ b/packages/site/src/demos/varlock/Varlock.svelte
@@ -17,7 +17,7 @@
 import { ENV } from 'varlock/env';
 
 await load(); // parse + validate .env.schema once at boot
-const port = ENV.API_PORT; // typed + coerced: a number, not a string`,
+const port = ENV.DEMO_API_PORT; // typed + coerced: a number, not a string`,
     'typescript',
   );
 </script>
@@ -69,8 +69,8 @@ const port = ENV.API_PORT; // typed + coerced: a number, not a string`,
       </tbody>
     </table>
     <p class="note">
-      <code>API_PORT</code> arrives as a JavaScript <code>number</code> ({config.apiPort}), and
-      <code>API_URL</code> already has its <code>{'${API_PORT}'}</code> reference expanded to
+      <code>DEMO_API_PORT</code> arrives as a JavaScript <code>number</code> ({config.apiPort}), and
+      <code>DEMO_API_URL</code> already has its <code>{'${DEMO_API_PORT}'}</code> reference expanded to
       <code>{config.apiUrl}</code>. The <code>@sensitive</code> key never leaves the server — it's masked before it reaches the props, and <code>patchGlobalConsole()</code> keeps it
       out of your logs.
     </p>

--- a/packages/site/src/demos/varlock/Varlock.svelte
+++ b/packages/site/src/demos/varlock/Varlock.svelte
@@ -35,9 +35,15 @@ const port = ENV.DEMO_API_PORT; // typed + coerced: a number, not a string`,
       once at boot, then read live values through the typed <code>ENV</code> proxy during SSR.
     </p>
     <CodeSnippet html={codeInstall} />
-    <p>Point <code>package.json</code>'s <code>varlock.loadPath</code> at your schema, then:</p>
+    <p>
+      Point <code>package.json</code>'s <code>varlock.loadPath</code> at your schema, then do this once at the top of your server entry — <code>index.ts</code>, before
+      <code>Mochi.serve()</code> — so config is validated before the server boots and every request can read it:
+    </p>
     <CodeSnippet html={codeUsage} />
-    <p>See the full decorator DSL at <a href="https://varlock.dev" target="_blank" rel="noopener noreferrer">varlock.dev</a>.</p>
+    <p>
+      The <code>index.ts</code> tab below shows the full wiring, including <code>patchGlobalConsole()</code> to keep secrets out of your logs. See the decorator DSL at
+      <a href="https://varlock.dev" target="_blank" rel="noopener noreferrer">varlock.dev</a>.
+    </p>
   </div>
 
   <section class="card">

--- a/packages/site/src/demos/varlock/env.ts
+++ b/packages/site/src/demos/varlock/env.ts
@@ -1,0 +1,49 @@
+import { load } from 'varlock';
+import { ENV } from 'varlock/env';
+
+// varlock's CLI generates this augmentation from the schema; we inline it so `ENV.KEY` stays fully typed.
+declare module 'varlock/env' {
+  interface TypedEnvSchema {
+    APP_ENV: 'development' | 'preview' | 'production';
+    API_PORT: number;
+    API_URL: string;
+    OPENAI_API_KEY: string;
+  }
+}
+
+export interface VarlockItem {
+  key: string;
+  value: string | null;
+  jsType: string;
+  isSensitive: boolean;
+}
+
+export interface VarlockConfig {
+  items: VarlockItem[];
+  apiUrl: string;
+  apiPort: number;
+}
+
+let cached: VarlockConfig | null = null;
+
+export async function loadVarlockConfig(): Promise<VarlockConfig> {
+  if (cached) {
+    return cached;
+  }
+
+  await load();
+
+  const graph = JSON.parse(process.env.__VARLOCK_ENV ?? '{}') as {
+    config?: Record<string, { value: unknown; isSensitive?: boolean }>;
+  };
+
+  const items: VarlockItem[] = Object.entries(graph.config ?? {}).map(([key, item]) => ({
+    key,
+    isSensitive: Boolean(item.isSensitive),
+    jsType: typeof item.value,
+    value: item.isSensitive ? null : String(item.value),
+  }));
+
+  cached = { items, apiUrl: ENV.API_URL, apiPort: ENV.API_PORT };
+  return cached;
+}

--- a/packages/site/src/demos/varlock/env.ts
+++ b/packages/site/src/demos/varlock/env.ts
@@ -4,10 +4,10 @@ import { ENV } from 'varlock/env';
 // varlock's CLI generates this augmentation from the schema; we inline it so `ENV.KEY` stays fully typed.
 declare module 'varlock/env' {
   interface TypedEnvSchema {
-    APP_ENV: 'development' | 'preview' | 'production';
-    API_PORT: number;
-    API_URL: string;
-    OPENAI_API_KEY: string;
+    DEMO_APP_ENV: 'development' | 'preview' | 'production';
+    DEMO_API_PORT: number;
+    DEMO_API_URL: string;
+    DEMO_SECRET_KEY: string;
   }
 }
 
@@ -44,6 +44,6 @@ export async function loadVarlockConfig(): Promise<VarlockConfig> {
     value: item.isSensitive ? null : String(item.value),
   }));
 
-  cached = { items, apiUrl: ENV.API_URL, apiPort: ENV.API_PORT };
+  cached = { items, apiUrl: ENV.DEMO_API_URL, apiPort: ENV.DEMO_API_PORT };
   return cached;
 }

--- a/packages/site/src/demos/varlock/files.ts
+++ b/packages/site/src/demos/varlock/files.ts
@@ -1,0 +1,9 @@
+import type { SourceSpec } from '../../components/utils.ts';
+
+export const files: SourceSpec[] = [
+  { label: 'Varlock.svelte', path: './src/demos/varlock/Varlock.svelte' },
+  { label: 'env.ts', path: './src/demos/varlock/env.ts' },
+  { label: 'routes.ts', path: './src/demos/varlock/routes.ts' },
+  { label: '.env.schema', path: './src/demos/varlock/.env.schema', lang: 'bash' },
+  { label: 'index.ts', path: './src/demos/varlock/index.ts' },
+];

--- a/packages/site/src/demos/varlock/index.ts
+++ b/packages/site/src/demos/varlock/index.ts
@@ -11,7 +11,7 @@ await load();
 patchGlobalConsole();
 
 await Mochi.serve({
-  port: ENV.API_PORT,
-  development: ENV.APP_ENV === 'development',
+  port: ENV.DEMO_API_PORT,
+  development: ENV.DEMO_APP_ENV === 'development',
   routes,
 });

--- a/packages/site/src/demos/varlock/index.ts
+++ b/packages/site/src/demos/varlock/index.ts
@@ -1,0 +1,17 @@
+import { load } from 'varlock';
+import { patchGlobalConsole } from 'varlock/patch-console';
+import { ENV } from 'varlock/env';
+import { Mochi } from 'mochi-framework';
+import { routes } from './routes';
+
+// Parse + validate `.env.schema` before any code reads config; throws on a schema violation.
+await load();
+
+// Redact every `@sensitive` value from console output for the rest of the process.
+patchGlobalConsole();
+
+await Mochi.serve({
+  port: ENV.API_PORT,
+  development: ENV.APP_ENV === 'development',
+  routes,
+});

--- a/packages/site/src/demos/varlock/routes.ts
+++ b/packages/site/src/demos/varlock/routes.ts
@@ -1,0 +1,9 @@
+import { Mochi } from 'mochi-framework';
+import type { MochiRouteValue } from 'mochi-framework';
+import { loadVarlockConfig } from './env';
+
+export const routes: Record<string, MochiRouteValue> = {
+  '/demos/varlock': Mochi.page('./src/demos/varlock/Varlock.svelte', {
+    serverProps: async () => ({ config: await loadVarlockConfig() }),
+  }),
+};

--- a/packages/site/src/lib/demoIcons.ts
+++ b/packages/site/src/lib/demoIcons.ts
@@ -55,6 +55,7 @@ import Recycle from '@lucide/svelte/icons/recycle';
 import ChartSpline from '@lucide/svelte/icons/chart-spline';
 import Atom from '@lucide/svelte/icons/atom';
 import TextQuote from '@lucide/svelte/icons/text-quote';
+import FileKey from '@lucide/svelte/icons/file-key';
 
 export interface DemoIconMeta {
   icon: Component;
@@ -63,6 +64,7 @@ export interface DemoIconMeta {
 
 export const demoIconFor: Record<string, DemoIconMeta> = {
   'Hello World': { icon: Sprout, label: 'Pure SSR' },
+  'Varlock env schemas': { icon: FileKey, label: 'Schema-validated .env read on SSR' },
   MdSvex: { icon: FileText, label: 'Markdown route via mdsvex' },
   'Server Props': { icon: PackageOpen, label: 'Server-resolved props' },
   'Hydration Modes': { icon: Layers, label: 'All hydration modes' },

--- a/packages/site/src/lib/demos.ts
+++ b/packages/site/src/lib/demos.ts
@@ -51,6 +51,7 @@ import { files as serverProps } from '../demos/server-props/files.ts';
 import { files as sharedState } from '../demos/shared-state/files.ts';
 import { files as streams } from '../demos/streams/files.ts';
 import { files as url } from '../demos/url/files.ts';
+import { files as varlock } from '../demos/varlock/files.ts';
 import { files as viewTransitions } from '../demos/view-transitions/files.ts';
 
 export type DemoCategory = 'hydration' | 'data' | 'endpoints' | 'forms' | 'errors' | 'sites';
@@ -150,6 +151,14 @@ export const demos: Demo[] = [
     files: url,
     title: 'Isomorphic URL',
     hook: 'How the isomorphic URL helper works — one import that reads the request URL on the server and window.location on the client.',
+    category: 'data',
+  },
+  {
+    href: '/demos/varlock/',
+    slug: 'varlock',
+    files: varlock,
+    title: 'Varlock env schemas',
+    hook: 'How schema-validated env works — load a typed .env.schema with Varlock and read coerced, expanded, redacted config through the ENV proxy on every SSR render.',
     category: 'data',
   },
   {

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -73,6 +73,7 @@ import { routes as serverPropsRoutes } from './demos/server-props/routes';
 import { routes as sharedStateRoutes } from './demos/shared-state/routes';
 import { routes as streamsRoutes } from './demos/streams/routes';
 import { routes as urlRoutes } from './demos/url/routes';
+import { routes as varlockRoutes } from './demos/varlock/routes';
 import { routes as viewTransitionsRoutes } from './demos/view-transitions/routes';
 import { routes as customTransitionsRoutes } from './demos/custom-transitions/routes';
 import { routes as yourFirstMochiAppRoutes } from './demos/your-first-mochi-app/routes';
@@ -353,6 +354,7 @@ export const routes: Record<string, MochiRouteValue> = {
   ...sharedStateRoutes,
   ...streamsRoutes,
   ...urlRoutes,
+  ...varlockRoutes,
   ...viewTransitionsRoutes,
   ...customTransitionsRoutes,
   ...yourFirstMochiAppRoutes,


### PR DESCRIPTION
## What

Adds a **Varlock env schemas** demo to the Mochi site showing how to use [Varlock](https://varlock.dev) (schema-validated, AI-safe `.env` files) inside a Mochi app.

Varlock's framework integrations (e.g. Vite) do build-time static substitution of `ENV.X` references. **Mochi is dynamic-SSR only** — no prerender, no static inlining — so that half doesn't apply. The correct pattern here is: `load()` + validate the schema once at boot, then read live values through the typed `ENV` proxy on **each SSR render**. This demo teaches exactly that.

### Two examples
1. **Typed/validated config read on SSR** — `@type=port` coerced to a JS `number`, `@type=url` with `${API_PORT}` expansion, `@type=enum`.
2. **Sensitive redaction** — a `@sensitive @type=string(startsWith=sk-)` key rendered masked (`••••••••`), never sent to the client; the `patchGlobalConsole()` log-redaction pattern is shown in the source.

The live "Resolved on this request" table is driven by a real `await load()` (in-process, no CLI shell-out) reading the demo's own `.env.schema` via `package.json`'s `varlock.loadPath`.

## Changes
- New demo folder `packages/site/src/demos/varlock/` — `.env.schema`, `env.ts` (memoized loader + typed `ENV` module augmentation), `index.ts` (illustrative bootstrap wiring), `Varlock.svelte`, `routes.ts`, `files.ts`
- Add `varlock@1.16.0` dependency + `varlock.loadPath` to `packages/site/package.json`
- Register the demo in `routes.ts`, `lib/demos.ts` (category `data`), `lib/demoIcons.ts` (`file-key` icon)

> Note: this demo's `index.ts` source tab is a demo-local, illustrative bootstrap (rather than the shared `demoIndex.ts`) because the demo is specifically *about* wiring Varlock into `Mochi.serve()`.

## Verification
- Live browser check at `/demos/varlock/`: table renders real resolved values (`API_PORT` → `number`, `API_URL` → `http://localhost:8080` expanded), secret masked, **zero console errors**. Confirmed the resolved secret does not leak through props.
- Lint ✅, format ✅, typecheck ✅ (0 errors), `demoRegistry.test.ts` ✅.
- `demoLlms.test.ts` passes **73/73** with an adequate timeout (it exercises the new `/demos/varlock/llms.txt` route). Its `beforeAll` cold-compiles the whole site in-process and can exceed the default hook timeout on slow machines — a pre-existing condition (fails identically on `main`), not introduced here.