### PR TITLE
feat(site): add mode-watcher library demo

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -218,6 +218,7 @@
         "mdsvex": "^0.12.8",
         "mochi-framework": "workspace:*",
         "mochi-shared": "workspace:*",
+        "mode-watcher": "1.1.0",
         "rehype-slug": "^6.0.0",
         "runed": "^0.37.1",
         "shiki": "^4.4.1",
@@ -999,6 +1000,8 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inline-style-parser": ["inline-style-parser@0.2.7", "", {}, "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
@@ -1190,6 +1193,8 @@
     "mochi-support": ["mochi-support@workspace:packages/support"],
 
     "mochi-video-animations": ["mochi-video-animations@workspace:packages/video-animations"],
+
+    "mode-watcher": ["mode-watcher@1.1.0", "", { "dependencies": { "runed": "^0.25.0", "svelte-toolbelt": "^0.7.1" }, "peerDependencies": { "svelte": "^5.27.0" } }, "sha512-mUT9RRGPDYenk59qJauN1rhsIMKBmWA3xMF+uRwE8MW/tjhaDSCCARqkSuDTq8vr4/2KcAxIGVjACxTjdk5C3g=="],
 
     "modern-tar": ["modern-tar@0.7.6", "", {}, "sha512-sweCIVXzx1aIGTCdzcMlSZt1h8k5Tmk08VNAuRk3IU28XamGiOH5ypi11g6De2CH7PhYqSSnGy2A/EFhbWnVKg=="],
 
@@ -1409,6 +1414,8 @@
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
+
     "subset-font": ["subset-font@2.5.0", "", { "dependencies": { "fontverter": "^2.0.0", "harfbuzzjs": "^0.10.3", "lodash": "^4.17.21", "p-limit": "^3.1.0" } }, "sha512-Vsa8ngQ/ohhUj0an7on49y9jLZ2rK5U+T1FzPM4/ZQY0xUy5mLis6BfFtPGzecTjFgYXQlvY7FlsJF4t3R/6Ug=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
@@ -1426,6 +1433,8 @@
     "svelte-shaker": ["svelte-shaker@0.18.1", "", { "dependencies": { "@rsvelte/compiler": "0.9.4", "magic-string": "1.0.0", "picomatch": "4.0.5", "zimmerframe": "1.1.4" }, "optionalDependencies": { "svelte-shaker-engine-scan-native": "~0.3.0" }, "peerDependencies": { "svelte": "^5.56.6" } }, "sha512-zZzDsG7OumLYk8gAH5FJv4AP4E00AWT8/emPNUsinCq3v5VOJO+coR4B2fhPmZW/v1T2lnvJRbYZ8/ANs99KWQ=="],
 
     "svelte-shaker-engine-scan-native": ["svelte-shaker-engine-scan-native@0.3.0", "", {}, "sha512-6r6UNE4Hxw92SZXqJCjuHJxeo5UhrlnH7MLe5gdsiNDGaJsEVI2wevBx2RkpM+penmoFhszFouf7nrCa1xxiBQ=="],
+
+    "svelte-toolbelt": ["svelte-toolbelt@0.7.1", "", { "dependencies": { "clsx": "^2.1.1", "runed": "^0.23.2", "style-to-object": "^1.0.8" }, "peerDependencies": { "svelte": "^5.0.0" } }, "sha512-HcBOcR17Vx9bjaOceUvxkY3nGmbBmCBBbuWLLEWO6jtmWH8f/QoWmbyUfQZrpDINH39en1b8mptfPQT9VKQ1xQ=="],
 
     "svelte-writable-derived": ["svelte-writable-derived@3.1.1", "", { "peerDependencies": { "svelte": "^3.2.1 || ^4.0.0-next.1 || ^5.0.0-next.94" } }, "sha512-w4LR6/bYZEuCs7SGr+M54oipk/UQKtiMadyOhW0PTwAtJ/Ai12QS77sLngEcfBx2q4H8ZBQucc9ktSA5sUGZWw=="],
 
@@ -1613,6 +1622,8 @@
 
     "mdsvex/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "mode-watcher/runed": ["runed@0.25.0", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-7+ma4AG9FT2sWQEA0Egf6mb7PBT2vHyuHail1ie8ropfSjvZGtEAx8YTmUjv/APCsdRRxEVvArNjALk9zFSOrg=="],
