### PR TITLE
feat: Compression Dictionary Transport (RFC 9842) for HTML navigations

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -106,6 +106,7 @@
         "mochi-framework": "src/cli/cli.js",
       },
       "dependencies": {
+        "@bokuweb/zstd-wasm": "0.0.27",
         "@css-inline/css-inline-wasm": "^0.21.0",
         "@joint-ops/hitlimit-bun": "1.5.0",
         "@noble/ciphers": "2.2.0",
@@ -302,6 +303,8 @@
     "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
     "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
+
+    "@bokuweb/zstd-wasm": ["@bokuweb/zstd-wasm@0.0.27", "", {}, "sha512-GDm2uOTK3ESjnYmSeLQifJnBsRCWajKLvN32D2ZcQaaCIJI/Hse9s74f7APXjHit95S10UImsRGkTsbwHmrtmg=="],
 
     "@clack/core": ["@clack/core@1.4.3", "", { "dependencies": { "fast-wrap-ansi": "^0.2.0", "sisteransi": "^1.0.5" } }, "sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ=="],
 

--- a/packages/docs/120-middleware.md
+++ b/packages/docs/120-middleware.md
@@ -141,6 +141,8 @@ Every encoding streams through one `CompressionStream`, so a chunked SSR respons
 
 `compress()` is a no-op in development, because the debug bar must inject itself into the HTML after the response is built. In production it adds `Vary: Accept-Encoding` and compresses compressible content types (`text/*`, `application/json`, `application/javascript`, `application/xml`, and others). A response that already declares `Content-Encoding` passes through untouched. Static framework assets also flow through `handle`, so `compress()` covers them. Other body-touching middleware must branch on `event.kind === 'asset'` when it needs to skip framework bundles.
 
+HTML pages can additionally be delta-compressed against a site dictionary for returning visitors — see [Compression Dictionaries](/docs/compression-dictionaries/). It composes with `compress()`: dictionary-compressed responses pass through untouched, everything else negotiates as usual.
+
 ### `noCache`
 
 Built-in middleware that defaults `Cache-Control: no-cache` on `page` and `api` responses. A route that sets its own `Cache-Control` is left untouched, so opt-in caching works per route.

--- a/packages/docs/126-compression-dictionaries.md
+++ b/packages/docs/126-compression-dictionaries.md
@@ -1,0 +1,93 @@
+---
+title: 'Compression Dictionaries'
+slug: compression-dictionaries
+description: 'Serve dcz-compressed HTML navigations with Compression Dictionary Transport (RFC 9842).'
+---
+
+<script>
+  import Callout from './_components/Callout.svelte';
+  import VersionNote from './_components/VersionNote.svelte';
+</script>
+
+## Compression Dictionaries
+
+<VersionNote since="0.10.0" message="compressionDictionary was added in 0.10.0." />
+
+[Compression Dictionary Transport](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Compression_dictionary_transport) (RFC 9842) lets the browser reuse a previously downloaded dictionary when decompressing responses. Mochi pages share most of their HTML — shell, navigation, layout — so with a dictionary built from your own pages, a navigation only transfers what's unique to it. Transfer sizes routinely drop by an order of magnitude.
+
+```ts
+Mochi.serve({
+  compressionDictionary: true, // production only
+});
+```
+
+At boot, Mochi renders your static page routes once and publishes the harvested HTML as a shared dictionary at `/_mochi/dictionary/<hash>`. Every HTML page advertises it with a `Link: </_mochi/dictionary/<hash>>; rel="compression-dictionary"` header. The browser downloads the dictionary during idle time; from the next navigation on it sends `Available-Dictionary`, and Mochi answers with `Content-Encoding: dcz` — the page zstd-compressed against the dictionary.
+
+<Callout type="info">
+
+Chromium 130+ only. Every other browser (and any client that doesn't present a matching `Available-Dictionary` hash) falls back to your regular `compress()` negotiation — responses carry `Vary: Accept-Encoding, Available-Dictionary`, so caches stay correct. Browsers require a secure context: HTTPS in production, while `localhost` works as-is.
+
+</Callout>
+
+### Options
+
+Pass an object for per-mode control and tuning:
+
+```ts
+Mochi.serve({
+  compressionDictionary: {
+    enabledInProd: true,
+    enabledInDev: true, // for local testing; the dictionary is built once at boot and does not track dev edits
+    routes: ['/', '/docs'], // default: every static page route
+    maxDictionaryBytes: 262144, // cap on the idle-time download (default 256 KB)
+    zstdLevel: 10, // per-response dcz compression level
+  },
+});
+```
+
+Routes with `:param` or `*` segments have no single canonical URL, so they can't be rendered at boot and are skipped with a warning. A page that would push the dictionary past `maxDictionaryBytes` is skipped whole, so the dictionary never ends mid-markup.
+
+A `dictionary:ready` event fires once the dictionary is published (see [Events](/docs/events/)).
+
+### Deploys
+
+The dictionary is served from a content-addressed URL with `Cache-Control: immutable`, so a deploy that changes your HTML changes the hash and the URL. A returning visitor advertises the previous deploy’s hash, which the new process no longer holds, so that one navigation falls back to your normal `compress()` encoding. The `Link` header on it already points at the new dictionary, so the browser idle-fetches it and the navigation after that is `dcz` again — the gap is a single request, not the lifetime of a cache entry.
+
+### Which responses get `dcz`
+
+Only `GET` page responses that return `200` with a `text/html` body, and only when the client explicitly lists `dcz` in `Accept-Encoding` — `Accept-Encoding: *` never selects it. Responses that set a cookie are served normally.
+
+<Callout type="danger">
+
+Dictionary compression carries the same risk profile as any HTTP compression of mixed content (BREACH-style side channels): if a page reflects per-user secrets **and** attacker-controlled input, response sizes can leak information. Mochi never delta-compresses a response that sets cookies, but if your pages embed per-user secrets alongside user-supplied content, leave `compressionDictionary` off.
+
+</Callout>
+
+<Callout type="warning">
+
+If you set a `Content-Security-Policy`, the dictionary URL must be allowed by `connect-src` (or `default-src`).
+
+</Callout>
+
+### Serving your own dictionary
+
+The navigation dictionary rides on a public API you can use directly — useful for delta-compressing your own hashed JS bundles. Register bytes in a `DictionaryStore`, serve them with a `Use-As-Dictionary` header, and match the `Available-Dictionary` hash clients send back:
+
+```ts
+import { DictionaryStore, formatUseAsDictionary } from 'mochi-framework';
+
+const dictionaries = new DictionaryStore();
+const entry = dictionaries.add(await Bun.file('./app.dictionary.bin').bytes());
+
+Mochi.api(
+  () =>
+    new Response(entry.bytes, {
+      headers: {
+        'Use-As-Dictionary': formatUseAsDictionary({ match: '/app/*.js' }),
+        'Cache-Control': 'public, max-age=31536000, immutable',
+      },
+    }),
+);
+```
+
+`parseAvailableDictionary`, `parseDictionaryId` and `frameDcz` cover the request side and the `dcz` frame layout. `dcb` (dictionary brotli) is not offered: no server-side encoder exists for it, and `dcz` covers every browser that supports either.

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -27,6 +27,7 @@ Event names use a `namespace:action` convention. Every key is in the typed `Moch
 - [`email:sent`](#emailsent), [`email:error`](#emailerror) — [transactional email](/docs/email/) delivery
 - [`server:start`](#serverstart), [`server:stop`](#serverstop) — server lifecycle
 - [`warmup:start`](#warmupstart), [`warmup:complete`](#warmupcomplete) — route warmup batch (only with `warmup: true`)
+- [`dictionary:ready`](#dictionaryready) — navigation dictionary published (only with `compressionDictionary` enabled)
 - [`error`](#error) — a page/api/action handler threw
 - [`action:invoke`](#actioninvoke), [`action:complete`](#actioncomplete) — form action lifecycle
 - [`compile:start`](#compilestart), [`compile:complete`](#compilecomplete), [`compile:error`](#compileerror) — Svelte SSR build
@@ -299,6 +300,17 @@ Fires once after the [route warmup](/docs/serve-options/#route-warmup) batch fin
 | `routeCount` | `number` | static page routes warmed                |
 | `errorCount` | `number` | warmup invocations that threw or 5xx'd   |
 | `durationMs` | `number` | wall-clock ms for the whole warmup batch |
+
+#### `dictionary:ready`
+
+Fires once when the boot harvest publishes the navigation dictionary. Only emitted with [`compressionDictionary`](/docs/compression-dictionaries/) enabled.
+
+| Field        | Type     | Notes                                                    |
+| ------------ | -------- | -------------------------------------------------------- |
+| `hash`       | `string` | hex SHA-256 — also the `/_mochi/dictionary/:hash` URL id |
+| `sizeBytes`  | `number` | dictionary size, after any over-cap route was skipped    |
+| `routeCount` | `number` | page routes whose HTML made it into the dictionary       |
+| `durationMs` | `number` | wall-clock ms from boot-render start to publish          |
 
 #### `error`
 

--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -79,6 +79,7 @@ In production (`development: false`), prebuilt JS/CSS bundles served from `asset
 - `proxy` — `MochiProxyOptions` for trusted reverse-proxy headers. See below.
 - `hooks` / `filters` — named lifecycle hooks and value filters. See [Extensions](/docs/extensions/).
 - `warmup` — warm the SSR pipeline at startup by invoking every static page route once. `boolean | { enabledInProd, enabledInDev }`. Default: `false`. See below.
+- `compressionDictionary` — serve `dcz`-compressed HTML navigations via Compression Dictionary Transport (RFC 9842). `boolean | MochiCompressionDictionaryOptions`; `true` enables in production only. Default: `false`. See [Compression Dictionaries](/docs/compression-dictionaries/).
 - `bun` — escape hatch for raw `Bun.serve()` options Mochi does not surface — `idleTimeout`, `maxRequestBodySize`, `reusePort`, `tls`. `fetch` / `websocket` / `routes` / `error` are framework-owned and throw if set. See below.
 
 <Callout type="info">

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -102,6 +102,7 @@
     }
   },
   "dependencies": {
+    "@bokuweb/zstd-wasm": "0.0.27",
     "@css-inline/css-inline-wasm": "^0.21.0",
     "@joint-ops/hitlimit-bun": "1.5.0",
     "@noble/ciphers": "2.2.0",

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -56,6 +56,7 @@ import {
   apiError,
   collectHeaderPairs,
   cssLinkTag,
+  extractParams,
   FONT_PRELOAD_MAX,
   fontPreloadTag,
   headResponse,
@@ -67,8 +68,10 @@ import {
   withHead,
 } from './utils';
 import { serveDiskAsset } from './utils/serveDiskAsset';
+import { buildDictionaryBytes, DictionaryStore, formatUseAsDictionary, resolveCompressionDictionary } from './runtime/compressionDictionary';
+import { createDictionaryHandle } from './middleware/dictionaryCompress';
 import type { MochiEvent, MochiEventKind, MochiResolveOptions } from './runtime/hooks';
-import { applyResolveOptions } from './runtime/hooks';
+import { applyResolveOptions, sequence } from './runtime/hooks';
 import { alternateSlashPattern, trailingSlashRedirect } from './runtime/trailingSlash';
 import { resolveWarmupEnabled, markWarmupRequest, isWarmablePattern } from './runtime/warmup';
 import { createErrorResponder, DEFAULT_ERROR_PAGE_PATH } from './runtime/errors';
@@ -483,9 +486,12 @@ export class Mochi {
     const development = options.development ?? true;
     const inlineNestedIslands = options.inlineNestedIslands !== false;
     const warmupEnabled = resolveWarmupEnabled(options.warmup, development);
+    const dictionaryConfig = resolveCompressionDictionary(options.compressionDictionary, development, normalizeAssetPrefix(options.assetPrefix));
+    const dictionaryStore = new DictionaryStore();
     const debugBarEnabled = development && (options.debugBar ?? true);
     const liveReloadEnabled = options.liveReload ?? development;
-    const middleware = options.handle;
+    // The dictionary handle runs innermost so a user `compress()` sees its `Content-Encoding: dcz` and passes it through.
+    const middleware = dictionaryConfig ? sequence(...(options.handle ? [options.handle] : []), createDictionaryHandle(dictionaryConfig, dictionaryStore)) : options.handle;
     const protectionEnabled = options.protection?.enabled === true;
     const baseOutDir = options.outDir ?? './.mochi';
     // Nesting dev artifacts keeps a stale prod manifest and dev chunks apart across a later `start`, while prod stays at
@@ -734,6 +740,7 @@ export class Mochi {
     // Pre-compile Mochi.page() handlers so SSR is ready at startup
     const mochiPageMap = new Map<string, MochiPageConfig>();
     const warmupHandlers: { pattern: string; handler: (req: Request, server: Server<undefined>) => Promise<Response> }[] = [];
+    const harvestHandlers: { pattern: string; handler: (req: Request, server: Server<undefined>) => Promise<Response> }[] = [];
     const wsHandlersMap = new Map<string, MochiWsHandlers<unknown>>();
     const apiHandlerMap = development ? new Map<string, MochiApiHandler>() : undefined;
     const sseHandlerMap = development ? new Map<string, MochiSseHandler>() : undefined;
@@ -994,6 +1001,13 @@ export class Mochi {
 
         if (warmupEnabled && isWarmablePattern(pattern)) {
           warmupHandlers.push({ pattern, handler: getHandler });
+        }
+        if (dictionaryConfig && (!dictionaryConfig.routes || dictionaryConfig.routes.includes(pattern))) {
+          if (isWarmablePattern(pattern)) {
+            harvestHandlers.push({ pattern, handler: getHandler });
+          } else if (dictionaryConfig.routes) {
+            logger.warn(`compressionDictionary: route "${pattern}" has :param or * segments and cannot be rendered at boot — skipped`);
+          }
         }
 
         if (actions || pageConfigMap) {
@@ -1525,6 +1539,23 @@ export class Mochi {
 
     // After the mirroring pass on purpose: a `/*` pattern must not be mirrored to `/*\/`.
     registerStaticDirRoutes(bunRoutes, staticDirMounts);
+
+    if (dictionaryConfig) {
+      bunRoutes[`${registry.assetPrefix}/dictionary/:hash`] = withHead(async (req: Request): Promise<Response> => {
+        const entry = dictionaryStore.getByHex(extractParams(req).hash ?? '');
+        if (!entry) {
+          return new Response('Not found', { status: 404 });
+        }
+        return new Response(entry.bytes, {
+          headers: {
+            'Content-Type': 'application/octet-stream',
+            // match-dest limits dictionary use to navigations; subresources keep their hashed-URL immutable caching.
+            'Use-As-Dictionary': formatUseAsDictionary({ match: '/*', matchDest: ['document', 'frame', 'iframe'] }),
+            'Cache-Control': 'public, max-age=31536000, immutable',
+          },
+        });
+      });
+    }
 
     // Register server island endpoint
     bunRoutes[`${registry.assetPrefix}/island/:componentName`] = withHead(async (req: Request, server: Server<undefined>): Promise<Response> => {
@@ -2087,14 +2118,38 @@ export class Mochi {
       }
     }
 
-    if (warmupHandlers.length > 0) {
-      mochiEvents.emit('warmup:start', { routeCount: warmupHandlers.length });
+    if (dictionaryConfig?.routes) {
+      const unmatched = dictionaryConfig.routes.filter((route) => !harvestHandlers.some((h) => h.pattern === route));
+      if (unmatched.length > 0) {
+        logger.warn(`compressionDictionary: configured route(s) ${unmatched.map((r) => `"${r}"`).join(', ')} match no page route — skipped`);
+      }
+    }
+
+    // Warmup and dictionary harvest share one synthetic-request pass so a route serving both purposes renders once.
+    const bootRenders = new Map<string, { handler: (req: Request, server: Server<undefined>) => Promise<Response>; warm: boolean; harvest: boolean }>();
+    for (const { pattern, handler } of warmupHandlers) {
+      bootRenders.set(pattern, { handler, warm: true, harvest: false });
+    }
+    for (const { pattern, handler } of harvestHandlers) {
+      const existing = bootRenders.get(pattern);
+      if (existing) {
+        existing.harvest = true;
+      } else {
+        bootRenders.set(pattern, { handler, warm: false, harvest: true });
+      }
+    }
+
+    if (bootRenders.size > 0) {
+      if (warmupHandlers.length > 0) {
+        mochiEvents.emit('warmup:start', { routeCount: warmupHandlers.length });
+      }
       const t0 = performance.now();
       // SSR is CPU-bound and serializes on the single thread, so parallel warming would render no faster while smearing
       // every route's `request` duration into the batch total; one at a time keeps per-route timings honest.
       void (async () => {
         let errorCount = 0;
-        for (const { pattern, handler } of warmupHandlers) {
+        const harvested: { pattern: string; html: string }[] = [];
+        for (const [pattern, { handler, warm, harvest }] of bootRenders) {
           // The canonical path keeps the trailing-slash policy from redirecting early instead of running the render being warmed.
           const url = new URL(`http://localhost${pattern}`);
           const redirect = trailingSlashPolicy ? trailingSlashRedirect('GET', url, trailingSlashPolicy) : null;
@@ -2103,18 +2158,57 @@ export class Mochi {
             // The handler swallows render errors and returns a 5xx error page, so 5xx counts as "didn't warm cleanly"
             // alongside a throw. 4xx is expected — an auth-gated route seeing the anonymous warmup visitor.
             const response = await handler(markWarmupRequest(new Request(href)), server);
-            if (response.status >= 500) {
+            if (warm && response.status >= 500) {
               errorCount += 1;
             }
+            if (harvest) {
+              if (response.status === 200 && isHtmlResponse(response)) {
+                harvested.push({ pattern, html: await response.text() });
+              } else {
+                logger.warn(`compressionDictionary: route "${pattern}" returned ${response.status} ${response.headers.get('Content-Type') ?? ''} — not harvested`);
+              }
+            }
           } catch {
-            errorCount += 1;
+            if (warm) {
+              errorCount += 1;
+            }
           }
         }
-        mochiEvents.emit('warmup:complete', {
-          routeCount: warmupHandlers.length,
-          errorCount,
-          durationMs: performance.now() - t0,
-        });
+        if (warmupHandlers.length > 0) {
+          mochiEvents.emit('warmup:complete', {
+            routeCount: warmupHandlers.length,
+            errorCount,
+            durationMs: performance.now() - t0,
+          });
+        }
+        if (dictionaryConfig) {
+          if (harvested.length === 0) {
+            logger.warn('compressionDictionary: no routes rendered into a dictionary — dictionary transport is off for this boot');
+          } else {
+            const { bytes, skipped } = buildDictionaryBytes(
+              harvested.map((h) => h.html),
+              dictionaryConfig.maxDictionaryBytes,
+            );
+            // Naming each route only helps when the user picked them; on the harvest-everything default a big site
+            // overflows the cap by design, so one summary line stands in for dozens of warnings.
+            if (skipped.length > 0) {
+              if (dictionaryConfig.routes) {
+                for (const index of skipped) {
+                  logger.warn(`compressionDictionary: route "${harvested[index]!.pattern}" would exceed maxDictionaryBytes (${dictionaryConfig.maxDictionaryBytes}) — skipped`);
+                }
+              } else {
+                logger.info(`compressionDictionary: dictionary filled at ${dictionaryConfig.maxDictionaryBytes} bytes — ${skipped.length} further route(s) not included`);
+              }
+            }
+            const entry = dictionaryStore.add(bytes);
+            mochiEvents.emit('dictionary:ready', {
+              hash: entry.hashHex,
+              sizeBytes: bytes.length,
+              routeCount: harvested.length - skipped.length,
+              durationMs: performance.now() - t0,
+            });
+          }
+        }
       })();
     }
 

--- a/packages/mochi/src/__fixtures__/dictionary/Page.svelte
+++ b/packages/mochi/src/__fixtures__/dictionary/Page.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  let { title = 'home' } = $props();
+</script>
+
+<header class="site-header">
+  <nav>
+    <a href="/">Home</a>
+    <a href="/about">About</a>
+  </nav>
+</header>
+<main>
+  <h1>{title}</h1>
+  <p>Shared page chrome that a navigation dictionary should compress away.</p>
+</main>
+
+<style>
+  .site-header {
+    border-bottom: 1px solid #ccc;
+  }
+</style>

--- a/packages/mochi/src/compressionDictionary.dev.test.ts
+++ b/packages/mochi/src/compressionDictionary.dev.test.ts
@@ -1,0 +1,43 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+
+const PAGE = path.join(import.meta.dir, '__fixtures__', 'dictionary', 'Page.svelte');
+
+describe('compressionDictionary: true is inert in development', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-dcz-dev-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: true,
+      logger: { enabled: false },
+      outDir,
+      compressionDictionary: true,
+      routes: { '/': Mochi.page(PAGE) },
+    });
+    base = `http://localhost:${server.port}`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('the dictionary route is not registered', async () => {
+    const res = await fetch(`${base}/_mochi/dictionary/${'0'.repeat(64)}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('pages carry no dictionary headers', async () => {
+    const res = await fetch(`${base}/`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get('link')).toBeNull();
+    expect(res.headers.get('vary')).toBeNull();
+  });
+});

--- a/packages/mochi/src/compressionDictionary.test.ts
+++ b/packages/mochi/src/compressionDictionary.test.ts
@@ -1,0 +1,138 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+import { compress } from './middleware/compress';
+import { mochiEvents } from './events';
+import type { MochiDictionaryReadyEvent } from './events';
+import { success } from './runtime/forms';
+import { DCZ_MAGIC, loadDczCodec } from './runtime/compressionDictionary';
+
+const PAGE = path.join(import.meta.dir, '__fixtures__', 'dictionary', 'Page.svelte');
+const CHROME_ACCEPT = 'gzip, deflate, br, zstd, dcz';
+
+describe('compressionDictionary end-to-end', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+  let ready: MochiDictionaryReadyEvent;
+  let dictionaryBytes: Uint8Array;
+  let availableDictionary: string;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-dcz-'));
+    const readyPromise = new Promise<MochiDictionaryReadyEvent>((resolve) => {
+      const handler = (event: MochiDictionaryReadyEvent): void => {
+        mochiEvents.off('dictionary:ready', handler);
+        resolve(event);
+      };
+      mochiEvents.on('dictionary:ready', handler);
+    });
+
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      csrf: { checkOrigin: false },
+      compressionDictionary: { enabledInProd: true, enabledInDev: false, zstdLevel: 12 },
+      handle: compress(),
+      routes: {
+        '/': Mochi.page(PAGE, { serverProps: { title: 'home' } }),
+        '/about': Mochi.page(PAGE, { serverProps: { title: 'about' } }),
+        '/account': Mochi.page(PAGE, { serverProps: { title: 'account' }, actions: { default: () => success({}) } }),
+      },
+    });
+    base = `http://localhost:${server.port}`;
+    ready = await readyPromise;
+
+    const res = await fetch(`${base}/_mochi/dictionary/${ready.hash}`);
+    expect(res.status).toBe(200);
+    dictionaryBytes = new Uint8Array(await res.arrayBuffer());
+    const hasher = new Bun.CryptoHasher('sha256');
+    hasher.update(dictionaryBytes);
+    availableDictionary = `:${Buffer.from(hasher.digest()).toString('base64')}:`;
+  });
+
+  afterAll(() => {
+    server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  async function decode(framed: Uint8Array): Promise<string> {
+    await loadDczCodec();
+    const { createDCtx, decompressUsingDict } = await import('@bokuweb/zstd-wasm');
+    return new TextDecoder().decode(decompressUsingDict(createDCtx(), framed.slice(40), dictionaryBytes));
+  }
+
+  test('harvests every static route and reports the dictionary', () => {
+    expect(ready.routeCount).toBe(3);
+    expect(ready.sizeBytes).toBeGreaterThan(0);
+    expect(ready.hash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  test('pages advertise the dictionary via a Link header', async () => {
+    const res = await fetch(`${base}/`, { headers: { 'Accept-Encoding': 'identity' } });
+    expect(res.headers.get('link')).toBe(`</_mochi/dictionary/${ready.hash}>; rel="compression-dictionary"`);
+    // The harvested HTML must stay byte-identical to what is served, so the advertisement lives in a header.
+    expect(await res.text()).not.toContain('compression-dictionary');
+  });
+
+  test('dictionary endpoint carries Use-As-Dictionary and immutable caching', async () => {
+    const res = await fetch(`${base}/_mochi/dictionary/${ready.hash}`);
+    expect(res.headers.get('content-type')).toBe('application/octet-stream');
+    expect(res.headers.get('use-as-dictionary')).toBe('match="/*", match-dest=("document" "frame" "iframe")');
+    expect(res.headers.get('cache-control')).toBe('public, max-age=31536000, immutable');
+    const hashOfBody = new Bun.CryptoHasher('sha256');
+    hashOfBody.update(new Uint8Array(await res.arrayBuffer()));
+    expect(Buffer.from(hashOfBody.digest()).toString('hex')).toBe(ready.hash);
+  });
+
+  test('unknown dictionary hash 404s', async () => {
+    const res = await fetch(`${base}/_mochi/dictionary/${'0'.repeat(64)}`);
+    expect(res.status).toBe(404);
+  });
+
+  test('a matching Available-Dictionary gets a dcz response that round-trips', async () => {
+    const plainHtml = await (await fetch(`${base}/about`, { headers: { 'Accept-Encoding': 'identity' } })).text();
+
+    const res = await fetch(`${base}/about`, {
+      headers: { 'Accept-Encoding': CHROME_ACCEPT, 'Available-Dictionary': availableDictionary },
+    });
+    expect(res.headers.get('content-encoding')).toBe('dcz');
+    expect(res.headers.get('vary')).toBe('Accept-Encoding, Available-Dictionary');
+
+    const framed = new Uint8Array(await res.arrayBuffer());
+    expect(framed.slice(0, 8)).toEqual(DCZ_MAGIC);
+    expect(Buffer.from(framed.slice(8, 40)).toString('hex')).toBe(ready.hash);
+    expect(await decode(framed)).toBe(plainHtml);
+    expect(framed.length).toBeLessThan(plainHtml.length);
+  });
+
+  test('a form action POST re-render is never dcz-encoded, even holding the dictionary', async () => {
+    const res = await fetch(`${base}/account`, {
+      method: 'POST',
+      headers: { 'Accept-Encoding': CHROME_ACCEPT, 'Available-Dictionary': availableDictionary, 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: '',
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-encoding')).not.toBe('dcz');
+    expect(await res.text()).toContain('account');
+  });
+
+  test('a stale dictionary hash falls back to standard negotiation with Vary intact', async () => {
+    const res = await fetch(`${base}/`, {
+      headers: { 'Accept-Encoding': CHROME_ACCEPT, 'Available-Dictionary': `:${Buffer.alloc(32, 1).toString('base64')}:` },
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-encoding')).not.toBe('dcz');
+    expect(res.headers.get('vary')).toBe('Accept-Encoding, Available-Dictionary');
+  });
+
+  test('clients without Available-Dictionary negotiate normally and still see Vary', async () => {
+    const res = await fetch(`${base}/`, { headers: { 'Accept-Encoding': 'gzip' } });
+    expect(res.headers.get('content-encoding')).toBe('gzip');
+    expect(res.headers.get('vary')).toBe('Accept-Encoding, Available-Dictionary');
+  });
+});

--- a/packages/mochi/src/dev/consoleLogger.ts
+++ b/packages/mochi/src/dev/consoleLogger.ts
@@ -159,6 +159,15 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     };
   });
 
+  subscribe('dictionary:ready', ({ hash, sizeBytes, routeCount, durationMs }) => ({
+    label: 'DICT',
+    path: `${routeCount} ${routeCount === 1 ? 'route' : 'routes'} → ${(sizeBytes / 1024).toFixed(0)} KB`,
+    note: styleText('dim', hash.slice(0, 12)),
+    duration: durationMs,
+    slow,
+    verySlow,
+  }));
+
   subscribe('error', ({ kind, method, path, status, message }) => ({
     label: 'ERR ',
     path,

--- a/packages/mochi/src/events.ts
+++ b/packages/mochi/src/events.ts
@@ -298,6 +298,15 @@ export interface MochiWarmupCompleteEvent {
   durationMs: number;
 }
 
+export interface MochiDictionaryReadyEvent {
+  /** Lowercase hex SHA-256 of the dictionary — also its `/_mochi/dictionary/:hash` URL segment. */
+  hash: string;
+  sizeBytes: number;
+  /** Static page routes whose HTML was harvested into the dictionary. */
+  routeCount: number;
+  durationMs: number;
+}
+
 export type MochiErrorKind = 'page' | 'api' | 'action' | 'file';
 
 export interface MochiErrorEvent {
@@ -457,6 +466,7 @@ export type MochiEventMap = {
   'server:stop': MochiServerStopEvent;
   'warmup:start': MochiWarmupStartEvent;
   'warmup:complete': MochiWarmupCompleteEvent;
+  'dictionary:ready': MochiDictionaryReadyEvent;
   error: MochiErrorEvent;
   'action:invoke': MochiActionInvokeEvent;
   'action:complete': MochiActionCompleteEvent;

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -47,6 +47,8 @@ export { sequence } from './runtime/hooks';
 export { compress } from './middleware/compress';
 export type { CompressOptions } from './middleware/compress';
 export type { CompressionMethod } from './utils';
+export { DictionaryStore, parseAvailableDictionary, parseDictionaryId, formatUseAsDictionary, frameDcz, DCZ_MAGIC } from './runtime/compressionDictionary';
+export type { DictionaryEntry } from './runtime/compressionDictionary';
 export { noCache } from './middleware/noCache';
 export { consoleLogger, silenceInternalRoutes } from './dev/consoleLogger';
 export type { ConsoleLoggerOptions } from './dev/consoleLogger';
@@ -99,6 +101,7 @@ export type {
   MochiServerStopEvent,
   MochiWarmupStartEvent,
   MochiWarmupCompleteEvent,
+  MochiDictionaryReadyEvent,
   MochiErrorEvent,
   MochiErrorKind,
   MochiActionInvokeEvent,
@@ -210,6 +213,7 @@ export type {
   MochiServeOptions,
   MochiWorkerOptions,
   MochiWarmupOptions,
+  MochiCompressionDictionaryOptions,
   MochiRouteValue,
   MochiWsConfig,
   MochiWsHandlers,

--- a/packages/mochi/src/middleware/dictionaryCompress.test.ts
+++ b/packages/mochi/src/middleware/dictionaryCompress.test.ts
@@ -1,0 +1,225 @@
+import { describe, expect, test } from 'bun:test';
+import type { Server } from 'bun';
+import type { MochiEvent } from '../runtime/hooks';
+import { sequence } from '../runtime/hooks';
+import { MochiCookieJar } from '../runtime/cookies';
+import { requestContext, type MochiRequestContext } from '../runtime/requestContext';
+import { DCZ_MAGIC, DictionaryStore, loadDczCodec, type ResolvedCompressionDictionary } from '../runtime/compressionDictionary';
+import { createDictionaryHandle } from './dictionaryCompress';
+import { compress } from './compress';
+
+const DICT = new TextEncoder().encode('<html><head><title>site</title></head><body><nav>Home Docs About</nav>'.repeat(30));
+const PAGE = '<html><head><title>site</title></head><body><nav>Home Docs About</nav><main>' + 'page body '.repeat(100) + '</main></body></html>';
+
+const CHROME_ACCEPT = 'gzip, br, zstd, dcb, dcz';
+
+const OPTS: ResolvedCompressionDictionary = {
+  routes: null,
+  maxDictionaryBytes: 1024 * 1024,
+  zstdLevel: 10,
+  dictionaryPath: '/_mochi/dictionary',
+};
+
+function freshStore(): { store: DictionaryStore; header: string; hashHex: string } {
+  const store = new DictionaryStore();
+  const entry = store.add(DICT);
+  return { store, header: `:${Buffer.from(entry.hash).toString('base64')}:`, hashHex: entry.hashHex };
+}
+
+function makeEvent(req: Request, kind: MochiEvent['kind'] = 'page'): MochiEvent {
+  return { request: req, url: new URL(req.url), server: {} as Server<undefined>, locals: {}, kind, isWarmup: false };
+}
+
+function htmlResponse(body: string = PAGE, init: ResponseInit = {}): Response {
+  return new Response(body, { ...init, headers: { 'Content-Type': 'text/html; charset=utf-8', ...init.headers } });
+}
+
+function dczRequest(url = 'http://localhost/page', extra: Record<string, string> = {}, header?: string): Request {
+  return new Request(url, { headers: { 'Accept-Encoding': 'gzip, br, zstd, dcb, dcz', ...(header ? { 'Available-Dictionary': header } : {}), ...extra } });
+}
+
+async function decodeDcz(response: Response): Promise<{ magic: Uint8Array; hash: Uint8Array; text: string }> {
+  const body = new Uint8Array(await response.arrayBuffer());
+  // Reuse the framework's single init: the lib's init() is not idempotent and corrupts in-flight contexts when re-run.
+  await loadDczCodec();
+  const { createDCtx, decompressUsingDict } = await import('@bokuweb/zstd-wasm');
+  return { magic: body.slice(0, 8), hash: body.slice(8, 40), text: new TextDecoder().decode(decompressUsingDict(createDCtx(), body.slice(40), DICT)) };
+}
+
+describe('createDictionaryHandle()', () => {
+  test('serves dcz when the client advertises the matching dictionary', async () => {
+    const { store, header, hashHex } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+
+    const response = await handle({ event: makeEvent(dczRequest(undefined, {}, header)), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBe('dcz');
+    expect(response.headers.get('Content-Length')).toBeNull();
+    expect(response.headers.get('Vary')).toBe('Accept-Encoding, Available-Dictionary');
+    expect(response.headers.get('Link')).toBe(`</_mochi/dictionary/${hashHex}>; rel="compression-dictionary"`);
+
+    const { magic, text } = await decodeDcz(response);
+    expect(magic).toEqual(DCZ_MAGIC);
+    expect(text).toBe(PAGE);
+  });
+
+  test('advertises Link + Vary without compressing when the client has no dictionary', async () => {
+    const { store, hashHex } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+    const req = new Request('http://localhost/page', { headers: { 'Accept-Encoding': 'gzip, br' } });
+
+    const response = await handle({ event: makeEvent(req), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+    expect(response.headers.get('Link')).toBe(`</_mochi/dictionary/${hashHex}>; rel="compression-dictionary"`);
+    expect(response.headers.get('Vary')).toBe('Accept-Encoding, Available-Dictionary');
+    expect(await response.text()).toBe(PAGE);
+  });
+
+  test('falls back on a hash miss', async () => {
+    const { store } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+    const stale = `:${Buffer.alloc(32, 7).toString('base64')}:`;
+
+    const response = await handle({ event: makeEvent(dczRequest(undefined, {}, stale)), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+    expect(await response.text()).toBe(PAGE);
+  });
+
+  // The framework only ever registers one dictionary per boot, but the store matches any it holds — the hook a future
+  // deploy-spanning dictionary would need.
+  test('a client holding a non-current registered dictionary gets a dcz framed against that one', async () => {
+    const { store } = freshStore();
+    const old = store.add(new TextEncoder().encode('an older deploy'.repeat(50)));
+    const current = store.add(new TextEncoder().encode('the newest deploy'.repeat(50)));
+    const handle = createDictionaryHandle(OPTS, store);
+    const header = `:${Buffer.from(old.hash).toString('base64')}:`;
+
+    const response = await handle({ event: makeEvent(dczRequest(undefined, {}, header)), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBe('dcz');
+    expect(response.headers.get('Link')).toBe(`</_mochi/dictionary/${current.hashHex}>; rel="compression-dictionary"`);
+    const body = new Uint8Array(await response.arrayBuffer());
+    expect(body.slice(8, 40)).toEqual(old.hash);
+  });
+
+  test('falls back when dcz is offered with q=0', async () => {
+    const { store, header } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+    const req = new Request('http://localhost/page', { headers: { 'Accept-Encoding': 'dcz;q=0, gzip', 'Available-Dictionary': header } });
+
+    const response = await handle({ event: makeEvent(req), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+  });
+
+  test('Accept-Encoding: * never selects dcz', async () => {
+    const { store, header } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+    const req = new Request('http://localhost/page', { headers: { 'Accept-Encoding': '*', 'Available-Dictionary': header } });
+
+    const response = await handle({ event: makeEvent(req), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+  });
+
+  test('does nothing before the boot harvest installs a dictionary', async () => {
+    const store = new DictionaryStore();
+    const handle = createDictionaryHandle(OPTS, store);
+    const header = `:${Buffer.alloc(32, 1).toString('base64')}:`;
+
+    const response = await handle({ event: makeEvent(dczRequest(undefined, {}, header)), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+    expect(response.headers.get('Link')).toBeNull();
+    expect(response.headers.get('Vary')).toBeNull();
+  });
+
+  test('skips non-page kinds, non-GET methods, non-200 statuses, and non-HTML bodies', async () => {
+    const { store, header } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+
+    const asset = await handle({ event: makeEvent(dczRequest('http://localhost/a.js', {}, header), 'asset'), resolve: async () => htmlResponse() });
+    expect(asset.headers.get('Link')).toBeNull();
+
+    const post = await handle({
+      event: makeEvent(new Request('http://localhost/page', { method: 'POST', headers: { 'Accept-Encoding': 'dcz', 'Available-Dictionary': header } })),
+      resolve: async () => htmlResponse(),
+    });
+    expect(post.headers.get('Content-Encoding')).toBeNull();
+    expect(post.headers.get('Link')).toBeNull();
+
+    const notFound = await handle({ event: makeEvent(dczRequest(undefined, {}, header)), resolve: async () => htmlResponse(PAGE, { status: 404 }) });
+    expect(notFound.headers.get('Content-Encoding')).toBeNull();
+    expect(notFound.headers.get('Link')).toBeNull();
+
+    const json = await handle({
+      event: makeEvent(dczRequest(undefined, {}, header)),
+      resolve: async () => new Response('{}', { headers: { 'Content-Type': 'application/json' } }),
+    });
+    expect(json.headers.get('Link')).toBeNull();
+  });
+
+  test('HEAD mirrors the GET advertisement headers but is never encoded', async () => {
+    const { store, header, hashHex } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+    const req = new Request('http://localhost/page', { method: 'HEAD', headers: { 'Accept-Encoding': CHROME_ACCEPT, 'Available-Dictionary': header } });
+
+    const response = await handle({ event: makeEvent(req), resolve: async () => htmlResponse() });
+
+    // A shared cache may store a HEAD response, so it needs the same Vary as the GET it mirrors.
+    expect(response.headers.get('Vary')).toBe('Accept-Encoding, Available-Dictionary');
+    expect(response.headers.get('Link')).toBe(`</_mochi/dictionary/${hashHex}>; rel="compression-dictionary"`);
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+  });
+
+  test('skips dcz when the response already carries Set-Cookie', async () => {
+    const { store, header, hashHex } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+
+    const response = await handle({
+      event: makeEvent(dczRequest(undefined, {}, header)),
+      resolve: async () => htmlResponse(PAGE, { headers: { 'Set-Cookie': 'session=abc' } }),
+    });
+
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+    // Still advertised: only the delta encoding is withheld, not the dictionary itself.
+    expect(response.headers.get('Link')).toBe(`</_mochi/dictionary/${hashHex}>; rel="compression-dictionary"`);
+  });
+
+  test('skips dcz for a cookie pending on the jar, which finalizeCookieHeaders only attaches after middleware', async () => {
+    const { store, header } = freshStore();
+    const handle = createDictionaryHandle(OPTS, store);
+    const jar = new MochiCookieJar(null);
+    jar.set('session', 'abc');
+    const ctx = { cookies: jar } as MochiRequestContext;
+
+    const response = await requestContext.run(ctx, () => handle({ event: makeEvent(dczRequest(undefined, {}, header)), resolve: async () => htmlResponse() }));
+
+    expect(response.headers.get('Content-Encoding')).toBeNull();
+    expect(await response.text()).toBe(PAGE);
+  });
+
+  test('composes with compress(): dcz passes through untouched', async () => {
+    const { store, header } = freshStore();
+    const handle = sequence(compress(), createDictionaryHandle(OPTS, store));
+
+    const response = await handle({ event: makeEvent(dczRequest(undefined, {}, header)), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBe('dcz');
+    expect((await decodeDcz(response)).text).toBe(PAGE);
+  });
+
+  test('composes with compress(): clients without a dictionary still get zstd', async () => {
+    const { store, hashHex } = freshStore();
+    const handle = sequence(compress(), createDictionaryHandle(OPTS, store));
+    const req = new Request('http://localhost/page', { headers: { 'Accept-Encoding': 'zstd, gzip' } });
+
+    const response = await handle({ event: makeEvent(req), resolve: async () => htmlResponse() });
+
+    expect(response.headers.get('Content-Encoding')).toBe('zstd');
+    expect(response.headers.get('Link')).toBe(`</_mochi/dictionary/${hashHex}>; rel="compression-dictionary"`);
+    expect(response.headers.get('Vary')).toBe('Accept-Encoding, Available-Dictionary');
+  });
+});

--- a/packages/mochi/src/middleware/dictionaryCompress.ts
+++ b/packages/mochi/src/middleware/dictionaryCompress.ts
@@ -1,0 +1,54 @@
+import type { Handle } from '../runtime/hooks';
+import { getRequestContext } from '../runtime/requestContext';
+import { acceptsDcz, encodeDcz, type DictionaryStore, type ResolvedCompressionDictionary } from '../runtime/compressionDictionary';
+import { appendVary, isHtmlResponse } from '../utils';
+
+// RFC 9842 §9.2: compressing a page that also sets per-user secrets against a public dictionary is a BREACH-shaped
+// oracle, so any pending Set-Cookie (jar writes land after middleware, via finalizeCookieHeaders) disables dcz.
+function setsCookies(response: Response): boolean {
+  if (response.headers.getSetCookie().length > 0) {
+    return true;
+  }
+  try {
+    return getRequestContext().cookies.getSetCookieHeaders().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Framework-internal innermost middleware: advertises the dictionary on HTML pages and serves dcz to clients that hold it. */
+export function createDictionaryHandle(opts: ResolvedCompressionDictionary, store: DictionaryStore): Handle {
+  return async ({ event, resolve }) => {
+    const response = await resolve(event);
+
+    // HEAD is advertised alongside GET so a cached HEAD carries the same Vary; only GET is ever encoded.
+    const method = event.request.method;
+    if (event.kind !== 'page' || (method !== 'GET' && method !== 'HEAD')) {
+      return response;
+    }
+    const current = store.current;
+    if (!current || response.status !== 200 || !isHtmlResponse(response) || response.headers.get('Content-Encoding')) {
+      return response;
+    }
+
+    // Both dimensions vary the bytes: the encoding chosen and whether the client holds the dictionary.
+    appendVary(response.headers, 'Accept-Encoding');
+    appendVary(response.headers, 'Available-Dictionary');
+    response.headers.append('Link', `<${opts.dictionaryPath}/${current.hashHex}>; rel="compression-dictionary"`);
+
+    if (method !== 'GET' || !acceptsDcz(event.request.headers.get('Accept-Encoding') ?? '')) {
+      return response;
+    }
+    // A client may hold a previous deploy's dictionary; serve whichever one it actually has.
+    const entry = store.match(event.request.headers.get('Available-Dictionary'));
+    if (!entry || setsCookies(response)) {
+      return response;
+    }
+
+    const framed = await encodeDcz(new Uint8Array(await response.arrayBuffer()), entry, opts.zstdLevel);
+    const headers = new Headers(response.headers);
+    headers.set('Content-Encoding', 'dcz');
+    headers.delete('Content-Length');
+    return new Response(framed, { status: response.status, statusText: response.statusText, headers });
+  };
+}

--- a/packages/mochi/src/runtime/compressionDictionary.test.ts
+++ b/packages/mochi/src/runtime/compressionDictionary.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, test } from 'bun:test';
+import {
+  acceptsDcz,
+  buildDictionaryBytes,
+  DCZ_MAGIC,
+  DictionaryStore,
+  encodeDcz,
+  formatUseAsDictionary,
+  frameDcz,
+  loadDczCodec,
+  parseAvailableDictionary,
+  parseDictionaryId,
+  resolveCompressionDictionary,
+} from './compressionDictionary';
+
+function sha256(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(bytes);
+  return new Uint8Array(hasher.digest());
+}
+
+function availableDictionaryHeader(dictionary: Uint8Array): string {
+  return `:${Buffer.from(sha256(dictionary)).toString('base64')}:`;
+}
+
+describe('parseAvailableDictionary', () => {
+  const validB64 = Buffer.alloc(32, 7).toString('base64');
+
+  test('accepts a well-formed 32-byte sequence', () => {
+    const parsed = parseAvailableDictionary(`:${validB64}:`);
+    expect(parsed).toEqual(new Uint8Array(Buffer.alloc(32, 7)));
+  });
+
+  test('tolerates surrounding whitespace', () => {
+    expect(parseAvailableDictionary(`  :${validB64}:  `)).not.toBeNull();
+  });
+
+  test.each([
+    [null, 'null'],
+    ['', 'empty'],
+    ['::', 'empty sequence'],
+    [validB64, 'missing colons'],
+    [`:${validB64}`, 'missing trailing colon'],
+    [`:${Buffer.alloc(16, 7).toString('base64')}:`, 'wrong hash length'],
+    [`:${validB64.slice(0, -1)}!:`, 'invalid base64 characters'],
+    [`:${validB64.slice(0, -2)}:`, 'truncated base64'],
+    [':not base64 at all:', 'garbage'],
+  ])('rejects %p (%s)', (value) => {
+    expect(parseAvailableDictionary(value as string | null)).toBeNull();
+  });
+});
+
+describe('parseDictionaryId', () => {
+  test('unquotes a structured-field string', () => {
+    expect(parseDictionaryId('"dictionary-12345"')).toBe('dictionary-12345');
+  });
+
+  test('unescapes backslash escapes', () => {
+    expect(parseDictionaryId('"a\\"b\\\\c"')).toBe('a"b\\c');
+  });
+
+  test.each([[null], [''], ['unquoted'], ['"unterminated']])('rejects %p', (value) => {
+    expect(parseDictionaryId(value as string | null)).toBeNull();
+  });
+});
+
+describe('formatUseAsDictionary', () => {
+  test('match only', () => {
+    expect(formatUseAsDictionary({ match: '/*' })).toBe('match="/*"');
+  });
+
+  test('match with destinations and id', () => {
+    expect(formatUseAsDictionary({ match: '/*', matchDest: ['document', 'frame'], id: 'dict-1' })).toBe('match="/*", match-dest=("document" "frame"), id="dict-1"');
+  });
+
+  test('escapes quotes and backslashes', () => {
+    expect(formatUseAsDictionary({ match: '/a"b\\c' })).toBe('match="/a\\"b\\\\c"');
+  });
+});
+
+describe('frameDcz', () => {
+  test('emits magic, hash, then the stream', () => {
+    const hash = new Uint8Array(32).fill(9);
+    const stream = Uint8Array.of(1, 2, 3);
+    const framed = frameDcz(stream, hash);
+    expect(framed.length).toBe(8 + 32 + 3);
+    expect(framed.slice(0, 8)).toEqual(DCZ_MAGIC);
+    expect(framed.slice(8, 40)).toEqual(hash);
+    expect(framed.slice(40)).toEqual(stream);
+  });
+
+  test('rejects a hash that is not 32 bytes', () => {
+    expect(() => frameDcz(new Uint8Array(3), new Uint8Array(31))).toThrow('32 bytes');
+  });
+});
+
+describe('DictionaryStore', () => {
+  test('add + getByHex + match round-trip', () => {
+    const store = new DictionaryStore();
+    const bytes = new TextEncoder().encode('<html>shared shell</html>');
+    const entry = store.add(bytes, { id: 'nav' });
+
+    expect(entry.hash).toEqual(sha256(bytes));
+    expect(entry.hashHex).toBe(Buffer.from(sha256(bytes)).toString('hex'));
+    expect(entry.id).toBe('nav');
+    expect(store.getByHex(entry.hashHex)).toBe(entry);
+    expect(store.getByHex(entry.hashHex.toUpperCase())).toBe(entry);
+    expect(store.match(availableDictionaryHeader(bytes))).toBe(entry);
+  });
+
+  test('match misses on an unknown hash or malformed header', () => {
+    const store = new DictionaryStore();
+    store.add(new TextEncoder().encode('a'));
+    expect(store.match(availableDictionaryHeader(new TextEncoder().encode('b')))).toBeNull();
+    expect(store.match('garbage')).toBeNull();
+    expect(store.match(null)).toBeNull();
+  });
+});
+
+describe('acceptsDcz', () => {
+  test('an explicit dcz token matches', () => {
+    expect(acceptsDcz('gzip, br, zstd, dcb, dcz')).toBe(true);
+    expect(acceptsDcz('DCZ')).toBe(true);
+  });
+
+  test('q=0 disables it', () => {
+    expect(acceptsDcz('dcz;q=0')).toBe(false);
+    expect(acceptsDcz('dcz;q=0.0, gzip')).toBe(false);
+    expect(acceptsDcz('dcz;q=0.5')).toBe(true);
+  });
+
+  test('a wildcard never selects dcz', () => {
+    expect(acceptsDcz('*')).toBe(false);
+    expect(acceptsDcz('gzip, br')).toBe(false);
+    expect(acceptsDcz('')).toBe(false);
+    expect(acceptsDcz('dcb')).toBe(false);
+  });
+});
+
+describe('buildDictionaryBytes', () => {
+  test('joins pages with a newline', () => {
+    const { bytes, skipped } = buildDictionaryBytes(['aa', 'bb'], 1024);
+    expect(bytes).toEqual(new TextEncoder().encode('aa\nbb'));
+    expect(skipped).toEqual([]);
+  });
+
+  test('skips whole pages that would exceed the cap, reporting their index', () => {
+    const { bytes, skipped } = buildDictionaryBytes(['aa', 'cccccccccc', 'bb'], 5);
+    expect(new TextDecoder().decode(bytes)).toBe('aa\nbb');
+    expect(skipped).toEqual([1]);
+  });
+});
+
+describe('resolveCompressionDictionary', () => {
+  test('boolean true is production-only', () => {
+    expect(resolveCompressionDictionary(true, true, '/_mochi')).toBeNull();
+    expect(resolveCompressionDictionary(true, false, '/_mochi')).toEqual({
+      routes: null,
+      maxDictionaryBytes: 262144,
+      zstdLevel: 10,
+      dictionaryPath: '/_mochi/dictionary',
+    });
+  });
+
+  test('false and undefined stay off', () => {
+    expect(resolveCompressionDictionary(false, false, '/_mochi')).toBeNull();
+    expect(resolveCompressionDictionary(undefined, false, '/_mochi')).toBeNull();
+  });
+
+  test('object form controls each mode and carries overrides', () => {
+    const opts = { enabledInProd: false, enabledInDev: true, routes: ['/'], maxDictionaryBytes: 1024, zstdLevel: 3 };
+    expect(resolveCompressionDictionary(opts, false, '/_mochi')).toBeNull();
+    expect(resolveCompressionDictionary(opts, true, '/_mochi')).toEqual({
+      routes: ['/'],
+      maxDictionaryBytes: 1024,
+      zstdLevel: 3,
+      dictionaryPath: '/_mochi/dictionary',
+    });
+  });
+
+  test('dictionaryPath follows a custom asset prefix', () => {
+    expect(resolveCompressionDictionary(true, false, '/custom')?.dictionaryPath).toBe('/custom/dictionary');
+  });
+});
+
+describe('encodeDcz', () => {
+  test('frames a dictionary-decodable zstd stream behind the magic and dictionary hash', async () => {
+    const store = new DictionaryStore();
+    const dictionary = new TextEncoder().encode('<html><body><nav>shared shell markup</nav>'.repeat(20));
+    const entry = store.add(dictionary);
+    const payload = new TextEncoder().encode('<html><body><nav>shared shell markup</nav><main>unique</main></body></html>');
+
+    const framed = await encodeDcz(payload, entry, 10);
+
+    expect(framed.slice(0, 8)).toEqual(DCZ_MAGIC);
+    expect(framed.slice(8, 40)).toEqual(entry.hash);
+
+    // Reuse the framework's single init: the lib's init() is not idempotent and corrupts in-flight contexts when re-run.
+    await loadDczCodec();
+    const { createDCtx, decompressUsingDict } = await import('@bokuweb/zstd-wasm');
+    expect(Buffer.from(decompressUsingDict(createDCtx(), framed.slice(40), dictionary)).equals(Buffer.from(payload))).toBe(true);
+  });
+});

--- a/packages/mochi/src/runtime/compressionDictionary.ts
+++ b/packages/mochi/src/runtime/compressionDictionary.ts
@@ -1,0 +1,216 @@
+import type { MochiCompressionDictionaryOptions } from '../types';
+
+/** The `dcz` frame prefix from RFC 9842: a zstd skippable-frame header carrying the 32-byte dictionary hash. */
+export const DCZ_MAGIC = Uint8Array.of(0x5e, 0x2a, 0x4d, 0x18, 0x20, 0x00, 0x00, 0x00);
+
+const SHA256_BYTES = 32;
+
+/** A dictionary registered for Compression Dictionary Transport. */
+export interface DictionaryEntry {
+  bytes: Uint8Array<ArrayBuffer>;
+  /** Raw SHA-256 of `bytes` — what clients echo in `Available-Dictionary`. */
+  hash: Uint8Array<ArrayBuffer>;
+  hashHex: string;
+  id?: string;
+}
+
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/**
+ * Parse an `Available-Dictionary` request header — an RFC 8941 byte sequence (`:base64:`).
+ * Strict: anything that isn't exactly one well-formed 32-byte hash returns `null`.
+ */
+export function parseAvailableDictionary(value: string | null): Uint8Array | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length < 3 || !trimmed.startsWith(':') || !trimmed.endsWith(':')) {
+    return null;
+  }
+  const b64 = trimmed.slice(1, -1);
+  if (b64.length % 4 !== 0 || !BASE64_RE.test(b64)) {
+    return null;
+  }
+  const bytes = new Uint8Array(Buffer.from(b64, 'base64'));
+  return bytes.length === SHA256_BYTES ? bytes : null;
+}
+
+/** Parse a `Dictionary-ID` request header (RFC 8941 string). Informational only — the hash stays authoritative. */
+export function parseDictionaryId(value: string | null): string | null {
+  if (!value) {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (trimmed.length < 2 || !trimmed.startsWith('"') || !trimmed.endsWith('"')) {
+    return null;
+  }
+  return trimmed.slice(1, -1).replace(/\\(.)/g, '$1');
+}
+
+function sfString(value: string): string {
+  return `"${value.replace(/([\\"])/g, '\\$1')}"`;
+}
+
+/** Format a `Use-As-Dictionary` response header (RFC 9842 §2.1). */
+export function formatUseAsDictionary(opts: { match: string; matchDest?: string[]; id?: string }): string {
+  let out = `match=${sfString(opts.match)}`;
+  if (opts.matchDest && opts.matchDest.length > 0) {
+    out += `, match-dest=(${opts.matchDest.map(sfString).join(' ')})`;
+  }
+  if (opts.id) {
+    out += `, id=${sfString(opts.id)}`;
+  }
+  return out;
+}
+
+/** Prefix a dictionary-compressed zstd stream with the `dcz` magic + dictionary hash. */
+export function frameDcz(zstdStream: Uint8Array, dictionaryHash: Uint8Array): Uint8Array<ArrayBuffer> {
+  if (dictionaryHash.length !== SHA256_BYTES) {
+    throw new Error(`[mochi] dcz dictionary hash must be ${SHA256_BYTES} bytes, got ${dictionaryHash.length}`);
+  }
+  const out = new Uint8Array(DCZ_MAGIC.length + SHA256_BYTES + zstdStream.length);
+  out.set(DCZ_MAGIC, 0);
+  out.set(dictionaryHash, DCZ_MAGIC.length);
+  out.set(zstdStream, DCZ_MAGIC.length + SHA256_BYTES);
+  return out;
+}
+
+function sha256(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(bytes);
+  return new Uint8Array(hasher.digest());
+}
+
+/** Registered dictionaries, looked up by the hash a client presents in `Available-Dictionary`. */
+export class DictionaryStore {
+  private byHex = new Map<string, DictionaryEntry>();
+  /** The entry pages advertise. A client may still hold an older one, which `match()` keeps serving. */
+  current: DictionaryEntry | null = null;
+
+  add(bytes: Uint8Array<ArrayBuffer>, opts?: { id?: string }): DictionaryEntry {
+    const hash = sha256(bytes);
+    const entry: DictionaryEntry = { bytes, hash, hashHex: Buffer.from(hash).toString('hex'), ...(opts?.id ? { id: opts.id } : {}) };
+    this.byHex.set(entry.hashHex, entry);
+    this.current = entry;
+    return entry;
+  }
+
+  getByHex(hex: string): DictionaryEntry | undefined {
+    return this.byHex.get(hex.toLowerCase());
+  }
+
+  match(availableDictionaryHeader: string | null): DictionaryEntry | null {
+    const hash = parseAvailableDictionary(availableDictionaryHeader);
+    return hash ? (this.byHex.get(Buffer.from(hash).toString('hex')) ?? null) : null;
+  }
+}
+
+type DczCodec = Pick<typeof import('@bokuweb/zstd-wasm'), 'createCCtx' | 'freeCCtx' | 'compressUsingDict'>;
+
+let codecPromise: Promise<DczCodec> | null = null;
+
+// Loaded lazily so the wasm module (and its ~1 MB instantiation) costs nothing unless the feature is enabled.
+export function loadDczCodec(): Promise<DczCodec> {
+  codecPromise ??= (async () => {
+    const zstd = await import('@bokuweb/zstd-wasm');
+    await zstd.init();
+    return zstd;
+  })();
+  return codecPromise;
+}
+
+/**
+ * Whether `Accept-Encoding` explicitly lists `dcz` with a non-zero q. RFC 9842 clients advertise dictionary encodings
+ * only when they hold a matching dictionary, so `*` must never select dcz — hence no generic negotiator here.
+ */
+export function acceptsDcz(acceptEncoding: string): boolean {
+  for (const part of acceptEncoding.split(',')) {
+    const [name, ...params] = part.trim().split(';');
+    if (name?.trim().toLowerCase() !== 'dcz') {
+      continue;
+    }
+    for (const param of params) {
+      const [key, value] = param.split('=');
+      if (key?.trim().toLowerCase() === 'q' && parseFloat(value ?? '') === 0) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return false;
+}
+
+export const DEFAULT_ZSTD_LEVEL = 10;
+export const DEFAULT_MAX_DICTIONARY_BYTES = 262144;
+
+/** Compress `payload` against a registered dictionary and frame it as `dcz`. */
+export async function encodeDcz(payload: Uint8Array, entry: DictionaryEntry, level: number = DEFAULT_ZSTD_LEVEL): Promise<Uint8Array<ArrayBuffer>> {
+  const codec = await loadDczCodec();
+  // A fresh context per call: the lib's `init()` re-instantiates the wasm heap, so a long-cached cctx can dangle.
+  const cctx = codec.createCCtx();
+  try {
+    return frameDcz(codec.compressUsingDict(cctx, payload, entry.bytes, level), entry.hash);
+  } finally {
+    codec.freeCCtx(cctx);
+  }
+}
+
+/**
+ * Join harvested pages into dictionary bytes, dropping any page that would push the total past `maxBytes` — a
+ * whole-page skip keeps the dictionary deterministic where a mid-page truncation would not. Returns the dropped
+ * indices so the caller can name the routes it skipped.
+ */
+export function buildDictionaryBytes(pages: string[], maxBytes: number): { bytes: Uint8Array<ArrayBuffer>; skipped: number[] } {
+  const encoder = new TextEncoder();
+  const parts: Uint8Array[] = [];
+  const skipped: number[] = [];
+  let total = 0;
+  for (const [index, page] of pages.entries()) {
+    const encoded = encoder.encode(page);
+    const separator = parts.length > 0 ? 1 : 0;
+    if (total + separator + encoded.length > maxBytes) {
+      skipped.push(index);
+      continue;
+    }
+    if (separator) {
+      parts.push(Uint8Array.of(0x0a));
+    }
+    parts.push(encoded);
+    total += separator + encoded.length;
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const part of parts) {
+    bytes.set(part, offset);
+    offset += part.length;
+  }
+  return { bytes, skipped };
+}
+
+export interface ResolvedCompressionDictionary {
+  /** Static page patterns to harvest, or `null` for every warmable page route. */
+  routes: string[] | null;
+  maxDictionaryBytes: number;
+  zstdLevel: number;
+  /** Serve path of the dictionary route, `${assetPrefix}/dictionary`; the hash is appended per entry. */
+  dictionaryPath: string;
+}
+
+/** Boolean `true` enables in production only, mirroring `warmup` — dev HTML churns too fast for a boot-built dictionary to pay off. */
+export function resolveCompressionDictionary(
+  value: boolean | MochiCompressionDictionaryOptions | undefined,
+  development: boolean,
+  assetPrefix: string,
+): ResolvedCompressionDictionary | null {
+  if (!value || (typeof value === 'boolean' ? development : !(development ? value.enabledInDev : value.enabledInProd))) {
+    return null;
+  }
+  const opts = typeof value === 'boolean' ? undefined : value;
+  return {
+    routes: opts?.routes ?? null,
+    maxDictionaryBytes: opts?.maxDictionaryBytes ?? DEFAULT_MAX_DICTIONARY_BYTES,
+    zstdLevel: opts?.zstdLevel ?? DEFAULT_ZSTD_LEVEL,
+    dictionaryPath: `${assetPrefix}/dictionary`,
+  };
+}

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -437,6 +437,23 @@ export interface MochiWarmupOptions {
   enabledInDev: boolean;
 }
 
+/**
+ * Object form of `MochiServeOptions['compressionDictionary']` for per-mode
+ * control and tuning. See that field for semantics.
+ */
+export interface MochiCompressionDictionaryOptions {
+  /** Serve a navigation dictionary when running in production (`development: false`). */
+  enabledInProd: boolean;
+  /** Serve a navigation dictionary when running in development (`development: true`) — useful for testing; the dictionary is built once at boot and does not track dev edits. */
+  enabledInDev: boolean;
+  /** Static page patterns to build the dictionary from. Default: every static (warmable) page route. */
+  routes?: string[];
+  /** Cap on the dictionary size in bytes — it's an extra idle-time download for first-time visitors. Default: 256 KB. */
+  maxDictionaryBytes?: number;
+  /** zstd compression level for per-response `dcz` encoding. Default: 10. */
+  zstdLevel?: number;
+}
+
 /** Keys the framework sets on `Bun.serve()` itself; rejected under `bun` and stripped from `BunServeOverrides`. */
 export const FRAMEWORK_OWNED_BUN_KEYS = ['fetch', 'websocket', 'routes', 'error'] as const;
 
@@ -669,6 +686,19 @@ export interface MochiServeOptions {
    * the server accepts traffic immediately and a `warmup:complete` event fires once the batch finishes. Default: `false`.
    */
   warmup?: boolean | MochiWarmupOptions;
+  /**
+   * Compression Dictionary Transport (RFC 9842) for page navigations. At boot, Mochi renders the site's static page
+   * routes, publishes the harvested HTML as a shared dictionary at `/_mochi/dictionary/:hash`, advertises it on every
+   * HTML page with a `Link: rel="compression-dictionary"` header, and serves `dcz`-encoded HTML to browsers that
+   * present a matching `Available-Dictionary` hash — repeat navigations then transfer only what a page doesn't share
+   * with the dictionary. Only GET page responses that are 200 `text/html` and set no cookies are ever dcz-encoded.
+   *
+   * Chromium 130+ only; every other client falls back to your regular `compress()` / plain negotiation via `Vary`.
+   *
+   * Pass `true` to enable in **production only**, or a `MochiCompressionDictionaryOptions` object for per-mode control
+   * and tuning. Default: `false`.
+   */
+  compressionDictionary?: boolean | MochiCompressionDictionaryOptions;
   /**
    * On-the-fly image transforms via named sizes, mounting a signed `/_mochi/image/*` endpoint behind `getImageUrl()` and `<Image>`.
    * Every served URL's payload is encrypted, so arbitrary sources and transforms stay unreachable. Default: enabled; pass

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -198,6 +198,7 @@ await Mochi.serve({
   idleTimeout: 60,
   compressServerIslandProps: true,
   warmup: { enabledInProd: true, enabledInDev: true },
+  compressionDictionary: true,
   additionalWatchPaths: ['../docs'],
   logger: { level: 'log' },
   proxy: { origin }, // TODO: This is a bit of an awkward way to set the allowed csrf domain...


### PR DESCRIPTION
## What

[Compression Dictionary Transport (RFC 9842)](https://www.rfc-editor.org/rfc/rfc9842) for HTML page navigations, behind an opt-in `Mochi.serve({ compressionDictionary })` flag (default `false`, production-only).

Pages on a Mochi site share most of their markup — shell, nav, footer. With `compressionDictionary: true`:

1. At boot, the framework renders the site's static page routes through their real handlers and installs the harvested HTML as a raw dictionary. This shares one synthetic-request pass with `warmup`, so a route serving both purposes renders once.
2. The dictionary is served from a **content-addressed** `/_mochi/dictionary/:hash` with `Use-As-Dictionary: match="/*", match-dest=("document" "frame" "iframe")` and `immutable` caching.
3. Every HTML page advertises it via `Link: </_mochi/dictionary/<hash>>; rel="compression-dictionary"` + `Vary: Accept-Encoding, Available-Dictionary`.
4. Requests carrying the matching `Available-Dictionary` SHA-256 with `dcz` in `Accept-Encoding` get a **dictionary-compressed Zstandard** response (40-byte skippable-frame header + zstd stream, per §5).

### Measured on the main site (enabled here)

| Page | plain | gzip | zstd | **dcz** |
| --- | --- | --- | --- | --- |
| `/docs/intro/` | 143.7 kB | 31.7 kB | 30.6 kB | **2.9 kB** |

Verified end-to-end in headless Chrome: it idle-fetches the dictionary from the `Link` header on first visit, sends `Available-Dictionary` on the next navigation, receives `Content-Encoding: dcz`, and renders with a clean console.

## Design notes

- **Codec**: `@bokuweb/zstd-wasm` (MIT, zero deps, wasm — no native build), a direct dependency loaded lazily so it costs nothing unless the feature is on. Re-verified on **Bun 1.4.0**: `Bun.zstdCompressSync` still silently ignores its `dictionary` option (byte-identical output with and without), and `node:zlib` has no dictionary API — an external codec is still required. A fresh cctx per compression, freed in `finally`, because the lib's `init()` is not idempotent. dcz-only: there is no maintained brotli-with-dictionary encoder, and Chrome supports both.
- **Wiring**: an internal `Handle` composed innermost after the user's `handle`, so a user `compress()` sees `Content-Encoding: dcz` and passes it through; clients without the dictionary still negotiate zstd/gzip normally. `middleware/compress.ts` and `utils/index.ts` are untouched.
- **Deploys**: the content-addressed immutable URL means a deploy costs a returning visitor exactly **one** fallback navigation — the `Link` header on that response already points at the new dictionary, so the browser idle-fetches it and the navigation after that is `dcz` again.

## Security (RFC 9842 §9)

dcz is only ever applied to **GET** page responses that are **200** and **`text/html`**, and **never** to a response that sets a cookie — the pending cookie jar is checked as well as the response headers, since `finalizeCookieHeaders` attaches `Set-Cookie` *after* the middleware chain, and `wrapRequest` is shared by the page GET **and** form-action POST handlers. `Accept-Encoding: *` never selects dcz, and `q=0` is honoured. Docs carry a danger callout for apps reflecting per-user secrets alongside attacker-controlled input.

## Tests

53 new tests: unit (header building/parsing, `acceptsDcz` negotiation, dcz frame layout, dictionary assembly, option resolution), handle-level (round-trip, fallbacks, `Set-Cookie` skip via both paths, HEAD parity, `compress()` composition), and full `Mochi.serve` e2e in prod and dev modes — including an assertion that a form-action POST re-render is never dcz-encoded. The three security guards were mutation-tested: disabling each one fails exactly the intended test.

`bun run checks` is green across all workspaces — 186/186 framework, 14/14 site, 3/3 support.

## Supersedes #267

#267 was a parallel implementation of the same feature and is now closed. This PR takes its security model wholesale (the GET/200/`Set-Cookie` guards, `acceptsDcz`, the BREACH danger callout, the boot diagnostics) on top of this branch's architecture (content-addressed dictionary URL, merged warmup+harvest pass), and adopts its simpler codec strategy — a direct `@bokuweb/zstd-wasm` dependency rather than a separate optional `@mochi-framework/zstd` package, which is dropped here along with its release wiring.
