### PR TITLE
fix(compiler): keep SSR-only barrel components out of client chunks

### DIFF
--- a/packages/mochi/src/__fixtures__/barrel-split/CaptchaIsland.svelte
+++ b/packages/mochi/src/__fixtures__/barrel-split/CaptchaIsland.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import { MochiCaptcha } from 'mochi-framework/components';
+</script>
+
+<MochiCaptcha />

--- a/packages/mochi/src/__fixtures__/barrel-split/Page.svelte
+++ b/packages/mochi/src/__fixtures__/barrel-split/Page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import CaptchaIsland from './CaptchaIsland.svelte';
+</script>
+
+<main>
+  <CaptchaIsland mochi:hydrate />
+</main>

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -12,6 +12,7 @@ import { mochiEvents } from '../events';
 import { detectHeavyBarrels, formatBarrelLine, formatBarrelSummary, type BarrelMetafile, type HeavyBarrel } from './barrelDetect';
 import type { MarkdownConfig, MochiBarrelWarningOptions, MochiManifest, MochiSvelteShakerOptions } from '../types';
 import { type HydratableComponent, type PreprocessIslandError, type ServerIslandComponent } from './svelteAstPreprocess';
+import { FRAMEWORK_COMPONENTS_SPECIFIER, rewriteFrameworkComponentImports } from './frameworkComponents';
 import { cachedPreprocessHydratable, createPreprocessCacheStats } from './preprocessCache';
 import { CompileCache, compileFingerprint, createCompileCacheStats, type CompileCacheStats } from './compileCache';
 import { mergeCompilerOptions, type MochiSvelteConfig } from './svelteConfig';
