### PR TITLE
perf(debug-bar): compile the debug bar standalone with production-mode Svelte

### DIFF
--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -20,8 +20,9 @@ import { applyFilter } from '../extensions';
 import { decodeSourcePath, encodeSourcePath } from './manifestPaths';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
 import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
-import { renderMochiEnvServer, renderMochiEnvClient } from './virtualModuleTemplate';
-import { buildDebugBarBundle, stripEsmEnvImports, ESM_ENV_STRIP_FILTER, type DebugBarBundle } from './buildDebugBarBundle';
+import { renderMochiEnvServer } from './virtualModuleTemplate';
+import { buildDebugBarBundle, type DebugBarBundle } from './buildDebugBarBundle';
+import { registerEsmEnvStrip, registerMochiEnvClient, registerSvelteModuleLoader } from './clientBuildLoaders';
 import { createImageAssetLoader, IMAGE_FILE_FILTER } from './imageAssetLoader';
 import { EMAIL_TEMPLATE_DIR } from '../email/templates';
 import { registerLocalImageAsset } from '../image/localAssetRegistry';
@@ -1125,8 +1126,6 @@ export class ComponentRegistry {
       filesMap[entryPath] = entrySource;
     }
 
-    const cookiesClientPath = toPosixPath(path.join(srcDir, 'runtime/cookies.client.ts'));
-    const enhanceClientPath = toPosixPath(path.join(srcDir, 'runtime/enhance.client.ts'));
     const imageAssetLoader = createImageAssetLoader({
       outDir: this.outDir,
       assetPrefix: this.assetPrefix,
@@ -1170,40 +1169,15 @@ export class ComponentRegistry {
           }
           return { contents: buildServerOnlyStubModule(args.path, scan), loader: 'js' };
         });
-        build.onResolve({ filter: /^mochi-framework$/ }, () => ({
-          path: 'mochi-framework',
-          namespace: 'mochi-env',
-        }));
-        build.onLoad({ filter: /.*/, namespace: 'mochi-env' }, () => ({
-          contents: renderMochiEnvClient(development, cookiesClientPath, enhanceClientPath),
-          loader: 'js',
-        }));
+        registerMochiEnvClient(build, development);
         // Client builds never run the island preprocessor, so the injected
         // boundary import shouldn't appear in a client graph — this alias is
         // cheap insurance against a stray specifier failing the whole build.
         build.onResolve({ filter: /^mochi-framework\/hydratable-boundary$/ }, () => ({
           path: path.join(SRC_DIR, 'islands/HydratableBoundary.svelte'),
         }));
