### PR TITLE
fix(site): decode HTML entities in docs nav titles

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -213,6 +213,7 @@
         "@tanstack/svelte-table": "^9.0.0",
         "@tmcp/adapter-valibot": "0.1.6",
         "@tmcp/transport-http": "0.8.6",
+        "entities": "^8.0.0",
         "hast-util-to-html": "^9.0.5",
         "layerchart": "^2.0.3",
         "mdsvex": "^0.12.8",
@@ -825,7 +826,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.24.3", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ=="],
 
-    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1606,6 +1607,8 @@
     "d3-sankey/d3-array": ["d3-array@2.12.1", "", { "dependencies": { "internmap": "^1.0.0" } }, "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ=="],
 
     "d3-sankey/d3-shape": ["d3-shape@1.3.7", "", { "dependencies": { "d3-path": "1" } }, "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw=="],
+
+    "happy-dom/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "happy-dom/ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
 

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -24,6 +24,7 @@
     "@tanstack/svelte-table": "^9.0.0",
     "@tmcp/adapter-valibot": "0.1.6",
     "@tmcp/transport-http": "0.8.6",
+    "entities": "^8.0.0",
     "hast-util-to-html": "^9.0.5",
     "layerchart": "^2.0.3",
     "mdsvex": "^0.12.8",

--- a/packages/site/src/lib/markdown.test.ts
+++ b/packages/site/src/lib/markdown.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { compile as mdsvexCompile } from 'mdsvex';
+import rehypeSlug from 'rehype-slug';
+import { collectHeadings, type HastNode, type MdsvexRehypePlugin } from './markdown';
+import type { TocEntry } from './toc';
+
+// Mirrors parseDoc in docs.ts: run the same mdsvex + rehype pipeline the docs build with,
+// then extract the first heading the nav/TOC render.
+async function firstHeading(markdown: string): Promise<TocEntry> {
+  let toc: TocEntry[] = [];
+  const capture = () => (tree: HastNode) => {
+    toc = collectHeadings(tree);
+  };
+  await mdsvexCompile(markdown, {
+    extensions: ['.md', '.svx'],
+    rehypePlugins: [rehypeSlug as unknown as MdsvexRehypePlugin, capture as unknown as MdsvexRehypePlugin],
+    highlight: false,
+  });
+  const [h] = toc;
+  if (!h) {
+    throw new Error('no headings extracted');
+  }
+  return h;
+}
+
+describe('collectHeadings', () => {
+  test('decodes angle brackets escaped inside code spans', async () => {
+    const h = await firstHeading('### Component-scoped `<style>` blocks\n');
+    expect(h.text).toBe('Component-scoped <style> blocks');
+    expect(h.text).not.toContain('&lt;');
+    expect(h.text).not.toContain('&gt;');
+  });
+
+  test('decodes braces escaped inside code spans (numeric entities)', async () => {
+    const h = await firstHeading('### The `{@html}` directive\n');
+    expect(h.text).toBe('The {@html} directive');
+    expect(h.text).not.toContain('&#123;');
+  });
+
+  test('leaves plain headings untouched', async () => {
+    const h = await firstHeading('## Getting started\n');
+    expect(h.text).toBe('Getting started');
+  });
+
+  test('preserves a bare ampersand in prose', async () => {
+    const h = await firstHeading('## Docs & demos\n');
+    expect(h.text).toBe('Docs & demos');
+  });
+
+  test('decodes the display text but leaves the slug matching the page anchor', async () => {
+    const h = await firstHeading('### Component-scoped `<style>` blocks\n');
+    expect(h.level).toBe(3);
+    // The slug comes from rehype-slug run on the still-encoded tree, so it must be left
+    // as-is to keep matching the id on the rendered heading — only the text is decoded.
+    expect(h.slug).toBe('component-scoped-ltstylegt-blocks');
+  });
+});

--- a/packages/site/src/lib/markdown.ts
+++ b/packages/site/src/lib/markdown.ts
@@ -1,5 +1,6 @@
 import { compile as mdsvexCompile } from 'mdsvex';
 import { toHtml } from 'hast-util-to-html';
+import { decodeHTML } from 'entities';
 import rehypeSlug from 'rehype-slug';
 import rehypeExternalLinks from './rehypeExternalLinks';
 import type { TocEntry } from './toc';
@@ -16,7 +17,9 @@ export type HastNode = {
 
 export function hastText(node: HastNode): string {
   if (node.type === 'text') {
-    return node.value ?? '';
+    // mdsvex entity-encodes text inside code spans (`<` → `&lt;`, `{` → `&#123;`) so
+    // the compiled Svelte stays valid; decode it back for use as a plain-text title.
+    return decodeHTML(node.value ?? '');
   }
   if (!node.children) {
     return '';


### PR DESCRIPTION
## Problem

An item in the left sidebar / mobile drawer menu (and the on-page "On this page" TOC) rendered with literal HTML entities:

> Component-scoped `&lt;style&gt;` blocks

instead of the intended `<style>`.

## Root cause

The source heading `` ### Component-scoped `<style>` blocks `` (`packages/docs/155-css-imports.md`) puts a tag name inside a code span. mdsvex entity-encodes text **inside code spans** (`<`→`&lt;`, `>`→`&gt;`, `{`/`}`→`&#123;`/`&#125;`) so the compiled Svelte source stays valid. That encoded string landed verbatim in the extracted nav/TOC title via `hastText()`. Because the menu components render titles as auto-escaped plain text (`{entry.text}`), the leading `&` got escaped a **second** time and the browser displayed the literal `&lt;style&gt;`.

This is a whole class of bug: the desktop sidebar, the mobile drawer, and the "On this page" TOC all shared it, and any heading with `<`, `>`, `{`, or `}` in a code span (e.g. `` `{@html}` ``) would break identically.

## Fix

Decode HTML entities at the single point where the hast tree becomes a plain-text title — inside `hastText()` in `packages/site/src/lib/markdown.ts`, using the canonical `entities` package's `decodeHTML`. This covers all three consumers at once. The heading **slug/anchor** is deliberately left untouched (it comes from rehype-slug on the encoded tree and matches the rendered heading's `id`), so existing links keep working.

## Changes
- `packages/site/src/lib/markdown.ts` — decode entities in `hastText`.
- `packages/site/package.json` — add `entities@^8.0.0`.
- `packages/site/src/lib/markdown.test.ts` — new regression test (encoded `<style>`, brace numeric entities, plain heading, bare `&` in prose, slug preservation).

## Verification
- `bun run checks` (lint + format + typecheck + test) — green across all workspaces.
- Browser (chrome-devtools) at 375px and desktop on `/docs/css-imports/`: sidebar link, mobile drawer item, and on-page TOC all read `Component-scoped <style> blocks` with real angle brackets; anchor still resolves; no console errors on hydration.