@@ -156,6 +157,9 @@ function createMarkdownLoader(opts: {
       opts.hydration.allServerIslands.push(...serverIslands);
       opts.hydration.filePreprocessErrors.set(args.path, preprocessErrors);
       svelteSource = preprocessed.transformed;
+    }
+    if (opts.target === 'client') {
+      svelteSource = rewriteFrameworkComponentImports(svelteSource, args.path);
     }
     const { js, css } = opts.backend.compile(
       svelteSource,
@@ -1140,6 +1144,14 @@ export class ComponentRegistry {
         build.onResolve({ filter: /^mochi-framework\/hydratable-boundary$/ }, () => ({
           path: path.join(SRC_DIR, 'islands/HydratableBoundary.svelte'),
         }));
+        // Static `.svelte`/`.md` imports of the barrel are split into per-component imports before compile, so anything
+        // reaching this resolver arrived through a shape the rewrite can't see — fail loudly instead of silently
+        // bundling every barrel component (including SSR-only ones) into client chunks.
+        build.onResolve({ filter: /^mochi-framework\/components$/ }, (args) => {
+          throw new Error(
+            `[mochi] "${FRAMEWORK_COMPONENTS_SPECIFIER}" reached the client bundle from ${relForDisplay(args.importer)} through a path the framework can't split (a dynamic import, a re-export, or a .ts/.js module). Import the component's file directly.`,
+          );
+        });
         registerEsmEnvStrip(build);
         registerSvelteModuleLoader(build, backend, mergeCompilerOptions(userCompilerOptions, { generate: 'client', dev: development }));
         build.onLoad({ filter: /\.svelte$/ }, async (args) => {
@@ -1149,8 +1161,9 @@ export class ComponentRegistry {
             return { contents: cached.js, loader: 'js' };
           }
           const preprocessed = await applyUserPreprocessors(source, args.path, 'client', development);
+          const rewritten = rewriteFrameworkComponentImports(preprocessed, args.path);
           const { js } = backend.compile(
-            preprocessed,
+            rewritten,
             mergeCompilerOptions(userCompilerOptions, {
               generate: 'client',
               filename: args.path,

--- a/packages/mochi/src/compiler/barrelImportSplit.test.ts
+++ b/packages/mochi/src/compiler/barrelImportSplit.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, readdirSync, readFileSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { ComponentRegistry } from './ComponentRegistry';
+
+const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'barrel-split');
+const PAGE = path.join(FIXTURE_DIR, 'Page.svelte');
+
+// An island importing `{ MochiCaptcha }` from the `mochi-framework/components` barrel must not drag the barrel's
+// SSR-only components (ViewTransitions, RawScript) into the client bundle — the regression behind the captcha demo
+// shipping a ViewTransitions chunk.
+describe('client bundle splits the framework components barrel', () => {
+  let outDir: string;
+  let registry: ComponentRegistry;
+
+  beforeEach(() => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-barrel-split-'));
+    registry = new ComponentRegistry({ development: true, outDir });
+  });
+
+  afterEach(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('only the imported component reaches the client build inputs', async () => {
+    await registry.compileAll([PAGE]);
+    const inputs = (registry.getClientStats()?.outputs ?? []).flatMap((o) => o.inputs.map((i) => i.path));
+    expect(inputs.length).toBeGreaterThan(0);
+    expect(inputs.some((p) => p.includes('MochiCaptcha.svelte'))).toBe(true);
+    expect(inputs.some((p) => p.includes('ViewTransitions.svelte'))).toBe(false);
+    expect(inputs.some((p) => p.includes('RawScript.svelte'))).toBe(false);
+    expect(inputs.some((p) => p.includes('components/index.ts'))).toBe(false);
+  });
+
+  test('no emitted chunk carries ViewTransitions code', async () => {
+    await registry.compileAll([PAGE]);
+    const clientDir = path.join(outDir, 'svelte-client');
+    const chunks = readdirSync(clientDir).filter((f) => f.endsWith('.js'));
+    expect(chunks.length).toBeGreaterThan(0);
+    const texts = chunks.map((f) => readFileSync(path.join(clientDir, f), 'utf8'));
+    // Dev-mode compiles embed the source filename, and the hydration guard's message is unique to ViewTransitions.
+    expect(texts.some((t) => t.includes('MochiCaptcha.svelte'))).toBe(true);
+    for (const text of texts) {
+      expect(text).not.toContain('ViewTransitions.svelte');
+      expect(text).not.toContain('must not be hydrated');
+    }
+  });
+});

--- a/packages/mochi/src/compiler/frameworkComponents.rewrite.test.ts
+++ b/packages/mochi/src/compiler/frameworkComponents.rewrite.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { rewriteFrameworkComponentImports } from './frameworkComponents';
+
+const FILE = '/app/src/CaptchaForm.svelte';
+
+const wrap = (script: string, body = '<p>hi</p>') => `<script>\n${script}\n</script>\n\n${body}\n`;
+
+describe('rewriteFrameworkComponentImports', () => {
+  test('splits a named barrel import into a direct component import', () => {
+    const out = rewriteFrameworkComponentImports(wrap(`import { MochiCaptcha } from 'mochi-framework/components';`), FILE);
+    expect(out).toMatch(/import MochiCaptcha from ".*captcha\/MochiCaptcha\.svelte";/);
+    expect(out).not.toContain(`from 'mochi-framework/components'`);
+    expect(out).not.toContain('\\');
+  });
+
+  test('keeps the local alias', () => {
+    const out = rewriteFrameworkComponentImports(wrap(`import { MochiCaptcha as Cap } from 'mochi-framework/components';`), FILE);
+    expect(out).toMatch(/import Cap from ".*captcha\/MochiCaptcha\.svelte";/);
+  });
+
+  test('splits multiple specifiers into one import per component', () => {
+    const out = rewriteFrameworkComponentImports(wrap(`import { MochiCaptcha, RawScript } from 'mochi-framework/components';`), FILE);
+    expect(out).toMatch(/import MochiCaptcha from ".*captcha\/MochiCaptcha\.svelte";/);
+    expect(out).toMatch(/import RawScript from ".*components\/RawScript\.svelte";/);
+  });
+
+  test('rewrites inside <script module>', () => {
+    const source = `<script module>\nimport { RawScript } from 'mochi-framework/components';\n</script>\n\n<p>hi</p>\n`;
+    const out = rewriteFrameworkComponentImports(source, FILE);
+    expect(out).toMatch(/import RawScript from ".*components\/RawScript\.svelte";/);
+  });
+
+  test('returns the source unchanged without the specifier', () => {
+    const source = wrap(`import Local from './Local.svelte';`);
+    expect(rewriteFrameworkComponentImports(source, FILE)).toBe(source);
+  });
+
+  test('leaves a string literal containing the specifier alone', () => {
+    const source = wrap(`const sample = "import { MochiCaptcha } from 'mochi-framework/components';";`, '<pre>{sample}</pre>');
+    expect(rewriteFrameworkComponentImports(source, FILE)).toBe(source);
+  });
+
+  test('throws on an unknown export name, naming the file and the import', () => {
+    expect(() => rewriteFrameworkComponentImports(wrap(`import { NotAComponent } from 'mochi-framework/components';`), FILE)).toThrow(
+      /NotAComponent.*mochi-framework\/components|CaptchaForm\.svelte/,
+    );
+  });
+
+  test('throws on a namespace import of the barrel', () => {
+    expect(() => rewriteFrameworkComponentImports(wrap(`import * as Components from 'mochi-framework/components';`), FILE)).toThrow(/namespace import/);
+  });
+
+  test('throws on a re-export from the barrel', () => {
+    expect(() => rewriteFrameworkComponentImports(wrap(`export { MochiCaptcha } from 'mochi-framework/components';`), FILE)).toThrow(/re-exporting/);
+    expect(() => rewriteFrameworkComponentImports(wrap(`export * from 'mochi-framework/components';`), FILE)).toThrow(/re-exporting/);
+  });
+});

--- a/packages/mochi/src/compiler/frameworkComponents.ts
+++ b/packages/mochi/src/compiler/frameworkComponents.ts
@@ -1,6 +1,8 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { parse } from 'svelte/compiler';
+import MagicString from 'magic-string';
+import { relForDisplay, toPosixPath } from '../utils';
 
 /**
  * Resolves the framework's own public components (`mochi-framework/components`) to the on-disk `.svelte` files they
@@ -68,4 +70,62 @@ function parseBarrel(): Map<string, FrameworkComponent> {
 export function resolveFrameworkComponent(exportName: string): FrameworkComponent | null {
   cache ??= parseBarrel();
   return cache.get(exportName) ?? null;
+}
+
+/** Svelte's AST nodes all have start/end, but estree types don't declare them. */
+interface Positioned {
+  start: number;
+  end: number;
+}
+
+/**
+ * Replaces `mochi-framework/components` imports with direct imports of the underlying component files, so a client
+ * bundle only carries the components actually imported — the barrel co-locates SSR-only components (`ViewTransitions`,
+ * `RawScript`) with hydratable ones (`MochiCaptcha`), and without this split the unused ones ride into client chunks
+ * as dead code (nothing declares `sideEffects`, so the bundler keeps every re-export live). Client build only; the
+ * barrel is correct server-side. Throws on shapes it can't split (namespace/default imports, re-exports, unknown
+ * names) — the client build surfaces the message as a build error rather than silently re-bloating.
+ */
+export function rewriteFrameworkComponentImports(source: string, filePath: string): string {
+  if (!source.includes(FRAMEWORK_COMPONENTS_SPECIFIER)) {
+    return source;
+  }
+  const ast = parse(source, { modern: true });
+  const s = new MagicString(source);
+  let changed = false;
+  for (const script of [ast.instance, ast.module]) {
+    for (const node of script?.content.body ?? []) {
+      if ((node.type === 'ExportNamedDeclaration' || node.type === 'ExportAllDeclaration') && node.source?.value === FRAMEWORK_COMPONENTS_SPECIFIER) {
+        throw new Error(
+          `[mochi] ${relForDisplay(filePath)}: re-exporting from "${FRAMEWORK_COMPONENTS_SPECIFIER}" can't be split for the client bundle — import the components and re-export them individually.`,
+        );
+      }
+      if (node.type !== 'ImportDeclaration' || node.source.value !== FRAMEWORK_COMPONENTS_SPECIFIER) {
+        continue;
+      }
+      const lines: string[] = [];
+      for (const spec of node.specifiers ?? []) {
+        if (spec.type !== 'ImportSpecifier') {
+          throw new Error(
+            `[mochi] ${relForDisplay(filePath)}: only named imports of "${FRAMEWORK_COMPONENTS_SPECIFIER}" can be split for the client bundle — rewrite this ${spec.type === 'ImportNamespaceSpecifier' ? 'namespace' : 'default'} import as named imports.`,
+          );
+        }
+        const name = specifierName(spec.imported);
+        const framework = resolveFrameworkComponent(name);
+        if (!framework) {
+          throw new Error(`[mochi] ${relForDisplay(filePath)}: "${name}" is not a component exported by "${FRAMEWORK_COMPONENTS_SPECIFIER}".`);
+        }
+        const target = toPosixPath(framework.resolvedPath);
+        lines.push(
+          framework.exportName === 'default'
+            ? `import ${spec.local.name} from "${target}";`
+            : `import { ${JSON.stringify(framework.exportName)} as ${spec.local.name} } from "${target}";`,
+        );
+      }
+      const pos = node as unknown as Positioned;
+      s.overwrite(pos.start, pos.end, lines.join('\n'));
+      changed = true;
+    }
+  }
+  return changed ? s.toString() : source;
 }


### PR DESCRIPTION
## Problem

The captcha demo (`/demos/captcha/`) loaded a client chunk containing `ViewTransitions.svelte` — a component that is SSR-only by design (it emits static CSS and throws if hydrated). This was not a debug-bar reporting bug: post-#223 the listing is accurate, and the browser genuinely downloaded the chunk.

Root cause: `CaptchaForm.svelte` (a `mochi:hydrate` island) imports `{ MochiCaptcha }` from the `mochi-framework/components` barrel. The client build never rewrote that import — the existing barrel resolution in `svelteAstPreprocess.ts` only applies to components carrying `mochi:` directives — and with no `sideEffects` declaration, Bun keeps every barrel re-export live. So `ViewTransitions` and `RawScript` rode into a shared client chunk as dead code.

## Fix

- **`rewriteFrameworkComponentImports()`** (new, in `compiler/frameworkComponents.ts`): AST-driven rewrite of `mochi-framework/components` imports into direct per-component file imports, table-driven off the existing `parseBarrel()` map so new barrel exports can't drift. Handles aliasing and multiple specifiers; throws with an actionable message on unsplittable shapes (namespace/default imports, re-exports, unknown names). AST-only matching, so string literals containing the specifier (docs code samples) are untouched.
- Applied in the **client build only**: the client `.svelte` onLoad and the markdown client loader in `ComponentRegistry.ts`. SSR builds keep using the barrel — correct there.
- **Fail-loud safety net**: a client-build `onResolve` for the bare barrel specifier fails the build with an actionable error for any vector the rewrite can't see (dynamic `import()`, `export * from`, `.ts`/`.js` importers), so this class of leak can't silently recur. Verified empirically that Bun surfaces plugin throws in `result.logs` and fails the build.

## Tests

- `frameworkComponents.rewrite.test.ts` — unit tests for the rewriter (splitting, aliasing, `<script module>`, string-literal false positives, all throw paths).
- `barrelImportSplit.test.ts` + `__fixtures__/barrel-split/` — functional regression test: builds a real client bundle through `ComponentRegistry` for an island importing `{ MochiCaptcha }` from the barrel, then asserts both the metafile inputs **and the emitted chunk contents** carry no ViewTransitions/RawScript/barrel code. Mutation-checked: with the rewrite disabled, both tests fail (the safety net trips the build).

## Verification

- Browser smoke test (chrome-devtools) on `/demos/captcha/`: zero ViewTransitions bytes across all 21 loaded scripts, all islands hydrate with a clean console, captcha form round-trip works (unsolved submit → `reason: rejected`), debug-bar chunk list clean. `/demos/view-transitions/` (SSR barrel usage) and `/demos/captcha-styling/` (4 captcha islands) also verified clean.
- `bun run checks` (lint + format + typecheck + test): all green, 153/153 framework test files pass.

`CaptchaForm.svelte` deliberately keeps its barrel import — it's the idiomatic form shown in the demo source viewer and now serves as the end-to-end regression surface.