-        build.onLoad({ filter: ESM_ENV_STRIP_FILTER }, async (args) => ({
-          contents: stripEsmEnvImports(await Bun.file(args.path).text()),
-          loader: 'js',
-        }));
-        build.onLoad({ filter: /\.svelte\.[jt]s$/ }, async (args) => {
-          let source = await Bun.file(args.path).text();
-          if (args.path.endsWith('.ts')) {
-            const transpiler = new Bun.Transpiler({ loader: 'ts' });
-            source = transpiler.transformSync(source);
-          }
-          const { js } = backend.compileModule(
-            source,
-            mergeCompilerOptions(userCompilerOptions, {
-              generate: 'client',
-              filename: args.path,
-              dev: development,
-            }),
-          );
-          return { contents: js.code, loader: 'js' };
-        });
+        registerEsmEnvStrip(build);
+        registerSvelteModuleLoader(build, backend, mergeCompilerOptions(userCompilerOptions, { generate: 'client', dev: development }));
         build.onLoad({ filter: /\.svelte$/ }, async (args) => {
           const source = shakenSources.get(args.path) ?? (await Bun.file(args.path).text());
           const cached = compileCache.get('client', args.path, source, clientFingerprint, compileCacheStats);

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -22,6 +22,7 @@ import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlySc
 import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 import { renderMochiEnvServer } from './virtualModuleTemplate';
 import { buildDebugBarBundle, type DebugBarBundle } from './buildDebugBarBundle';
+import { formatBuildMessages } from './formatBuildMessages';
 import { registerEsmEnvStrip, registerMochiEnvClient, registerSvelteModuleLoader } from './clientBuildLoaders';
 import { createImageAssetLoader, IMAGE_FILE_FILTER } from './imageAssetLoader';
 import { EMAIL_TEMPLATE_DIR } from '../email/templates';
@@ -83,45 +84,6 @@ const MANIFEST_VERSION = 2;
 const VARIATION_FORMAT_RE = /\bformat\((woff2-variations|woff-variations|truetype-variations|opentype-variations)\)/g;
 function restoreVariationsFormat(css: string): string {
   return css.replace(VARIATION_FORMAT_RE, "format('$1')");
-}
-
-/**
- * Format a `Bun.build()` failure's `logs` array as `file:line:column — message` per entry. Bun 1.2+ throws a generic
- * `AggregateError("Bundle failed")` with `stack === undefined`, losing the positions, so every call passes
- * `throw: false` to recover the structured logs for this helper.
- */
-export function formatBuildMessages(
-  logs: ReadonlyArray<{
-    message: string;
-    position?: { file: string; line: number; column: number } | null;
-  }>,
-): string {
-  if (logs.length === 0) {
-    return '  <no diagnostic messages>';
-  }
-  const formatted = logs
-    .map((l) => {
-      const p = l.position;
-      const where = p ? `${relForDisplay(p.file)}:${p.line}:${p.column}` : '<unknown>';
-      return `  ${where} — ${l.message}`;
-    })
-    .join('\n');
-
-  // A read failure on a file inside the isolated linker's node_modules/.bun
-  // symlink store is the signature of a known Bun bug (a second Bun.build in a
-  // `bun test` / --hot / --watch process fails reading deps the runtime loader
-  // already imported). Without this hint the error looks like a broken dep and
-  // costs hours; with it the fix is a two-line bunfig change.
-  if (/reading file/.test(formatted) && /node_modules[\\/]\.bun[\\/]/.test(formatted)) {
-    return (
-      `${formatted}\n` +
-      `  hint: this matches a known Bun bug — a second Bun.build() inside \`bun test\` (or --hot/--watch)\n` +
-      `  fails reading node_modules files resolved through the isolated linker's symlinked\n` +
-      `  node_modules/.bun store. Fix: add \`linker = "hoisted"\` under \`[install]\` in bunfig.toml,\n` +
-      `  delete node_modules, and reinstall. See https://github.com/khromov/bun-second-build-eisdir-repro`
-    );
-  }
-  return formatted;
 }
 
 const MARKDOWN_EXTENSIONS = ['.md', '.svx'];
@@ -1101,6 +1063,8 @@ export class ComponentRegistry {
     // sources don't change under a running user app, so watcher rebuilds skip it entirely.
     if (debugBarEnabled && !this.debugBarBundle) {
       this.debugBarBuildPromise ??= buildDebugBarBundle({ development, backend });
+      // If the main build below throws before the swap-time await, a rejection here would otherwise go unhandled.
+      this.debugBarBuildPromise.catch(() => {});
     }
 
     const srcDir = SRC_DIR;
@@ -1619,9 +1583,6 @@ export class ComponentRegistry {
         const reachable = ComponentRegistry.reachableOutputNames(entryRoots, outputByName);
         for (const output of this.clientStats.outputs) {
           const url = `${this.assetPrefix}/client/${output.name}`;
-          if (url === this.debugBarUrl) {
-            continue;
-          }
           if (url === this.islandBootstrapUrl) {
             if (!pageHasIslands) {
               continue;

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -21,6 +21,7 @@ import { decodeSourcePath, encodeSourcePath } from './manifestPaths';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
 import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 import { renderMochiEnvServer, renderMochiEnvClient } from './virtualModuleTemplate';
+import { buildDebugBarBundle, stripEsmEnvImports, ESM_ENV_STRIP_FILTER, type DebugBarBundle } from './buildDebugBarBundle';
 import { createImageAssetLoader, IMAGE_FILE_FILTER } from './imageAssetLoader';
 import { EMAIL_TEMPLATE_DIR } from '../email/templates';
 import { registerLocalImageAsset } from '../image/localAssetRegistry';
@@ -370,6 +371,8 @@ export class ComponentRegistry {
   private componentEntryUrls: Map<string, string> = new Map();
   private islandBootstrapUrl: string | null = null;
   private debugBarUrl: string | null = null;
+  private debugBarBundle: DebugBarBundle | null = null;
+  private debugBarBuildPromise: Promise<DebugBarBundle> | null = null;
   private clientFiles: Map<string, string> = new Map();
   /** Maps component file path → CSS URL */
   private cssFileUrls: Map<string, string> = new Map();
@@ -1092,20 +1095,20 @@ export class ComponentRegistry {
     const newClientFiles = new Map<string, string>();
     const newComponentEntryUrls = new Map<string, string>();
     let newIslandBootstrapUrl: string | null = null;
-    let newDebugBarUrl: string | null = null;
+
+    // The debug bar builds standalone (production-mode Svelte, own runtime) and only once per process — framework
+    // sources don't change under a running user app, so watcher rebuilds skip it entirely.
+    if (debugBarEnabled && !this.debugBarBundle) {
+      this.debugBarBuildPromise ??= buildDebugBarBundle({ development, backend });
+    }
 
     const srcDir = SRC_DIR;
     // Forward slashes survive intact in generated source, where Windows backslashes get eaten as JS escapes, and keep a
     // file's module identity consistent across its three uses: `Bun.build` entrypoint, `filesMap` key, import specifier.
     const hydratableIslandPath = toPosixPath(path.join(srcDir, 'web-components', 'HydratableIsland.ts'));
-    const debugBarDir = path.join(srcDir, 'debug-bar') + path.sep;
-    const debugBarEntryPath = toPosixPath(path.join(debugBarDir, 'debugbar-entry.ts'));
 
     // Generate per-component virtual entry points
     const entrypoints: string[] = [hydratableIslandPath];
-    if (debugBarEnabled) {
-      entrypoints.push(debugBarEntryPath);
-    }
     const filesMap: Record<string, string> = {};
 
     for (const [, comp] of unique) {
@@ -1181,14 +1184,10 @@ export class ComponentRegistry {
         build.onResolve({ filter: /^mochi-framework\/hydratable-boundary$/ }, () => ({
           path: path.join(SRC_DIR, 'islands/HydratableBoundary.svelte'),
         }));
-        // Bun can't propagate constants through esm-env's conditional exports, so stripping the imports turns
-        // DEV/BROWSER/NODE into free variables that Bun's `define` replaces with literal booleans, letting `if (DEV)`
-        // blocks be eliminated.
-        build.onLoad({ filter: /node_modules\/svelte\/src\/.*\.js$/ }, async (args) => {
-          let source = await Bun.file(args.path).text();
-          source = source.replace(/import\s*\{[^}]*\}\s*from\s*['"]esm-env['"]\s*;?/g, '');
-          return { contents: source, loader: 'js' };
-        });
+        build.onLoad({ filter: ESM_ENV_STRIP_FILTER }, async (args) => ({
+          contents: stripEsmEnvImports(await Bun.file(args.path).text()),
+          loader: 'js',
+        }));
         build.onLoad({ filter: /\.svelte\.[jt]s$/ }, async (args) => {
           let source = await Bun.file(args.path).text();
           if (args.path.endsWith('.ts')) {
@@ -1217,8 +1216,6 @@ export class ComponentRegistry {
             mergeCompilerOptions(userCompilerOptions, {
               generate: 'client',
               filename: args.path,
-              // TODO: Verify that this still works after node_modules migration
-              css: args.path.startsWith(debugBarDir) ? 'injected' : undefined,
               dev: development,
             }),
           );
@@ -1280,9 +1277,6 @@ export class ComponentRegistry {
       // entryPoint is native; on Windows the formats diverge, the bootstrap lookup misses, and the hydration `<script>` disappears.
       const entryToComponent = new Map<string, string | null>();
       entryToComponent.set(toPosixPath(path.resolve(hydratableIslandPath)), null);
-      if (debugBarEnabled) {
-        entryToComponent.set(toPosixPath(path.resolve(debugBarEntryPath)), '__debugbar__');
-      }
       for (const [, comp] of unique) {
         const entryPath = toPosixPath(path.resolve(path.join(srcDir, `_hydrate-${comp.name}.js`)));
         entryToComponent.set(entryPath, comp.name);
@@ -1297,8 +1291,6 @@ export class ComponentRegistry {
         const url = `${this.assetPrefix}/client/${path.basename(outPath)}`;
         if (compName === null) {
           newIslandBootstrapUrl = url;
-        } else if (compName === '__debugbar__') {
-          newDebugBarUrl = url;
         } else if (compName !== undefined) {
           newComponentEntryUrls.set(compName, url);
         }
@@ -1339,7 +1331,24 @@ export class ComponentRegistry {
       this.componentEntryUrls.set(k, v);
     }
     this.islandBootstrapUrl = newIslandBootstrapUrl;
-    this.debugBarUrl = newDebugBarUrl;
+
+    if (this.debugBarBuildPromise && !this.debugBarBundle) {
+      try {
+        this.debugBarBundle = await this.debugBarBuildPromise;
+      } catch (err) {
+        // A rejected promise must not be memoized (the next rebuild retries), and a broken debug bar must not take
+        // down page serving.
+        this.debugBarBuildPromise = null;
+        logger.warn(`[mochi] debug bar build failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (this.debugBarBundle) {
+      const debugBarUrl = `${clientPrefix}${this.debugBarBundle.fileName}`;
+      this.clientFiles.set(debugBarUrl, this.debugBarBundle.contents);
+      this.debugBarUrl = debugBarUrl;
+    } else {
+      this.debugBarUrl = null;
+    }
 
     const outputBytes = this.clientStats?.outputs.reduce((sum, o) => sum + o.size, 0) ?? 0;
     mochiEvents.emit('client-bundle:complete', {

--- a/packages/mochi/src/compiler/buildDebugBarBundle.ts
+++ b/packages/mochi/src/compiler/buildDebugBarBundle.ts
@@ -1,0 +1,91 @@
+/**
+ * Standalone production-Svelte build for the dev debug bar. The bar is framework-internal UI, so unlike user islands it
+ * compiles with `dev: false` + the `production` condition — roughly a third of the dev-mode output — at the cost of
+ * carrying its own small prod Svelte runtime instead of sharing the dev runtime chunk. Built once per process
+ * (framework sources don't change under a running user app), same lifecycle as `buildInlineWebComponent`.
+ */
+import path from 'node:path';
+import type { BunPlugin } from 'bun';
+import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
+import { renderMochiEnvClient } from './virtualModuleTemplate';
+import { formatBuildMessages } from './ComponentRegistry';
+import type { SvelteCompilerBackend } from './svelteCompilerBackend';
+import { toPosixPath } from '../utils';
+
+const SRC_DIR = path.resolve(import.meta.dir, '..');
+
+export const ESM_ENV_STRIP_FILTER = /node_modules\/svelte\/src\/.*\.js$/;
+
+// Bun can't propagate constants through esm-env's conditional exports, so stripping the imports turns DEV/BROWSER/NODE
+// into free variables that Bun's `define` replaces with literal booleans, letting `if (DEV)` blocks be eliminated.
+export function stripEsmEnvImports(source: string): string {
+  return source.replace(/import\s*\{[^}]*\}\s*from\s*['"]esm-env['"]\s*;?/g, '');
+}
+
+export interface DebugBarBundle {
+  fileName: string;
+  contents: string;
+}
+
+export async function buildDebugBarBundle(opts: { development: boolean; backend: SvelteCompilerBackend }): Promise<DebugBarBundle> {
+  const { development, backend } = opts;
+  const cookiesClientPath = toPosixPath(path.join(SRC_DIR, 'runtime/cookies.client.ts'));
+  const enhanceClientPath = toPosixPath(path.join(SRC_DIR, 'runtime/enhance.client.ts'));
+
+  const debugBarPlugin: BunPlugin = {
+    name: 'mochi-debug-bar',
+    setup(build) {
+      build.onLoad({ filter: ESM_ENV_STRIP_FILTER }, async (args) => ({
+        contents: stripEsmEnvImports(await Bun.file(args.path).text()),
+        loader: 'js',
+      }));
+      // Svelte compiles production-mode here, but mochi-level env stays truthful: if the bar ever imports
+      // `mochi-framework`'s `isDev`, it must still read `true` under a dev server.
+      build.onResolve({ filter: /^mochi-framework$/ }, () => ({
+        path: 'mochi-framework',
+        namespace: 'mochi-env',
+      }));
+      build.onLoad({ filter: /.*/, namespace: 'mochi-env' }, () => ({
+        contents: renderMochiEnvClient(development, cookiesClientPath, enhanceClientPath),
+        loader: 'js',
+      }));
+      build.onLoad({ filter: /\.svelte\.[jt]s$/ }, async (args) => {
+        let source = await Bun.file(args.path).text();
+        if (args.path.endsWith('.ts')) {
+          const transpiler = new Bun.Transpiler({ loader: 'ts' });
+          source = transpiler.transformSync(source);
+        }
+        const { js } = backend.compileModule(source, { generate: 'client', filename: args.path, dev: false });
+        return { contents: js.code, loader: 'js' };
+      });
+      build.onLoad({ filter: /\.svelte$/ }, async (args) => {
+        const source = await Bun.file(args.path).text();
+        const { js } = backend.compile(source, { generate: 'client', filename: args.path, css: 'injected', dev: false });
+        return { contents: js.code, loader: 'js' };
+      });
+    },
+  };
+
+  const result = await Bun.build({
+    entrypoints: [path.join(SRC_DIR, 'debug-bar', 'debugbar-entry.ts')],
+    // The guard goes first so its `onResolve` sees a server-only specifier before the debug-bar plugin's own handlers.
+    plugins: [serverOnlyModuleGuard, debugBarPlugin],
+    target: 'browser',
+    conditions: ['svelte', 'production'],
+    define: {
+      DEV: 'false',
+      BROWSER: 'true',
+      NODE: 'false',
+      ...CLIENT_BUILD_DEFINE,
+    },
+    minify: true,
+    naming: '[name]-[hash].[ext]',
+    throw: false,
+  });
+
+  if (!result.success) {
+    throw new Error(`Debug bar client build failed:\n${formatBuildMessages(result.logs)}`);
+  }
+  const output = result.outputs[0]!;
+  return { fileName: path.basename(output.path), contents: await output.text() };
+}

--- a/packages/mochi/src/compiler/buildDebugBarBundle.ts
+++ b/packages/mochi/src/compiler/buildDebugBarBundle.ts
@@ -9,7 +9,7 @@ import type { BunPlugin } from 'bun';
 import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 import { registerEsmEnvStrip, registerMochiEnvClient, registerSvelteModuleLoader } from './clientBuildLoaders';
 import { mergeCompilerOptions } from './svelteConfig';
-import { formatBuildMessages } from './ComponentRegistry';
+import { formatBuildMessages } from './formatBuildMessages';
 import type { SvelteCompilerBackend } from './svelteCompilerBackend';
 
 const SRC_DIR = path.resolve(import.meta.dir, '..');
@@ -59,6 +59,11 @@ export async function buildDebugBarBundle(opts: { development: boolean; backend:
   if (!result.success) {
     throw new Error(`Debug bar client build failed:\n${formatBuildMessages(result.logs)}`);
   }
-  const output = result.outputs[0]!;
-  return { fileName: path.basename(output.path), contents: await output.text() };
+  // No `.css`-strip or image-asset loader is registered here — a debug-bar component gaining such an import would add
+  // outputs, so pick the entry by kind rather than trusting index 0.
+  const entry = result.outputs.find((o) => o.kind === 'entry-point');
+  if (!entry) {
+    throw new Error('Debug bar client build produced no entry-point output');
+  }
+  return { fileName: path.basename(entry.path), contents: await entry.text() };
 }

--- a/packages/mochi/src/compiler/buildDebugBarBundle.ts
+++ b/packages/mochi/src/compiler/buildDebugBarBundle.ts
@@ -7,20 +7,12 @@
 import path from 'node:path';
 import type { BunPlugin } from 'bun';
 import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
-import { renderMochiEnvClient } from './virtualModuleTemplate';
+import { registerEsmEnvStrip, registerMochiEnvClient, registerSvelteModuleLoader } from './clientBuildLoaders';
+import { mergeCompilerOptions } from './svelteConfig';
 import { formatBuildMessages } from './ComponentRegistry';
 import type { SvelteCompilerBackend } from './svelteCompilerBackend';
-import { toPosixPath } from '../utils';
 
 const SRC_DIR = path.resolve(import.meta.dir, '..');
-
-export const ESM_ENV_STRIP_FILTER = /node_modules\/svelte\/src\/.*\.js$/;
-
-// Bun can't propagate constants through esm-env's conditional exports, so stripping the imports turns DEV/BROWSER/NODE
-// into free variables that Bun's `define` replaces with literal booleans, letting `if (DEV)` blocks be eliminated.
-export function stripEsmEnvImports(source: string): string {
-  return source.replace(/import\s*\{[^}]*\}\s*from\s*['"]esm-env['"]\s*;?/g, '');
-}
 
 export interface DebugBarBundle {
   fileName: string;
@@ -29,38 +21,19 @@ export interface DebugBarBundle {
 
 export async function buildDebugBarBundle(opts: { development: boolean; backend: SvelteCompilerBackend }): Promise<DebugBarBundle> {
   const { development, backend } = opts;
-  const cookiesClientPath = toPosixPath(path.join(SRC_DIR, 'runtime/cookies.client.ts'));
-  const enhanceClientPath = toPosixPath(path.join(SRC_DIR, 'runtime/enhance.client.ts'));
 
   const debugBarPlugin: BunPlugin = {
     name: 'mochi-debug-bar',
     setup(build) {
-      build.onLoad({ filter: ESM_ENV_STRIP_FILTER }, async (args) => ({
-        contents: stripEsmEnvImports(await Bun.file(args.path).text()),
-        loader: 'js',
-      }));
+      registerEsmEnvStrip(build);
       // Svelte compiles production-mode here, but mochi-level env stays truthful: if the bar ever imports
       // `mochi-framework`'s `isDev`, it must still read `true` under a dev server.
-      build.onResolve({ filter: /^mochi-framework$/ }, () => ({
-        path: 'mochi-framework',
-        namespace: 'mochi-env',
-      }));
-      build.onLoad({ filter: /.*/, namespace: 'mochi-env' }, () => ({
-        contents: renderMochiEnvClient(development, cookiesClientPath, enhanceClientPath),
-        loader: 'js',
-      }));
-      build.onLoad({ filter: /\.svelte\.[jt]s$/ }, async (args) => {
-        let source = await Bun.file(args.path).text();
-        if (args.path.endsWith('.ts')) {
-          const transpiler = new Bun.Transpiler({ loader: 'ts' });
-          source = transpiler.transformSync(source);
-        }
-        const { js } = backend.compileModule(source, { generate: 'client', filename: args.path, dev: false });
-        return { contents: js.code, loader: 'js' };
-      });
+      registerMochiEnvClient(build, development);
+      // `mergeCompilerOptions` with no user options: framework defaults apply, user svelte config doesn't.
+      registerSvelteModuleLoader(build, backend, mergeCompilerOptions(undefined, { generate: 'client', dev: false }));
       build.onLoad({ filter: /\.svelte$/ }, async (args) => {
         const source = await Bun.file(args.path).text();
-        const { js } = backend.compile(source, { generate: 'client', filename: args.path, css: 'injected', dev: false });
+        const { js } = backend.compile(source, mergeCompilerOptions(undefined, { generate: 'client', filename: args.path, css: 'injected', dev: false }));
         return { contents: js.code, loader: 'js' };
       });
     },

--- a/packages/mochi/src/compiler/clientBuildLoaders.ts
+++ b/packages/mochi/src/compiler/clientBuildLoaders.ts
@@ -1,0 +1,46 @@
+/**
+ * Loader registrations shared by the two client-side `Bun.build`s — the island bundle and the standalone debug bar —
+ * so their behavior can't drift.
+ */
+import path from 'node:path';
+import type { PluginBuilder } from 'bun';
+import type { CompileOptions } from 'svelte/compiler';
+import { renderMochiEnvClient } from './virtualModuleTemplate';
+import type { SvelteCompilerBackend } from './svelteCompilerBackend';
+import { toPosixPath } from '../utils';
+
+const SRC_DIR = path.resolve(import.meta.dir, '..');
+
+// Bun can't propagate constants through esm-env's conditional exports, so stripping the imports turns DEV/BROWSER/NODE
+// into free variables that Bun's `define` replaces with literal booleans, letting `if (DEV)` blocks be eliminated.
+export function registerEsmEnvStrip(build: PluginBuilder): void {
+  build.onLoad({ filter: /node_modules\/svelte\/src\/.*\.js$/ }, async (args) => ({
+    contents: (await Bun.file(args.path).text()).replace(/import\s*\{[^}]*\}\s*from\s*['"]esm-env['"]\s*;?/g, ''),
+    loader: 'js',
+  }));
+}
+
+export function registerMochiEnvClient(build: PluginBuilder, development: boolean): void {
+  const cookiesClientPath = toPosixPath(path.join(SRC_DIR, 'runtime/cookies.client.ts'));
+  const enhanceClientPath = toPosixPath(path.join(SRC_DIR, 'runtime/enhance.client.ts'));
+  build.onResolve({ filter: /^mochi-framework$/ }, () => ({
+    path: 'mochi-framework',
+    namespace: 'mochi-env',
+  }));
+  build.onLoad({ filter: /.*/, namespace: 'mochi-env' }, () => ({
+    contents: renderMochiEnvClient(development, cookiesClientPath, enhanceClientPath),
+    loader: 'js',
+  }));
+}
+
+export function registerSvelteModuleLoader(build: PluginBuilder, backend: SvelteCompilerBackend, options: CompileOptions): void {
+  build.onLoad({ filter: /\.svelte\.[jt]s$/ }, async (args) => {
+    let source = await Bun.file(args.path).text();
+    if (args.path.endsWith('.ts')) {
+      const transpiler = new Bun.Transpiler({ loader: 'ts' });
+      source = transpiler.transformSync(source);
+    }
+    const { js } = backend.compileModule(source, { ...options, filename: args.path });
+    return { contents: js.code, loader: 'js' };
+  });
+}

--- a/packages/mochi/src/compiler/debugBarStandalone.test.ts
+++ b/packages/mochi/src/compiler/debugBarStandalone.test.ts
@@ -1,0 +1,75 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { ComponentRegistry } from './ComponentRegistry';
+
+const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'debug-bar-bundles');
+const PAGE_A = path.join(FIXTURE_DIR, 'PageA.svelte');
+
+let outDir: string;
+let registry: ComponentRegistry;
+
+describe('debug bar standalone bundle', () => {
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-debug-bar-standalone-'));
+    registry = new ComponentRegistry({ development: true, outDir });
+    await registry.compileAll([PAGE_A]);
+  });
+
+  afterAll(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('compiles production-mode while islands stay dev-mode', () => {
+    const url = registry.getDebugBarUrl();
+    expect(url).not.toBeNull();
+    const contents = registry.getClientFile(url!);
+    expect(contents).toBeDefined();
+
+    // Svelte's dev output stamps `Component[FILENAME] = "<abs path>"`; the string survives minification, so its
+    // absence is the production-compile marker.
+    expect(contents!).not.toContain('debug-bar/MochiDebugBar.svelte');
+
+    const islandFiles = [...registry.getClientFiles().entries()].filter(([k]) => k !== url);
+    expect(islandFiles.some(([, v]) => v.includes('debug-bar-bundles/WidgetA.svelte'))).toBe(true);
+  });
+
+  test('bundle is self-contained and well under the old dev-mode size', () => {
+    const contents = registry.getClientFile(registry.getDebugBarUrl()!)!;
+    expect(contents).not.toContain('from"/_mochi/client/chunk-');
+    expect(contents.length).toBeLessThan(200_000);
+  });
+
+  test('survives a rebuild without rebuilding: same URL, still served', async () => {
+    const urlBefore = registry.getDebugBarUrl();
+    await registry.recompileAll();
+    expect(registry.getDebugBarUrl()).toBe(urlBefore!);
+    expect(registry.getClientFile(urlBefore!)).toBeDefined();
+  });
+
+  test('is excluded from client bundle stats', () => {
+    const url = registry.getDebugBarUrl()!;
+    const outputs = registry.getClientStats()?.outputs ?? [];
+    expect(outputs.some((o) => url.endsWith(o.name))).toBe(false);
+  });
+});
+
+describe('debug bar disabled', () => {
+  let disabledOutDir: string;
+
+  beforeAll(() => {
+    disabledOutDir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-debug-bar-disabled-'));
+  });
+
+  afterAll(() => {
+    rmSync(disabledOutDir, { recursive: true, force: true });
+  });
+
+  test('no bundle is built or served', async () => {
+    const disabled = new ComponentRegistry({ development: true, outDir: disabledOutDir, debugBar: false });
+    await disabled.compileAll([PAGE_A]);
+    expect(disabled.getDebugBarUrl()).toBeNull();
+    const files = [...disabled.getClientFiles().keys()];
+    expect(files.some((k) => k.includes('debugbar-entry'))).toBe(false);
+  });
+});

--- a/packages/mochi/src/compiler/formatBuildMessages.test.ts
+++ b/packages/mochi/src/compiler/formatBuildMessages.test.ts
@@ -2,7 +2,7 @@
 // a read failure on a file inside the symlinked node_modules/.bun store — and
 // never on ordinary build errors, so real diagnostics stay uncluttered.
 import { describe, expect, test } from 'bun:test';
-import { formatBuildMessages } from './ComponentRegistry';
+import { formatBuildMessages } from './formatBuildMessages';
 
 describe('formatBuildMessages isolated-linker hint', () => {
   test('appends the hint for a read failure inside the .bun store', () => {

--- a/packages/mochi/src/compiler/formatBuildMessages.ts
+++ b/packages/mochi/src/compiler/formatBuildMessages.ts
@@ -1,0 +1,40 @@
+import { relForDisplay } from '../utils';
+
+/**
+ * Format a `Bun.build()` failure's `logs` array as `file:line:column — message` per entry. Bun 1.2+ throws a generic
+ * `AggregateError("Bundle failed")` with `stack === undefined`, losing the positions, so every call passes
+ * `throw: false` to recover the structured logs for this helper.
+ */
+export function formatBuildMessages(
+  logs: ReadonlyArray<{
+    message: string;
+    position?: { file: string; line: number; column: number } | null;
+  }>,
+): string {
+  if (logs.length === 0) {
+    return '  <no diagnostic messages>';
+  }
+  const formatted = logs
+    .map((l) => {
+      const p = l.position;
+      const where = p ? `${relForDisplay(p.file)}:${p.line}:${p.column}` : '<unknown>';
+      return `  ${where} — ${l.message}`;
+    })
+    .join('\n');
+
+  // A read failure on a file inside the isolated linker's node_modules/.bun
+  // symlink store is the signature of a known Bun bug (a second Bun.build in a
+  // `bun test` / --hot / --watch process fails reading deps the runtime loader
+  // already imported). Without this hint the error looks like a broken dep and
+  // costs hours; with it the fix is a two-line bunfig change.
+  if (/reading file/.test(formatted) && /node_modules[\\/]\.bun[\\/]/.test(formatted)) {
+    return (
+      `${formatted}\n` +
+      `  hint: this matches a known Bun bug — a second Bun.build() inside \`bun test\` (or --hot/--watch)\n` +
+      `  fails reading node_modules files resolved through the isolated linker's symlinked\n` +
+      `  node_modules/.bun store. Fix: add \`linker = "hoisted"\` under \`[install]\` in bunfig.toml,\n` +
+      `  delete node_modules, and reinstall. See https://github.com/khromov/bun-second-build-eisdir-repro`
+    );
+  }
+  return formatted;
+}


### PR DESCRIPTION
## Problem

The dev debug bar entry (`/_mochi/client/debugbar-entry-*.js`) weighed ~277KB — and pulled another ~104KB of shared chunks behind it. The suspected cause (sourcemaps) turned out to be a red herring: the client build has no sourcemaps and is already minified. The real cost was **dev-mode Svelte compilation**: the bar's ~14 panel components were compiled like user islands (`dev: true` — location tracking, embedded source paths, validation code) against the development-condition Svelte runtime.

## Change

The debug bar is framework-internal UI, so it no longer needs any of that. It now compiles in its own standalone `Bun.build` (`compiler/buildDebugBarBundle.ts`, modeled on `buildInlineWebComponent.ts`):

- **Production-mode Svelte**: `dev: false`, `conditions: ['svelte', 'production']`, `DEV: 'false'` define. Mochi-level env stays truthful — the `mochi-env` virtual module still reports `isDev: true` under a dev server.
- **Fully self-contained**: carries its own small prod Svelte runtime instead of importing the shared dev-runtime chunks; CSS stays inlined (`css: 'injected'`). One request instead of eight.
- **Built once per process**: framework sources don't change under a running user app, so watcher rebuilds skip it entirely and its URL stays stable across rebuilds (the bundle is re-inserted after the client-file swap). A failed build logs a warning, is retried on the next rebuild, and never blocks page serving.
- **No user config leakage**: user svelte compiler options/preprocessors no longer apply to the bar's compiles, and it skips the compile cache (avoiding dev/prod fingerprint thrash).
- The `esm-env` import-strip loader is extracted into a shared helper used by both builds.
- Bundle stats / BundlesPanel now reflect only page-shipped JS (the bar was already excluded from the panel's list).

## Bundle size: before → after

Measured on `packages/site`'s homepage (`bun run dev:site`):

| | Before | After | Δ |
|---|---|---|---|
| Entry file (raw) | 276,833 B | 161,037 B | **−42%** |
| Entry file (gzip) | 78,886 B | 51,026 B | **−35%** |
| Total debug-bar JS incl. transitive chunks (raw) | 380,771 B | 161,037 B | **−58%** |
| Total (gzip) | 119,425 B | 51,026 B | **−57%** |
| Requests | 8 files | 1 file | −7 |

(“Total” = the entry plus every chunk it transitively imports, crawled from the served output; the old entry pulled the 89KB dev Svelte runtime chunk among others. The new bundle contains no dev-mode source-path strings and imports no chunks.)

## Testing

- New `compiler/debugBarStandalone.test.ts`: production-compile marker (no dev `FILENAME` path strings, while island bundles still have them), self-containment + size guard, URL/serving survival across `recompileAll()` (pins the client-file prefix-wipe edge), stats exclusion, and `debugBar: false`.
- `bun run checks` passes (lint, format, typecheck, 151/151 mochi test files).
- Smoke-tested on the dev site: debug bar mounts, panels render with styling, islands hydrate, console clean; URL unchanged and still served after a watcher rebuild.