### PR TITLE
docs: restore facts dropped in the STE rewrite

### DIFF
--- a/packages/docs/100-websocket-routes.md
+++ b/packages/docs/100-websocket-routes.md
@@ -135,7 +135,7 @@ Every socket exposes `ws.subscribe(topic)`, `ws.publish(topic, data)`, and `ws.u
 
 ### Lifecycle events
 
-Every WebSocket emits `ws:open`, `ws:message`, and `ws:close` on `mochiEvents`. `logger()` prints them. See [Events](/docs/events/) for the payload shape.
+Every WebSocket emits `ws:open`, `ws:message`, and `ws:close` on `mochiEvents`. `consoleLogger()` prints them. See [Events](/docs/events/) for the payload shape.
 
 <SeeItInAction
 demos={[

--- a/packages/docs/110-server-sent-events.md
+++ b/packages/docs/110-server-sent-events.md
@@ -65,7 +65,7 @@ stream.onClose(() => sub.unsubscribe());
 
 ### Events
 
-`Mochi.sse` emits `sse:open`, `sse:message`, and `sse:close` on `mochiEvents`. `logger()` prints them by default.
+`Mochi.sse` emits `sse:open`, `sse:message`, and `sse:close` on `mochiEvents`. `consoleLogger()` prints them by default.
 
 <SeeItInAction
 demos={[{ href: "/demos/streams/", title: "Real-time Streams", hook: "How server-sent events and WebSocket streaming work — live SSE and WebSocket clocks, lazily hydrated via mochi:hydrate:visible." }]}

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -140,7 +140,7 @@ Mochi.queue({ process: resizeImage, lockDuration: 60_000 });
 
 <Callout type="warning">
 
-`lockDuration` must exceed the **worst-case** runtime of `process`, not the typical one. A job that overruns is re-queued mid-flight. Its eventual success is rejected as `Invalid or expired lock token` and reported as a failure, even though the work succeeded.
+`lockDuration` must exceed the **worst-case** runtime of `process`, not the typical one. A job that overruns is re-queued mid-flight. Its eventual success is rejected as `Invalid or expired lock token` and reported as a failure, even though the work succeeded. The queue then either retries the job, which fires its side effects a second time, or abandons it where it stands.
 
 </Callout>
 
@@ -149,6 +149,8 @@ Mochi.queue({ process: resizeImage, lockDuration: 60_000 });
 **30 minutes is a ceiling, not just a default.** The queue drops any job that runs longer, whatever `lockDuration` says. Work that can run longer belongs outside the queue, or split into jobs that each finish well inside the limit.
 
 </Callout>
+
+Lowering `lockDuration` does not make a crashed worker's jobs recover faster. Heartbeat-based stall detection handles that, independently of the lock.
 
 ### Recovery on start
 

--- a/packages/docs/116-email.md
+++ b/packages/docs/116-email.md
@@ -213,7 +213,7 @@ Email templates always render outside the request context, even when sent from a
 
 <Callout type="warning">
 
-`<script>` tags in an email body are stripped during rendering. Email clients block scripts, so a script only bloats the message and trips spam filters. This applies to scripts you emit into the markup, for example through `<svelte:head>` or `{@html}`.
+`<script>` tags in an email body are stripped during rendering. Email clients block scripts, so a script only bloats the message and trips spam filters. The component's own `<script>` block (props, logic) is compile-time and never reaches the output, so it is unaffected. The strip applies to scripts you emit into the markup, for example through `<svelte:head>` or `{@html}`.
 
 </Callout>
 

--- a/packages/docs/122-rate-limiting.md
+++ b/packages/docs/122-rate-limiting.md
@@ -141,6 +141,8 @@ tier: (req, ctx) => (ctx.locals.plan as string) ?? 'free',
 ```ts
 skip: async (req) => {
   const header = req.headers.get('Authorization');
+  // No credentials at all is a browser fetching the 401 challenge, not a guess:
+  // do not stall it, and do not charge it quota.
   if (!header || credentialsMatch(header)) return true;
   await Bun.sleep(5000);
   return false;

--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -63,7 +63,7 @@ Use it from a page or API route:
 | `delete(key)`              | `Promise<void>`                      |
 | `clearItems()`             | `Promise<void>`                      |
 
-`peek(key)` reports a key's `status` and value **without** running `fn`, revalidating, or emitting `cache:read` — a pure probe that returns `null` on a miss. `markStale(key)` backdates an entry so its next read serves stale-while-revalidate. `set(key, value)` writes a value directly, stamped fresh. Prefer `set` over `delete(key)` then `fetch`: that sequence leaves the key absent, so concurrent readers each start their own recompute.
+`peek(key)` reports a key's `status` and value **without** running `fn`, revalidating, or emitting `cache:read` — a pure probe that returns `null` on a miss. `markStale(key)` backdates an entry so its next read serves stale-while-revalidate. It is a no-op on a missing or already-stale key, and it never freshens or un-expires one. Both run through the `storage` interface, so they apply to any backend. `set(key, value)` writes a value directly, stamped fresh. Prefer `set` over `delete(key)` then `fetch`: that sequence leaves the key absent, so concurrent readers each start their own recompute.
 
 `status` is `'fresh' | 'stale' | 'expired' | 'miss'`.
 
@@ -98,7 +98,9 @@ export const pokemonCache = new MochiCache({
 });
 ```
 
-A background sweep deletes expired files on an interval. `purgeOnInit` empties the directory on startup. Set `offloadBinary: true` when values carry large binaries. The built-in [image cache](/docs/images/) enables offloading internally.
+A background sweep deletes expired files on an interval. `purgeOnInit` empties the directory on startup.
+
+Binary fields (`Uint8Array` / `Buffer`) anywhere in a value round-trip transparently. By default Mochi inlines them as base64 in the JSON and returns them as `Uint8Array`. When values carry large binaries, set `offloadBinary: true`: Mochi writes each binary to its own file in a `<key-hash>/` folder and puts a pointer in the JSON instead of base64. An offloaded field reads back as a lazy blob reference, so a metadata read never loads the bytes. Resolve one with `readBlobRef(ref)`, and narrow a value with `isBlobRef(value)`. Deleting a key also removes its blob folder. Pointers already on disk always decode, so the flag never orphans existing entries. The built-in [image cache](/docs/images/) enables offloading internally.
 
 | Option          | Default           |                                                                            |
 | --------------- | ----------------- | -------------------------------------------------------------------------- |
@@ -107,6 +109,8 @@ A background sweep deletes expired files on an interval. `purgeOnInit` empties t
 | `purgeInterval` | `60_000` (1min)   | Background sweep interval in ms. `<= 0` disables the sweeper.              |
 | `maxAge`        | `600_000` (10min) | Files older than this are deleted by the sweep.                            |
 | `offloadBinary` | `false`           | Offload binary fields to per-key blob files, read back as lazy `BlobRef`s. |
+
+Only one background sweeper runs per cache directory per process. A new `FileStorage` on the same directory transfers the sweep to the newest instance, and with it that instance's `maxAge`, so a dev-server reload that re-runs your module never stacks up duplicate sweepers. Ownership never moves back: `dispose()` on the newest instance ends the sweep for that directory, even if an older instance is still in use.
 
 <Callout type="warning">
 

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -33,6 +33,7 @@ Event names use a `namespace:action` convention. Every key is in the typed `Moch
 - [`captcha:verify`](#captchaverify) — a `<MochiCaptcha>` submission was verified or rejected
 - [`file:change`](#filechange) — dev-only file watcher
 - [`image:store`](#imagestore), [`image:delete`](#imagedelete) — [`<Image>`](/docs/images/) cache activity
+- `image:cache-sweep` — aggregate counts per janitor sweep (see [Images](/docs/images/))
 - `cache:read`, `cache:revalidate` — see [Cache events](/docs/cache/#subscribing-to-cache-events)
 
 ### Subscribing

--- a/packages/docs/148-images.md
+++ b/packages/docs/148-images.md
@@ -110,7 +110,7 @@ Mochi copies the file to a content-hashed URL (`/_mochi/asset/<slug>-<hash>.<ext
 
 The `{ src, width, height, format }` shape is available as the exported `ImportedImage` type. Ambient module types come free through `mochi-framework/ambient`.
 
-A bare `<Image src={hero}>` with no `size` renders the original at its intrinsic dimensions straight from that static URL, with no endpoint hop.
+A bare `<Image src={hero}>` with no `size` renders the original at its intrinsic dimensions straight from that static URL. It never calls the image endpoint.
 
 <Callout type="warning">
 

--- a/packages/docs/148-images.md
+++ b/packages/docs/148-images.md
@@ -114,7 +114,7 @@ A bare `<Image src={hero}>` with no `size` renders the original at its intrinsic
 
 <Callout type="warning">
 
-Two edge cases. With `image.enabled: false` the `/_mochi/asset/…` route still serves the file, because that is plain static serving, but a `size` becomes a no-op and `<Image>` falls back to the raw static URL. And the [`image:url`](/docs/extensions/#imageurl) CDN-rewrite filter runs on minted transform URLs only, so the no-size static URL (`hero.src`) bypasses it. Use a `size` if you need local assets routed through the filter.
+Two edge cases. With `image.enabled: false` the `/_mochi/asset/…` route still serves the file, because that route is plain static serving and registers independently of the flag. The transform does not run: `<Image>` falls back to the raw static URL, while the `<img>` keeps the size's declared `width`/`height`, so the browser scales the full-size original into that box. And the [`image:url`](/docs/extensions/#imageurl) CDN-rewrite filter runs on minted transform URLs only, so the no-size static URL (`hero.src`) bypasses it. Use a `size` if you need local assets routed through the filter.
 
 </Callout>
 

--- a/packages/docs/148-images.md
+++ b/packages/docs/148-images.md
@@ -81,7 +81,7 @@ Add `placeholder` to render a [ThumbHash](https://evanw.github.io/thumbhash/) bl
 
 A bare `<Image src>` with no `size` serves the full-size original. An unknown size name degrades to the original and logs a one-time server warning.
 
-`<Image>` works inside `mochi:hydrate*` islands at any depth — it detects the hydrating subtree with [`isHydratable()`](/docs/selective-hydration/#ishydratable). Minting needs the server secret, so inside an island the minted URL is serialized into the page via Svelte's `hydratable` and reused during hydration.
+`<Image>` works inside `mochi:hydrate*` islands at any depth — it detects the hydrating subtree with [`isHydratable()`](/docs/selective-hydration/#ishydratable). Minting needs the server secret, so inside an island the minted URL is serialized into the page via Svelte's `hydratable` and reused during hydration. If a client-side re-render changes the image props, there is no snapshot to reuse and the `<img>` degrades to the raw `src` URL.
 
 <Callout type="warning">
 
@@ -109,6 +109,14 @@ Supported formats: png, jpg, jpeg, webp, avif, gif. Put SVGs in your `public/` d
 Mochi copies the file to a content-hashed URL (`/_mochi/asset/<slug>-<hash>.<ext>`) and serves it from disk with a long-lived immutable cache in production. Transforms read the file from disk, so `<Image src={hero} size="…">` and `placeholder` work without an origin round-trip. Emitted copies live under `<outDir>/assets/` and [relocate with the build](/docs/deployment-options/#relocatable-builds).
 
 The `{ src, width, height, format }` shape is available as the exported `ImportedImage` type. Ambient module types come free through `mochi-framework/ambient`.
+
+A bare `<Image src={hero}>` with no `size` renders the original at its intrinsic dimensions straight from that static URL, with no endpoint hop.
+
+<Callout type="warning">
+
+Two edge cases. With `image.enabled: false` the `/_mochi/asset/…` route still serves the file, because that is plain static serving, but a `size` becomes a no-op and `<Image>` falls back to the raw static URL. And the [`image:url`](/docs/extensions/#imageurl) CDN-rewrite filter runs on minted transform URLs only, so the no-size static URL (`hero.src`) bypasses it. Use a `size` if you need local assets routed through the filter.
+
+</Callout>
 
 ### `getImageUrl` — deferred URLs
 

--- a/packages/docs/148-view-transitions.md
+++ b/packages/docs/148-view-transitions.md
@@ -31,6 +31,8 @@ Render exactly **one** `<ViewTransitions />` per page. Two instances would emit 
 
 </Callout>
 
+Do not hydrate it. The component emits static CSS and no markup, so `mochi:hydrate` and `mochi:defer` have nothing to do. It throws if invoked as an island.
+
 ### Props
 
 | Prop                   | Type                                               | Default  | Description                                                           |

--- a/packages/docs/148-view-transitions.md
+++ b/packages/docs/148-view-transitions.md
@@ -31,8 +31,6 @@ Render exactly **one** `<ViewTransitions />` per page. Two instances would emit 
 
 </Callout>
 
-Do not hydrate it. The component emits static CSS and no markup, so `mochi:hydrate` and `mochi:defer` have nothing to do. It throws if invoked as an island.
-
 ### Props
 
 | Prop                   | Type                                               | Default  | Description                                                           |

--- a/packages/docs/150-captcha.md
+++ b/packages/docs/150-captcha.md
@@ -168,6 +168,18 @@ Every token failure returns the same message, so a probing bot cannot tell "too 
 
 `minAgeMs` is the only check that a submission took human time. The proof-of-work bounds an attacker's **cost** (~2^`bits` hashes per token), not any single solver's latency. A form with fields to type into runs past the 2s default. A form with nothing to fill in may not, so tune it per form with the [`captcha:minAgeMs`](/docs/extensions/#captchaminagems) filter.
 
+### Clock skew
+
+A token's age is `Date.now()` at verify minus the mint time sealed into the token. On one instance that is one clock, and the subtraction is exact. Across a multi-instance deploy the two reads come off different machines, so the difference also carries that pair's clock skew. A verifier that runs behind the minter understates the age and can refuse a real submission as too fast.
+
+Mochi pads `maxAgeMs` with a 30s allowance to absorb this. Adjust it with the [`captcha:driftAllowanceMs`](/docs/extensions/#captchadriftallowancems) filter. The floor is **not** padded: padding a floor means subtracting from it, so any allowance wider than `minAgeMs` would delete the too-fast check rather than soften it. Keep instances NTP-synced. A fleet skewed by seconds has no usable elapsed-time signal to floor, and it must share `MOCHI_KEY` and the nonce store anyway.
+
+<Callout type="info">
+
+A **negative** `ageMs` on the [`captcha:verify` event](/docs/events/#captchaverify) means a token was verified before it was minted, which is impossible on a single clock. It is an unambiguous skew alarm, and it fires in the direction that quietly weakens the floor rather than the one visitors complain about.
+
+</Callout>
+
 ### Replay protection
 
 A solved token is single-use. `verifyCaptcha()` burns its nonce on success. A second submission of the same token is rejected.
@@ -221,7 +233,30 @@ if (!captcha.ok) {
 
 ### Theming
 
-Every colour is a CSS custom property whose default lives in the `var()` fallback, so the widget looks finished with no CSS. Set any of them on an ancestor and they inherit down (`--mochi-captcha-accent`, `--mochi-captcha-track-bg`, `--mochi-captcha-handle-bg`, and more). The defaults are light-mode only. In a dark app, point these at your own tokens. The track height (44px) and handle width (44px) drive the drag maths and are not themeable.
+Every colour is a CSS custom property whose default lives in the `var()` fallback, so the widget looks finished with no CSS. Set any of them on an ancestor and they inherit down:
+
+```css
+.my-form {
+  --mochi-captcha-accent: #4a7c59;
+  --mochi-captcha-accent-soft: #e0ebe1;
+  --mochi-captcha-accent-soft-text: #2f5b3f;
+  --mochi-captcha-border: #e8e4d8;
+  --mochi-captcha-track-bg: #faf8f1;
+  --mochi-captcha-handle-bg: #fffdf8;
+  --mochi-captcha-handle-text: var(--mochi-captcha-accent);
+  --mochi-captcha-hint-text: #6e756d;
+  --mochi-captcha-radius: 999px;
+  --mochi-captcha-error-bg: #fdf3f2;
+  --mochi-captcha-error-border: #e9c9c4;
+  --mochi-captcha-error-text: #8a3324;
+}
+```
+
+The three `error` properties apply only in the [failure state](#when-it-fails).
+
+`--mochi-captcha-handle-text` colours the `emoji` glyph and follows the accent unless you set it. It applies only to glyphs with a text presentation, such as `▶` or `→`. Colour-font emoji like `🍡` paint themselves and ignore CSS colour.
+
+The defaults are light-mode only. In a dark or themed app, point these at your own tokens — `--mochi-captcha-track-bg: var(--surface-muted)` and so on — so the widget follows your theme. The track height (44px) and handle width (44px) drive the drag maths and are not themeable.
 
 ### Testing
 

--- a/packages/docs/150-captcha.md
+++ b/packages/docs/150-captcha.md
@@ -172,7 +172,7 @@ Every token failure returns the same message, so a probing bot cannot tell "too 
 
 A token's age is `Date.now()` at verify minus the mint time sealed into the token. On one instance that is one clock, and the subtraction is exact. Across a multi-instance deploy the two reads come off different machines, so the difference also carries that pair's clock skew. A verifier that runs behind the minter understates the age and can refuse a real submission as too fast.
 
-Mochi pads `maxAgeMs` with a 30s allowance to absorb this. Adjust it with the [`captcha:driftAllowanceMs`](/docs/extensions/#captchadriftallowancems) filter. The floor is **not** padded: padding a floor means subtracting from it, so any allowance wider than `minAgeMs` would delete the too-fast check rather than soften it. Keep instances NTP-synced. A fleet skewed by seconds has no usable elapsed-time signal to floor, and it must share `MOCHI_KEY` and the nonce store anyway.
+Mochi pads `maxAgeMs` with a 30s allowance to absorb this, adjustable with the [`captcha:driftAllowanceMs`](/docs/extensions/#captchadriftallowancems) filter. The floor is not padded.
 
 <Callout type="info">
 

--- a/packages/docs/150-captcha.md
+++ b/packages/docs/150-captcha.md
@@ -172,7 +172,7 @@ Every token failure returns the same message, so a probing bot cannot tell "too 
 
 A token's age is `Date.now()` at verify minus the mint time sealed into the token. On one instance that is one clock, and the subtraction is exact. Across a multi-instance deploy the two reads come off different machines, so the difference also carries that pair's clock skew. A verifier that runs behind the minter understates the age and can refuse a real submission as too fast.
 
-Mochi pads `maxAgeMs` with a 30s allowance to absorb this, adjustable with the [`captcha:driftAllowanceMs`](/docs/extensions/#captchadriftallowancems) filter. The floor is not padded.
+To absorb this, Mochi adds a 30s allowance to `maxAgeMs`, adjustable with the [`captcha:driftAllowanceMs`](/docs/extensions/#captchadriftallowancems) filter. It does not add one to `minAgeMs`.
 
 <Callout type="info">
 

--- a/packages/docs/155-css-imports.md
+++ b/packages/docs/155-css-imports.md
@@ -23,7 +23,7 @@ A side-effect `import` of a `.css` file from any `.svelte`, `.ts`, or `.js` modu
 
 Bare specifiers resolve through `package.json#main`, so `@fontsource/*`, CSS-only libraries, and any package that points its main entry at a stylesheet work the same way. Relative paths (`import './styles.css'`) resolve from the importing file.
 
-Mochi serves the bundle as `/_mochi/import-css/<n>-<hash>.css` (with `assetPrefix` configurable on `Mochi.serve`). It tracks the imports reachable from each page entry and injects a `<link rel="stylesheet">` only on pages that use them.
+Mochi serves the bundle as `/_mochi/import-css/<name>-<hash>.css` (with `assetPrefix` configurable on `Mochi.serve`). It tracks the imports reachable from each page entry and injects a `<link rel="stylesheet">` only on pages that use them.
 
 The import can live anywhere in the dependency graph — a leaf `.ts` module, a hydratable island, or the page component. Mochi follows the bundle, not the call site.
 
@@ -50,7 +50,7 @@ The Svelte compiler handles `<style>` inside a `.svelte` file. Mochi extracts th
 
 ### Variable fonts
 
-`@fontsource-variable/*` packages work without manual workarounds. Mochi takes care of the `*-variations` format hints these packages rely on, so variable fonts render correctly with no extra configuration.
+Bun's CSS bundler unquotes `format('woff2-variations')` to `format(woff2-variations)`. Browsers silently drop the unquoted form. After bundling, Mochi re-quotes the four `*-variations` hints (`woff2-variations`, `woff-variations`, `truetype-variations`, `opentype-variations`), so `@fontsource-variable/*` packages work with no manual workaround.
 
 ### Dev mode
 

--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -56,50 +56,85 @@ The manifest records a schema version, and the runtime loads only the exact vers
 
 Deploy code or containers. The platform manages infrastructure, scaling, and networking.
 
-- [Railway](https://railway.app) — dedicated Bun and Docker support
-- [Render](https://render.com) — Docker-based web services, Git-push deploys
-- [Fly.io](https://fly.io) — Docker-native, global edge, scale-to-zero
-- [Heroku](https://heroku.com) — supports Docker deployments
-- [Koyeb](https://koyeb.com) — Git or Docker, 250+ edge locations
-- [Clever Cloud](https://www.clever.cloud) — native Bun / Docker support
-- [Zeabur](https://zeabur.com) — auto-detects Bun
-- [Scaleway Serverless Containers](https://www.scaleway.com/en/serverless-containers/) — deploy from any registry, billed per millisecond
-- [DigitalOcean App Platform](https://www.digitalocean.com/products/app-platform) — Git or Docker deploy
+- <span title="USA">🇺🇸</span> <a href="https://railway.app" target="_blank" rel="nofollow noopener">Railway</a> — dedicated Bun and Docker support
+- <span title="USA">🇺🇸</span> <a href="https://render.com" target="_blank" rel="nofollow noopener">Render</a> — Docker-based web services, Git-push deploys
+- <span title="USA">🇺🇸</span> <a href="https://fly.io" target="_blank" rel="nofollow noopener">Fly.io</a> — Docker-native, global edge, scale-to-zero
+- <span title="USA">🇺🇸</span> <a href="https://heroku.com" target="_blank" rel="nofollow noopener">Heroku</a> — supports Docker deployments
+- <span title="France">🇫🇷</span> <a href="https://koyeb.com" target="_blank" rel="nofollow noopener">Koyeb</a> — Git or Docker, 250+ edge locations
+- <span title="France">🇫🇷</span> <a href="https://www.clever.cloud" target="_blank" rel="nofollow noopener">Clever Cloud</a> — native Bun / Docker support
+- <span title="USA — Zeabur Inc., Delaware">🇺🇸</span> <a href="https://zeabur.com" target="_blank" rel="nofollow noopener">Zeabur</a> — auto-detects Bun
+- <span title="France">🇫🇷</span> <a href="https://www.scaleway.com/en/serverless-containers/" target="_blank" rel="nofollow noopener">Scaleway Serverless Containers</a> — deploy from any registry, billed per millisecond
+- <span title="USA">🇺🇸</span> <a href="https://www.digitalocean.com/products/app-platform" target="_blank" rel="nofollow noopener">DigitalOcean App Platform</a> — Git or Docker deploy
 
 ## Traditional VPS / IaaS
 
 You get a server, install Bun yourself, and manage the process (systemd, Docker).
 
-- [Hetzner](https://hetzner.com)
-- [DigitalOcean Droplets](https://www.digitalocean.com/products/droplets)
-- [OVHcloud](https://ovhcloud.com)
-- [Scaleway Instances](https://www.scaleway.com/en/virtual-instances/)
-- [Vultr](https://vultr.com)
-- [Akamai / Linode](https://www.linode.com)
-- [Kamatera](https://kamatera.com)
+- <span title="Germany">🇩🇪</span> <a href="https://hetzner.com" target="_blank" rel="nofollow noopener">Hetzner</a> — very cheap, popular with indie devs
+- <span title="USA">🇺🇸</span> <a href="https://www.digitalocean.com/products/droplets" target="_blank" rel="nofollow noopener">DigitalOcean Droplets</a> — simple cloud VMs
+- <span title="France">🇫🇷</span> <a href="https://ovhcloud.com" target="_blank" rel="nofollow noopener">OVHcloud</a> — dedicated servers, VPS, private cloud, with strong GDPR compliance
+- <span title="France">🇫🇷</span> <a href="https://www.scaleway.com/en/virtual-instances/" target="_blank" rel="nofollow noopener">Scaleway Instances</a> — VMs alongside their serverless offering
+- <span title="USA">🇺🇸</span> <a href="https://vultr.com" target="_blank" rel="nofollow noopener">Vultr</a>
+- <span title="USA">🇺🇸</span> <a href="https://www.linode.com" target="_blank" rel="nofollow noopener">Akamai / Linode</a>
+- <span title="USA">🇺🇸</span><span title="Israeli-founded">🇮🇱</span> <a href="https://kamatera.com" target="_blank" rel="nofollow noopener">Kamatera</a> — pay-as-you-go cloud VMs
 
 ## Big cloud
 
 Each offers VPS, serverless, containers, and Kubernetes. Pick the model that fits.
 
-- [AWS](https://aws.amazon.com) — EC2, Lambda + Web Adapter, Fargate, App Runner, ECS/EKS
-- [Google Cloud](https://cloud.google.com) — Compute Engine, Cloud Run, GKE, Cloud Functions
-- [Azure](https://azure.microsoft.com) — VMs, Container Apps, ACI, AKS
-- [Oracle Cloud](https://cloud.oracle.com) — generous always-free ARM VMs
-- [IBM Cloud](https://www.ibm.com/cloud) — VPC, Code Engine, IKS/OpenShift
+- <span title="USA">🇺🇸</span> <a href="https://aws.amazon.com" target="_blank" rel="nofollow noopener">AWS</a> — EC2, Lambda + Web Adapter, Fargate, App Runner, ECS/EKS
+- <span title="USA">🇺🇸</span> <a href="https://cloud.google.com" target="_blank" rel="nofollow noopener">Google Cloud</a> — Compute Engine, Cloud Run, GKE, Cloud Functions
+- <span title="USA">🇺🇸</span> <a href="https://azure.microsoft.com" target="_blank" rel="nofollow noopener">Azure</a> — VMs, Container Apps, ACI, AKS
+- <span title="USA">🇺🇸</span> <a href="https://cloud.oracle.com" target="_blank" rel="nofollow noopener">Oracle Cloud</a> — generous always-free ARM VMs
+- <span title="USA">🇺🇸</span> <a href="https://www.ibm.com/cloud" target="_blank" rel="nofollow noopener">IBM Cloud</a> — VPC, Code Engine, IKS/OpenShift
 
 ## Self-hosted tools
 
 Install these on a VPS from one of the providers above.
 
-- [Coolify](https://coolify.io) — open-source, self-hosted PaaS
-- [Dokku](https://dokku.com) — open-source mini-Heroku
-- [CapRover](https://caprover.com) — open-source PaaS with web UI
+- <a href="https://coolify.io" target="_blank" rel="nofollow noopener">Coolify</a> — open-source, self-hosted PaaS
+- <a href="https://dokku.com" target="_blank" rel="nofollow noopener">Dokku</a> — open-source mini-Heroku
+- <a href="https://caprover.com" target="_blank" rel="nofollow noopener">CapRover</a> — open-source PaaS with web UI
 
 ## Hosted tools
 
 Connect to your existing infrastructure at different cloud providers.
 
-- [Northflank](https://northflank.com) — containers, jobs, and APIs, with bring-your-own-cloud
-- [Kuberns](https://kuberns.com) — Git-push deploy on AWS infra, no Dockerfile
-- [Convox](https://www.convox.com/)
+- <span title="United Kingdom">🇬🇧</span> <a href="https://northflank.com" target="_blank" rel="nofollow noopener">Northflank</a> — containers, jobs, and APIs, with bring-your-own-cloud
+- <span title="India">🇮🇳</span> <a href="https://kuberns.com" target="_blank" rel="nofollow noopener">Kuberns</a> — Git-push deploy on AWS infra, no Dockerfile
+- <span title="USA">🇺🇸</span> <a href="https://www.convox.com/" target="_blank" rel="nofollow noopener">Convox</a>
+
+## Where these companies are based
+
+The flag next to each provider above shows where the **company** is headquartered, not where its data centers are.
+
+<details>
+<summary style="cursor: pointer">Provider headquarters &amp; sources</summary>
+
+<!-- prettier-ignore -->
+| Provider | Country | Source |
+| --- | --- | --- |
+| Railway | 🇺🇸 USA | <a href="https://railway.com/legal/dpa" target="_blank" rel="nofollow noopener">DPA (San Francisco, CA)</a> |
+| Render | 🇺🇸 USA | <a href="https://render.com/about" target="_blank" rel="nofollow noopener">About (San Francisco, CA)</a> |
+| Fly.io | 🇺🇸 USA | <a href="https://fly.io/legal/terms-of-service/" target="_blank" rel="nofollow noopener">Terms (San Francisco, CA)</a> |
+| Heroku | 🇺🇸 USA | <a href="https://www.heroku.com/about" target="_blank" rel="nofollow noopener">About (San Francisco, CA)</a> |
+| Koyeb | 🇫🇷 France | <a href="https://www.koyeb.com/careers" target="_blank" rel="nofollow noopener">Careers (Paris, France)</a> |
+| Clever Cloud | 🇫🇷 France | <a href="https://clever.cloud/legal-notice/" target="_blank" rel="nofollow noopener">Legal notice (Nantes, France)</a> |
+| Zeabur | 🇺🇸 USA | <a href="https://zeabur.com/about" target="_blank" rel="nofollow noopener">About (Zeabur Inc., Delaware)</a> |
+| Scaleway | 🇫🇷 France | <a href="https://www.scaleway.com/en/legal-notice/" target="_blank" rel="nofollow noopener">Legal notice (Paris, France)</a> |
+| DigitalOcean | 🇺🇸 USA | <a href="https://www.digitalocean.com/legal/terms-of-service-agreement" target="_blank" rel="nofollow noopener">Terms (USA)</a> |
+| Hetzner | 🇩🇪 Germany | <a href="https://www.hetzner.com/legal/imprint" target="_blank" rel="nofollow noopener">Imprint (Gunzenhausen, Germany)</a> |
+| OVHcloud | 🇫🇷 France | <a href="https://www.ovhcloud.com/en/terms-and-conditions/" target="_blank" rel="nofollow noopener">Terms (Roubaix, France)</a> |
+| Vultr | 🇺🇸 USA | <a href="https://en.wikipedia.org/wiki/Vultr" target="_blank" rel="nofollow noopener">Wikipedia (West Palm Beach, FL)</a> |
+| Akamai / Linode | 🇺🇸 USA | <a href="https://www.akamai.com/company" target="_blank" rel="nofollow noopener">Company (Cambridge, MA)</a> |
+| Kamatera | 🇺🇸 USA · 🇮🇱 founded | <a href="https://en.wikipedia.org/wiki/Kamatera" target="_blank" rel="nofollow noopener">Wikipedia (US HQ, Israeli-founded)</a> |
+| AWS | 🇺🇸 USA | <a href="https://www.aboutamazon.com/about-us" target="_blank" rel="nofollow noopener">About Amazon (Seattle, WA)</a> |
+| Google Cloud | 🇺🇸 USA | <a href="https://en.wikipedia.org/wiki/Google" target="_blank" rel="nofollow noopener">Wikipedia (Mountain View, CA)</a> |
+| Azure | 🇺🇸 USA | <a href="https://news.microsoft.com/facts-about-microsoft/" target="_blank" rel="nofollow noopener">Microsoft facts (Redmond, WA)</a> |
+| Oracle Cloud | 🇺🇸 USA | <a href="https://en.wikipedia.org/wiki/Oracle_Corporation" target="_blank" rel="nofollow noopener">Wikipedia (Austin, TX)</a> |
+| IBM Cloud | 🇺🇸 USA | <a href="https://en.wikipedia.org/wiki/IBM" target="_blank" rel="nofollow noopener">Wikipedia (Armonk, NY)</a> |
+| Northflank | 🇬🇧 United Kingdom | <a href="https://northflank.com/about" target="_blank" rel="nofollow noopener">About (London, UK)</a> |
+| Kuberns | 🇮🇳 India | <a href="https://www.linkedin.com/company/kuberns" target="_blank" rel="nofollow noopener">LinkedIn (Gujarat, India)</a> |
+| Convox | 🇺🇸 USA | <a href="https://www.ycombinator.com/companies/convox" target="_blank" rel="nofollow noopener">Y Combinator (Atlanta, GA)</a> |
+
+</details>

--- a/packages/docs/190-docs-for-llms.md
+++ b/packages/docs/190-docs-for-llms.md
@@ -159,6 +159,19 @@ The full set of docs, concatenated in reading order, is served at [`/llms-recomm
 
 Each doc is reachable as plain text at `/docs/<slug>/llms.txt`, for example [`/docs/intro/llms.txt`](/docs/intro/llms.txt). The "Copy as llms.txt" button on each doc page emits just that page.
 
+The changelog is served the same way at [`/docs/changelog/llms.txt`](/docs/changelog/llms.txt), and reads as a page at [`/docs/changelog/`](/docs/changelog/). Mochi fetches it from GitHub, so both return `503` (not `404`) when that fetch is unavailable.
+
+#### Per-post text
+
+Each published blog post is reachable as raw markdown at `/blog/<slug>/llms.txt`, for example [`/blog/mochi-0-8-0/llms.txt`](/blog/mochi-0-8-0/llms.txt).
+
+#### Per-demo source
+
+Each demo's source is reachable as plain text alongside its demo page, usually `/demos/<slug>/llms.txt`. It is the exact source `/llms-full.txt` bundles for that demo, scoped to one demo:
+
+- [`/demos/hello-world/llms.txt`](/demos/hello-world/llms.txt)
+- [`/demos/chat/llms.txt`](/demos/chat/llms.txt)
+
 #### Machine-readable index
 
 [`/llms.json`](/llms.json) returns a JSON index of every doc, blog post, and demo, each with its `title`, `description`, and an absolute `url` to its `llms.txt`.

--- a/packages/docs/50-selective-hydration.md
+++ b/packages/docs/50-selective-hydration.md
@@ -51,7 +51,7 @@ Framework components from `mochi-framework/components` are the one package excep
 <MochiCaptcha mochi:hydrate />
 ```
 
-Two forms are a **compile error**, surfaced on the dev error page and in `mochi-framework build`:
+Any other import form is a **compile error**, surfaced on the dev error page and in `mochi-framework build`. The two you are most likely to hit:
 
 - **Third-party package imports** (`import { Widget } from 'some-ui-lib'`). Wrap the component in a local `.svelte` file and put the directive on the wrapper.
 - **Components received through props, variables, or namespaces** (`<Item.Row mochi:hydrate />`). An island needs a statically known source file. Use the same wrapper fix.


### PR DESCRIPTION
Follow-ups from the review of #173. Every change here restores something the STE rewrite deleted or garbled — no new documentation, no further tone changes.

The rewrite's own skill says it (`.claude/skills/ste-docs/SKILL.md`, workflow step 2): *"Preserve meaning exactly. Never drop a fact, constraint, warning, or step."* These are the places that didn't hold.

## Wrong text

| File | Was | Now |
| --- | --- | --- |
| `100-websocket-routes.md`, `110-server-sent-events.md` | `logger()` prints them | `consoleLogger()` prints them |
| `155-css-imports.md` | `/_mochi/import-css/<n>-<hash>.css` | `/_mochi/import-css/<name>-<hash>.css` |

`logger` is a level-gated object (`error`/`warn`/`info`/`log`/`debug`), not a callable — `logger()` is a TypeError. #173 fixed this same sentence in `147-events.md` but left the other two. The CSS pattern comes from `naming: { entry: '[name]-[hash].[ext]' }` in `ComponentRegistry.ts:1868`.

## Restored facts

Each of these was the only place the behaviour was documented:

- **`145-cache.md`** — `readBlobRef` / `isBlobRef` (real exports at `index.ts:26`) and the whole `offloadBinary` contract; `FileStorage` per-directory sweeper ownership and the one-way `dispose()`; `markStale`'s no-op-on-missing-or-stale contract.
- **`150-captcha.md`** — the Clock skew section (30s drift allowance on `maxAgeMs`, the deliberately unpadded floor, negative `ageMs` as the skew alarm); the full 12-variable theming reference, which `/demos/captcha-styling/` is built on.
- **`115-queues.md`** — an overrun `lockDuration` retries the job (firing side effects twice) or abandons it; heartbeat stall detection, not `lockDuration`, is what recovers a crashed worker.
- **`148-images.md`** — a client re-render degrades to the raw `src`; `image.enabled: false` makes `size` a no-op; `image:url` doesn't run on size-less local imports.
- **`148-view-transitions.md`** — `<ViewTransitions />` throws if used as an island (`ViewTransitions.svelte:121`).
- **`190-docs-for-llms.md`** — the `/blog/<slug>/llms.txt` and `/demos/<slug>/llms.txt` routes, plus the changelog's 503-not-404 behaviour.
- **`147-events.md`** — `image:cache-sweep` back in the event index (`events.ts:396`).
- **`50-selective-hydration.md`** — "any other import form is a compile error" restored; the rewrite narrowed it to a two-item list, implying bare-specifier aliases and dynamic `import()` were fine.
- **`116-email.md`** — the template's own `<script>` block is compile-time and unaffected by the strip.
- **`155-css-imports.md`** — why variable fonts need the `*-variations` re-quote (Bun's bundler unquotes them; browsers drop the unquoted form). Not in the original review list; same defect class, same file.

## Deployment page revert

`184-deployment.md` had every external link rewritten from `<a target="_blank" rel="nofollow noopener">` to plain markdown, dropping `nofollow` on ~25 commercial vendor links, and lost the sourced HQ/jurisdiction table and country flags. That's collateral from what was scoped as a tone rewrite — the STE prose is kept, the link markup and table are restored.

## Verification

- `bun run checks` passes (lint + format + typecheck + test).
- All 14 edited pages return 200 from a local dev server, with the restored content confirmed in the rendered HTML: 12 captcha CSS vars, 49 `rel="nofollow noopener"`, the 22-row HQ table.