+
     "proxy-agent/lru-cache": ["lru-cache@7.18.3", "", {}, "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="],
 
     "puppeteer/devtools-protocol": ["devtools-protocol@0.0.1521046", "", {}, "sha512-vhE6eymDQSKWUXwwA37NtTTVEzjtGVfDr3pRbsWEQ5onH/Snp2c+2xZHWJJawG/0hCCJLRGt4xVtEVUVILol4w=="],
@@ -1638,6 +1649,8 @@
     "svelte-eslint-parser/espree": ["espree@10.4.0", "", { "dependencies": { "acorn": "^8.15.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.1" } }, "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ=="],
 
     "svelte-shaker/magic-string": ["magic-string@1.0.0", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-CGvjzMN08iv6w1mm4/x3Gh1hLb4VnyRUA15FFpl6CsCIGGoe36k7kY5KNz9QDbSBN5I/fWHM6ZlIkUTa5xdUEA=="],
+
+    "svelte-toolbelt/runed": ["runed@0.23.4", "", { "dependencies": { "esm-env": "^1.0.0" }, "peerDependencies": { "svelte": "^5.7.0" } }, "sha512-9q8oUiBYeXIDLWNK5DfCWlkL0EW3oGbk845VdKlPeia28l751VpfesaB/+7pI6rnbx1I6rqoZ2fZxptOJLxILA=="],
 
     "tinyglobby/picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -29,6 +29,7 @@
     "mdsvex": "^0.12.8",
     "mochi-framework": "workspace:*",
     "mochi-shared": "workspace:*",
+    "mode-watcher": "1.1.0",
     "rehype-slug": "^6.0.0",
     "runed": "^0.37.1",
     "shiki": "^4.4.1",

--- a/packages/site/src/demos/mode-watcher/ModeControls.svelte
+++ b/packages/site/src/demos/mode-watcher/ModeControls.svelte
@@ -10,6 +10,10 @@
 
   const defaultMode = $derived(initialMode === 'light' || initialMode === 'dark' ? initialMode : 'system');
 
+  // mode.current is undefined during SSR and until mode-watcher resolves on the client. Fall back to
+  // the cookie value the server used so the switch renders its final state right away — no flash.
+  const shownMode = $derived(mode.current ?? (initialMode === 'dark' ? 'dark' : 'light'));
+
   // Mirror the resolved mode into a cookie so the server can render the right theme next time —
   // mode-watcher itself only persists to localStorage, which the server can't read.
   $effect(() => {
@@ -30,7 +34,7 @@
   <div class="ssr-controls">
     <code>server sent: {initialMode ?? '(no cookie yet)'}</code>
     <button class="switch" onclick={toggleMode}>
-      {#if mode.current === 'dark'}
+      {#if shownMode === 'dark'}
         <Sun size={15} /> Light
       {:else}
         <Moon size={15} /> Dark

--- a/packages/site/src/demos/mode-watcher/ModeControls.svelte
+++ b/packages/site/src/demos/mode-watcher/ModeControls.svelte
@@ -1,0 +1,187 @@
+<script lang="ts">
+  import { ModeWatcher, toggleMode, setMode, resetMode, mode, userPrefersMode, systemPrefersMode, modeStorageKey } from 'mode-watcher';
+  import { onMount } from 'svelte';
+  import Badge from '../../components/Badge.svelte';
+
+  // resetMode() persists async, which won't flush before a hard navigation unloads the page, so
+  // clear mode-watcher's stored key synchronously on leave — the demo hands <html> back to system.
+  onMount(() => {
+    const reset = () => localStorage.removeItem(modeStorageKey.current);
+    window.addEventListener('pagehide', reset);
+    return () => window.removeEventListener('pagehide', reset);
+  });
+</script>
+
+<ModeWatcher />
+
+<div class="grid">
+  <div class="card">
+    <div class="head">
+      <h3>toggleMode</h3>
+      <span class="hint">flip the global &lt;html&gt; between light and dark</span>
+    </div>
+    <div class="preview">
+      <span class="dot"></span>
+      {#if mode.current}
+        <Badge kind={mode.current === 'dark' ? 'info' : 'success'}>{mode.current}</Badge>
+      {:else}
+        <Badge kind="warning">undefined (server)</Badge>
+      {/if}
+    </div>
+    <button class="primary" onclick={toggleMode}>Toggle mode</button>
+  </div>
+
+  <div class="card">
+    <div class="head">
+      <h3>setMode / resetMode</h3>
+      <span class="hint">user pick vs resolved vs OS</span>
+    </div>
+    <div class="actions">
+      <button onclick={() => setMode('light')}>Light</button>
+      <button onclick={() => setMode('dark')}>Dark</button>
+      <button onclick={resetMode}>System</button>
+    </div>
+    <dl class="readout">
+      <div>
+        <dt>userPrefersMode</dt>
+        <dd>{userPrefersMode.current}</dd>
+      </div>
+      <div>
+        <dt>mode (resolved)</dt>
+        <dd>{mode.current ?? '—'}</dd>
+      </div>
+      <div>
+        <dt>systemPrefersMode</dt>
+        <dd>{systemPrefersMode.current ?? '—'}</dd>
+      </div>
+    </dl>
+  </div>
+</div>
+
+<style>
+  .grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+  }
+
+  .card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.8rem;
+    padding: 1rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: var(--surface-muted);
+  }
+
+  .head {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .head h3 {
+    font-size: 1rem;
+    font-weight: 700;
+    margin: 0;
+    color: var(--text);
+    font-family: var(--font-mono);
+  }
+
+  .hint {
+    font-size: 0.75rem;
+    color: var(--text-subtle);
+  }
+
+  .preview {
+    display: flex;
+    align-items: center;
+    gap: 0.6rem;
+    padding: 0.9rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: #ffffff;
+    color: #1a1a1a;
+    transition:
+      background 0.2s ease,
+      color 0.2s ease;
+  }
+
+  :global(html.dark) .preview {
+    background: #10131a;
+    color: #f4f5f7;
+  }
+
+  .dot {
+    width: 0.9rem;
+    height: 0.9rem;
+    border-radius: 999px;
+    background: #f6c453;
+    box-shadow: 0 0 0 3px rgba(246, 196, 83, 0.25);
+  }
+
+  :global(html.dark) .dot {
+    background: #6d7ce0;
+    box-shadow: 0 0 0 3px rgba(109, 124, 224, 0.3);
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  button {
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--surface);
+    color: var(--text);
+    font: inherit;
+    cursor: pointer;
+    transition:
+      background 0.12s ease,
+      border-color 0.12s ease;
+  }
+
+  button:hover {
+    background: var(--accent-soft);
+    border-color: var(--accent);
+    color: var(--accent-soft-text);
+  }
+
+  button.primary {
+    align-self: flex-start;
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--accent-text, #fff);
+  }
+
+  .readout {
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .readout > div {
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+    gap: 0.75rem;
+  }
+
+  .readout dt {
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    font-family: var(--font-mono);
+  }
+
+  .readout dd {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-weight: 700;
+    color: var(--accent);
+  }
+</style>

--- a/packages/site/src/demos/mode-watcher/ModeControls.svelte
+++ b/packages/site/src/demos/mode-watcher/ModeControls.svelte
@@ -1,18 +1,43 @@
 <script lang="ts">
-  import { ModeWatcher, toggleMode, setMode, resetMode, mode, userPrefersMode, systemPrefersMode, modeStorageKey } from 'mode-watcher';
-  import { onMount } from 'svelte';
+  import { ModeWatcher, toggleMode, setMode, resetMode, mode, userPrefersMode, systemPrefersMode } from 'mode-watcher';
+  import { cookies, isBrowser } from 'mochi-framework';
+  import Sun from '@lucide/svelte/icons/sun';
+  import Moon from '@lucide/svelte/icons/moon';
   import Badge from '../../components/Badge.svelte';
+  import { THEME_COOKIE } from './constants';
 
-  // resetMode() persists async, which won't flush before a hard navigation unloads the page, so
-  // clear mode-watcher's stored key synchronously on leave — the demo hands <html> back to system.
-  onMount(() => {
-    const reset = () => localStorage.removeItem(modeStorageKey.current);
-    window.addEventListener('pagehide', reset);
-    return () => window.removeEventListener('pagehide', reset);
+  let { initialMode = null }: { initialMode?: string | null } = $props();
+
+  const defaultMode = $derived(initialMode === 'light' || initialMode === 'dark' ? initialMode : 'system');
+
+  // Mirror the resolved mode into a cookie so the server can render the right theme next time —
+  // mode-watcher itself only persists to localStorage, which the server can't read.
+  $effect(() => {
+    const m = mode.current;
+    if (isBrowser && (m === 'light' || m === 'dark')) {
+      cookies.set(THEME_COOKIE, m, { expires: 365, path: '/demos/mode-watcher/', sameSite: 'Lax' });
+    }
   });
 </script>
 
-<ModeWatcher />
+<ModeWatcher {defaultMode} />
+
+<header class="ssr-header">
+  <div class="ssr-copy">
+    <strong>SSR theme</strong>
+    <span>server-rendered from a cookie — no flash on reload</span>
+  </div>
+  <div class="ssr-controls">
+    <code>server sent: {initialMode ?? '(no cookie yet)'}</code>
+    <button class="switch" onclick={toggleMode}>
+      {#if mode.current === 'dark'}
+        <Sun size={15} /> Light
+      {:else}
+        <Moon size={15} /> Dark
+      {/if}
+    </button>
+  </div>
+</header>
 
 <div class="grid">
   <div class="card">
@@ -59,6 +84,69 @@
 </div>
 
 <style>
+  .ssr-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.9rem 1.1rem;
+    margin-bottom: 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    background: #ffffff;
+    color: #1a1a1a;
+    transition:
+      background 0.2s ease,
+      color 0.2s ease;
+  }
+
+  :global(html.dark) .ssr-header {
+    background: #10131a;
+    color: #f4f5f7;
+  }
+
+  .ssr-copy {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .ssr-copy strong {
+    font-size: 0.95rem;
+  }
+
+  .ssr-copy span {
+    font-size: 0.75rem;
+    opacity: 0.7;
+  }
+
+  .ssr-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .ssr-controls code {
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    opacity: 0.75;
+  }
+
+  .switch {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.4rem 0.75rem;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: var(--accent);
+    color: var(--accent-text, #fff);
+    font: inherit;
+    font-size: 0.85rem;
+    cursor: pointer;
+  }
+
   .grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/packages/site/src/demos/mode-watcher/ModeWatcher.svelte
+++ b/packages/site/src/demos/mode-watcher/ModeWatcher.svelte
@@ -1,0 +1,107 @@
+<script>
+  import DemoPage from '../../components/DemoPage.svelte';
+  import CodeSnippet from '../../components/CodeSnippet.svelte';
+  import ModeControls from './ModeControls.svelte';
+  import { loadSources } from '../../components/utils.ts';
+  import { highlightCode } from '../../lib/highlight.server';
+  import { files } from './files.ts';
+
+  const sources = await loadSources(files);
+
+  const codeInstall = await highlightCode('bun add mode-watcher', 'bash');
+  const codeUsage = await highlightCode(
+    `import { ModeWatcher, toggleMode } from 'mode-watcher';
+
+// Mount ModeWatcher once; it applies the mode to <html>.
+// <ModeWatcher />
+// <button onclick={toggleMode}>Toggle</button>`,
+    'typescript',
+  );
+</script>
+
+<DemoPage
+  title="Mode Watcher"
+  description="mode-watcher manages light/dark mode by mutating the global <html> element. Because it reads the DOM and localStorage, the whole thing lives in a mochi:hydrate island — the page renders on the server, then mode-watcher takes over on the client."
+  {sources}
+>
+  <div class="intro">
+    <p>
+      <code>mode-watcher</code> needs a little setup: you mount its <code>&lt;ModeWatcher /&gt;</code> component once, and it reads <code>localStorage</code> and applies the mode
+      to the global <code>&lt;html&gt;</code> element — adding a
+      <code>dark</code> class and setting <code>color-scheme</code>. This site drives its own theme off a
+      <code>data-theme</code> attribute, so the two coexist; leaving this page clears the stored preference so the rest of the site stays on its own theme.
+    </p>
+    <CodeSnippet html={codeInstall} />
+    <p>Mount it once, then any button can drive the mode:</p>
+    <CodeSnippet html={codeUsage} />
+    <p>
+      Full API at <a href="https://mode-watcher.dev" target="_blank" rel="noopener noreferrer">mode-watcher.dev</a>.
+    </p>
+  </div>
+
+  <section class="card">
+    <header>
+      <h2>Toggle &amp; set the mode</h2>
+      <p>
+        <code>toggleMode</code>, <code>setMode</code>, and <code>resetMode</code> drive the global theme; the
+        <code>mode</code>, <code>userPrefersMode</code>, and <code>systemPrefersMode</code> runes report the current state.
+      </p>
+    </header>
+    <ModeControls mochi:hydrate />
+  </section>
+</DemoPage>
+
+<style>
+  .intro {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0 0 1.75rem;
+  }
+
+  .intro p {
+    margin: 0 0 0.75rem;
+  }
+
+  .intro a {
+    color: var(--accent);
+    text-decoration: underline;
+  }
+
+  .intro > p:last-child {
+    margin-bottom: 0;
+  }
+
+  .intro p code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+
+  .card {
+    margin-bottom: 2rem;
+  }
+
+  .card header {
+    margin-bottom: 0.9rem;
+  }
+
+  .card header p {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+    margin: 0.25rem 0 0;
+  }
+
+  .card header code {
+    background: var(--surface-muted);
+    border: 1px solid var(--border);
+    color: var(--text);
+    font-family: var(--font-mono);
+    padding: 0.1em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+</style>

--- a/packages/site/src/demos/mode-watcher/ModeWatcher.svelte
+++ b/packages/site/src/demos/mode-watcher/ModeWatcher.svelte
@@ -6,6 +6,8 @@
   import { highlightCode } from '../../lib/highlight.server';
   import { files } from './files.ts';
 
+  let { initialMode = null } = $props();
+
   const sources = await loadSources(files);
 
   const codeInstall = await highlightCode('bun add mode-watcher', 'bash');
@@ -15,6 +17,26 @@
 // Mount ModeWatcher once; it applies the mode to <html>.
 // <ModeWatcher />
 // <button onclick={toggleMode}>Toggle</button>`,
+    'typescript',
+  );
+  const codeSsr = await highlightCode(
+    `// routes.ts — read the cookie server-side, feed it to <ModeWatcher> as defaultMode
+Mochi.page('./ModeWatcher.svelte', {
+  serverProps: () => ({ initialMode: cookies.get('mochi-demo-theme') }),
+});
+
+// and set the class on <html> before the page is sent — so there's no flash:
+export const handle = async ({ event, resolve }) => {
+  const dark = getRequestContext().cookies.get('mochi-demo-theme') === 'dark';
+  return resolve(event, dark
+    ? { transformPage: ({ html }) => html.replace('<html lang="en">', '<html lang="en" class="dark">') }
+    : undefined);
+};
+
+// island — mirror the mode back into the cookie whenever it changes (isomorphic cookies API)
+$effect(() => {
+  if (mode.current) cookies.set('mochi-demo-theme', mode.current, { expires: 365 });
+});`,
     'typescript',
   );
 </script>
@@ -29,7 +51,7 @@
       <code>mode-watcher</code> needs a little setup: you mount its <code>&lt;ModeWatcher /&gt;</code> component once, and it reads <code>localStorage</code> and applies the mode
       to the global <code>&lt;html&gt;</code> element — adding a
       <code>dark</code> class and setting <code>color-scheme</code>. This site drives its own theme off a
-      <code>data-theme</code> attribute, so the two coexist; leaving this page clears the stored preference so the rest of the site stays on its own theme.
+      <code>data-theme</code> attribute, so the two coexist without collision.
     </p>
     <CodeSnippet html={codeInstall} />
     <p>Mount it once, then any button can drive the mode:</p>
@@ -47,7 +69,25 @@
         <code>mode</code>, <code>userPrefersMode</code>, and <code>systemPrefersMode</code> runes report the current state.
       </p>
     </header>
-    <ModeControls mochi:hydrate />
+    <ModeControls {initialMode} mochi:hydrate />
+  </section>
+
+  <section class="card">
+    <header>
+      <h2>SSR-friendly theme, no flash</h2>
+      <p>
+        mode-watcher only persists to <code>localStorage</code>, which the server can't read — so on its own the first paint can flash. The bar above fixes that: the island mirrors
+        the resolved mode into a cookie, <code>serverProps</code>
+        reads it back into <code>&lt;ModeWatcher defaultMode&gt;</code>, and a <code>transformPage</code> hook stamps
+        <code>class="dark"</code> onto <code>&lt;html&gt;</code> before the response is sent. Pick a mode, then reload — the page comes back correct with no flicker (<code
+          >server sent:</code
+        >
+        shows the value the server used).
+        <code>"system"</code> can't be server-resolved without JS, so the cookie stores the resolved
+        <code>light</code>/<code>dark</code>.
+      </p>
+    </header>
+    <CodeSnippet html={codeSsr} />
   </section>
 </DemoPage>
 

--- a/packages/site/src/demos/mode-watcher/constants.ts
+++ b/packages/site/src/demos/mode-watcher/constants.ts
@@ -1,0 +1,2 @@
+// Shared by routes.ts (server read) and ModeControls.svelte (client write) so the name can't drift.
+export const THEME_COOKIE = 'mochi-demo-theme';

--- a/packages/site/src/demos/mode-watcher/files.ts
+++ b/packages/site/src/demos/mode-watcher/files.ts
@@ -4,5 +4,6 @@ export const files: SourceSpec[] = [
   { label: 'ModeWatcher.svelte', path: './src/demos/mode-watcher/ModeWatcher.svelte' },
   { label: 'ModeControls.svelte', path: './src/demos/mode-watcher/ModeControls.svelte' },
   { label: 'routes.ts', path: './src/demos/mode-watcher/routes.ts' },
+  { label: 'constants.ts', path: './src/demos/mode-watcher/constants.ts' },
   { label: 'index.ts', path: './src/demoIndex.ts' },
 ];

--- a/packages/site/src/demos/mode-watcher/files.ts
+++ b/packages/site/src/demos/mode-watcher/files.ts
@@ -1,0 +1,8 @@
+import type { SourceSpec } from '../../components/utils.ts';
+
+export const files: SourceSpec[] = [
+  { label: 'ModeWatcher.svelte', path: './src/demos/mode-watcher/ModeWatcher.svelte' },
+  { label: 'ModeControls.svelte', path: './src/demos/mode-watcher/ModeControls.svelte' },
+  { label: 'routes.ts', path: './src/demos/mode-watcher/routes.ts' },
+  { label: 'index.ts', path: './src/demoIndex.ts' },
+];

--- a/packages/site/src/demos/mode-watcher/routes.ts
+++ b/packages/site/src/demos/mode-watcher/routes.ts
@@ -1,0 +1,6 @@
+import { Mochi } from 'mochi-framework';
+import type { MochiRouteValue } from 'mochi-framework';
+
+export const routes: Record<string, MochiRouteValue> = {
+  '/demos/mode-watcher': Mochi.page('./src/demos/mode-watcher/ModeWatcher.svelte'),
+};

--- a/packages/site/src/demos/mode-watcher/routes.ts
+++ b/packages/site/src/demos/mode-watcher/routes.ts
@@ -1,6 +1,23 @@
-import { Mochi } from 'mochi-framework';
-import type { MochiRouteValue } from 'mochi-framework';
+import { Mochi, getRequestContext } from 'mochi-framework';
+import type { MochiRouteValue, Handle } from 'mochi-framework';
+import { THEME_COOKIE } from './constants';
 
 export const routes: Record<string, MochiRouteValue> = {
-  '/demos/mode-watcher': Mochi.page('./src/demos/mode-watcher/ModeWatcher.svelte'),
+  '/demos/mode-watcher': Mochi.page('./src/demos/mode-watcher/ModeWatcher.svelte', {
+    serverProps: () => ({ initialMode: getRequestContext().cookies.get(THEME_COOKIE) ?? null }),
+  }),
+};
+
+// SSR the resolved theme: read the cookie the island mirrors the mode into, and set the `dark`
+// class on <html> before it's sent so the first paint already matches — no flash on reload.
+export const handle: Handle = async ({ event, resolve }) => {
+  if (!event.url.pathname.startsWith('/demos/mode-watcher')) {
+    return resolve(event);
+  }
+  if (getRequestContext().cookies.get(THEME_COOKIE) !== 'dark') {
+    return resolve(event);
+  }
+  return resolve(event, {
+    transformPage: ({ html }) => html.replace('<html lang="en">', '<html lang="en" class="dark">'),
+  });
 };

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -11,6 +11,7 @@ import { clearDocsCaches, DOCS_DIR } from './lib/docs';
 import { clearBlogCaches, BLOG_DIR } from './lib/blog';
 import { highlightCode } from './lib/highlight.server';
 import { handle as cookieVaryTestHandle } from './demos/cookie-vary-test/routes';
+import { handle as modeWatcherHandle } from './demos/mode-watcher/routes';
 import { handle as shotHandle } from './shot/routes';
 import { encodeDebugBarGlobals } from './lib/debugBarEncode';
 import { routes, queues } from './routes';
@@ -134,7 +135,18 @@ await Mochi.serve({
   htmlShell: './src/shell.html',
   trailingSlash: 'always',
   // /ci/dashboard is a chrome-free always-on display — it would otherwise report a pageview every refresh.
-  handle: sequence(compress(), immutableAssets, helloWorld, asciiDog, analytics({ exclude: ['/ci/dashboard'] }), encodeDebugBarPaths, noCache, cookieVaryTestHandle, shotHandle),
+  handle: sequence(
+    compress(),
+    immutableAssets,
+    helloWorld,
+    asciiDog,
+    analytics({ exclude: ['/ci/dashboard'] }),
+    encodeDebugBarPaths,
+    noCache,
+    cookieVaryTestHandle,
+    modeWatcherHandle,
+    shotHandle,
+  ),
   handleError,
   idleTimeout: 60,
   compressServerIslandProps: true,

--- a/packages/site/src/lib/demoIcons.ts
+++ b/packages/site/src/lib/demoIcons.ts
@@ -56,6 +56,7 @@ import ChartSpline from '@lucide/svelte/icons/chart-spline';
 import Atom from '@lucide/svelte/icons/atom';
 import TextQuote from '@lucide/svelte/icons/text-quote';
 import Table from '@lucide/svelte/icons/table';
+import SunMoon from '@lucide/svelte/icons/sun-moon';
 
 export interface DemoIconMeta {
   icon: Component;
@@ -87,6 +88,7 @@ export const demoIconFor: Record<string, DemoIconMeta> = {
   'Font loading': { icon: Type, label: 'Bundle fontsource + standalone fonts' },
   'Crossing the server-client boundary with props': { icon: Package2, label: 'Props serialized into the island — every devalue type' },
   'HTML Entities in Props': { icon: Ampersand, label: 'HTML entities in static island props decode across SSR + hydration' },
+  'Mode Watcher': { icon: SunMoon, label: 'Light/dark mode watching in an island' },
   'Runed Utilities': { icon: Atom, label: 'Runed reactive utilities hydrated in islands' },
   'Nested Components': { icon: ListTree, label: 'Five-level deep tree under one island' },
   'Nested Islands': { icon: SquareStack, label: 'Islands nested inside server islands' },

--- a/packages/site/src/lib/demos.ts
+++ b/packages/site/src/lib/demos.ts
@@ -45,6 +45,7 @@ import { files as rateLimit } from '../demos/rate-limit/files.ts';
 import { files as reloadFormData } from '../demos/reload-form-data/files.ts';
 import { files as requestCache } from '../demos/request-cache/files.ts';
 import { files as requestId } from '../demos/request-id/files.ts';
+import { files as modeWatcher } from '../demos/mode-watcher/files.ts';
 import { files as runed } from '../demos/runed/files.ts';
 import { files as serverIsland } from '../demos/server-island/files.ts';
 import { files as serverProps } from '../demos/server-props/files.ts';
@@ -514,6 +515,14 @@ export const demos: Demo[] = [
     files: entityProps,
     title: 'HTML Entities in Props',
     hook: 'How HTML entities in island props work — an entity in a static prop (label="Tom &amp; Jerry") decodes identically on the server and after hydration.',
+    category: 'hydration',
+  },
+  {
+    href: '/demos/mode-watcher/',
+    slug: 'mode-watcher',
+    files: modeWatcher,
+    title: 'Mode Watcher',
+    hook: "Light/dark mode in an island — mode-watcher's <ModeWatcher />, toggleMode/setMode, and the mode / userPrefersMode / systemPrefersMode runes driving the global <html> theme.",
     category: 'hydration',
   },
   {

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -66,6 +66,7 @@ import { routes as rateLimitRoutes } from './demos/rate-limit/routes';
 import { routes as reloadFormDataRoutes } from './demos/reload-form-data/routes';
 import { routes as requestCacheRoutes } from './demos/request-cache/routes';
 import { routes as requestIdRoutes } from './demos/request-id/routes';
+import { routes as modeWatcherRoutes } from './demos/mode-watcher/routes';
 import { routes as runedRoutes } from './demos/runed/routes';
 import { routes as serverIslandRoutes } from './demos/server-island/routes';
 import { routes as shotRoutes } from './shot/routes';
@@ -347,6 +348,7 @@ export const routes: Record<string, MochiRouteValue> = {
   ...reloadFormDataRoutes,
   ...requestCacheRoutes,
   ...requestIdRoutes,
+  ...modeWatcherRoutes,
   ...runedRoutes,
   ...serverIslandRoutes,
   ...serverPropsRoutes,


### PR DESCRIPTION
## What

Adds a short, minimal tutorial demo showing how to use the [`mode-watcher`](https://mode-watcher.dev) light/dark-mode library inside a Mochi hydration island.

New demo at `/demos/mode-watcher/` (`packages/site/src/demos/mode-watcher/`):

- **`ModeWatcher.svelte`** — the demo page: `DemoPage` + an intro that covers setup, the `bun add mode-watcher` install line, a minimal usage snippet, and a link to the library (all four things the `add-library-demo` skill requires), then mounts one `mochi:hydrate` island.
- **`ModeControls.svelte`** — the island. Mounts `<ModeWatcher />` once and exercises the API across two small interactive examples:
  1. `toggleMode` with a live preview panel that reacts to the global `dark` class, plus a badge showing the SSR (`undefined`) → client (`light`/`dark`) transition.
  2. `setMode('light'|'dark')` / `resetMode` with a live readout of `userPrefersMode` vs `mode` (resolved) vs `systemPrefersMode`.

Everything lives in a **single island** because `mode-watcher`'s module-singleton state isn't shared across separate island bundles.

## Notes

- `mode-watcher` mutates the **global** `<html>` element (adds a `dark` class, sets `color-scheme`). The site's own theme system keys off a `data-theme` **attribute**, so the two coexist without collision.
- Leaving the page clears the stored preference on `pagehide`. `resetMode()` persists asynchronously via runed's `PersistedState`, whose effect never flushes before a hard navigation unloads the page, so the key is cleared synchronously instead — this hands `<html>` back to the rest of the site.

## Wiring

Registered at the four standard points: `routes.ts`, `lib/demos.ts`, `lib/demoIcons.ts` (new `sun-moon` Lucide icon), and `files.ts`. Added `mode-watcher@1.1.0` to `packages/site`.

## Verification

- `bun run checks` — lint, format, typecheck all clean; **mochi-site tests 9/9 pass** (including `demoRegistry`/`demoLlms`).
- Drove a real browser against `/demos/mode-watcher/`: island hydrates with zero console errors, toggle/set/reset all drive the global `<html>` `dark` class + `color-scheme`, readouts update, `data-theme` stays untouched, and `pagehide` clears the stored key on leave.

<sub>Note: a couple of pre-existing wall-clock-sensitive tests in unrelated packages (`mochi-support`, `mochi` captcha) flake under parallel/CPU-loaded `bun --filter` runs but pass in isolation; they don't touch this change.</sub>