### PR TITLE
fix(debug-bar): isolate panel render faults behind a boundary, with a diagnostic build flag

### DIFF
--- a/packages/docs/172-debug-bar.md
+++ b/packages/docs/172-debug-bar.md
@@ -70,3 +70,9 @@ Any code can queue a warning into the toolbar by calling `window.__mochi_warn('m
 ### Info panel
 
 Shows the running Mochi, Svelte, and Bun versions, plus a snapshot of the resolved `Mochi.serve()` config — mode, port, trailing-slash policy, log level, route count, and whether warmup, live-reload, CSRF, proxy, and middleware are active. Captured once at startup.
+
+### Panel errors
+
+Each panel renders from live runtime state, so the panels are wrapped in an error boundary: a render fault in one degrades that panel instead of throwing onto the host page, and the toolbar stays usable. The fault is still logged to the console as `[mochi] debug-bar panel render fault: …`.
+
+The bar ships as a production-Svelte bundle, so that log carries no detail. To debug a panel fault, restart with `MOCHI_DEBUGBAR_DIAGNOSTIC=1` — the bar then compiles dev-Svelte and un-minified, so the logged error names the exact cause (and, for a keyed-`{#each}` collision, the duplicate key) with a readable stack. For temporary debugging only; it makes the bundle larger.

--- a/packages/mochi/src/compiler/buildDebugBarBundle.ts
+++ b/packages/mochi/src/compiler/buildDebugBarBundle.ts
@@ -22,6 +22,11 @@ export interface DebugBarBundle {
 export async function buildDebugBarBundle(opts: { development: boolean; backend: SvelteCompilerBackend }): Promise<DebugBarBundle> {
   const { development, backend } = opts;
 
+  // Diagnostic escape hatch: prod-Svelte's `each_key_duplicate` throws with no key and a minified stack, so a panel
+  // fault is unidentifiable. Set MOCHI_DEBUGBAR_DIAGNOSTIC=1 to build the bar dev-Svelte + un-minified — the runtime
+  // then names the offending key and the stack names the component. Larger output; for temporary debugging only.
+  const diagnostic = process.env.MOCHI_DEBUGBAR_DIAGNOSTIC === '1';
+
   const debugBarPlugin: BunPlugin = {
     name: 'mochi-debug-bar',
     setup(build) {
@@ -30,10 +35,10 @@ export async function buildDebugBarBundle(opts: { development: boolean; backend:
       // `mochi-framework`'s `isDev`, it must still read `true` under a dev server.
       registerMochiEnvClient(build, development);
       // `mergeCompilerOptions` with no user options: framework defaults apply, user svelte config doesn't.
-      registerSvelteModuleLoader(build, backend, mergeCompilerOptions(undefined, { generate: 'client', dev: false }));
+      registerSvelteModuleLoader(build, backend, mergeCompilerOptions(undefined, { generate: 'client', dev: diagnostic }));
       build.onLoad({ filter: /\.svelte$/ }, async (args) => {
         const source = await Bun.file(args.path).text();
-        const { js } = backend.compile(source, mergeCompilerOptions(undefined, { generate: 'client', filename: args.path, css: 'injected', dev: false }));
+        const { js } = backend.compile(source, mergeCompilerOptions(undefined, { generate: 'client', filename: args.path, css: 'injected', dev: diagnostic }));
         return { contents: js.code, loader: 'js' };
       });
     },
@@ -44,14 +49,15 @@ export async function buildDebugBarBundle(opts: { development: boolean; backend:
     // The guard goes first so its `onResolve` sees a server-only specifier before the debug-bar plugin's own handlers.
     plugins: [serverOnlyModuleGuard, debugBarPlugin],
     target: 'browser',
-    conditions: ['svelte', 'production'],
+    // The `development` esm-env condition flips Svelte's runtime `DEV` on so `each_key_duplicate` reports the key.
+    conditions: ['svelte', diagnostic ? 'development' : 'production'],
     define: {
-      DEV: 'false',
+      DEV: diagnostic ? 'true' : 'false',
       BROWSER: 'true',
       NODE: 'false',
       ...CLIENT_BUILD_DEFINE,
     },
-    minify: true,
+    minify: !diagnostic,
     naming: '[name]-[hash].[ext]',
     throw: false,
   });

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -160,14 +160,20 @@
 </script>
 
 <div class="mochi-debug-bar-root" bind:this={rootEl}>
-  <WarningsPanel open={activePanel === 'warnings'} onclose={() => (activePanel = null)} />
-  <IslandsPanel open={activePanel === 'islands'} onclose={() => (activePanel = null)} />
-  <ImagesPanel open={activePanel === 'images'} onclose={() => (activePanel = null)} />
-  <BundlesPanel open={activePanel === 'bundles'} onclose={() => (activePanel = null)} />
-  <RequestPanel open={activePanel === 'request'} onclose={() => (activePanel = null)} />
-  <InfoPanel open={activePanel === 'info'} onclose={() => (activePanel = null)} />
-  <CachePanel open={activePanel === 'cache'} onclose={() => (activePanel = null)} />
-  <SettingsPanel open={activePanel === 'settings'} onclose={() => (activePanel = null)} {hiddenPanels} ontoggle={togglePanelVisibility} />
+  <!-- A panel renders from uncontrolled runtime state (live DOM scans, request headers, cache keys); a fault there — a
+       keyed-each duplicate from that state, say — must degrade the non-essential debug UI, never throw an uncaught error
+       onto the host page. The toolbar below stays outside so it keeps working when a panel fails. -->
+  <svelte:boundary>
+    <WarningsPanel open={activePanel === 'warnings'} onclose={() => (activePanel = null)} />
+    <IslandsPanel open={activePanel === 'islands'} onclose={() => (activePanel = null)} />
+    <ImagesPanel open={activePanel === 'images'} onclose={() => (activePanel = null)} />
+    <BundlesPanel open={activePanel === 'bundles'} onclose={() => (activePanel = null)} />
+    <RequestPanel open={activePanel === 'request'} onclose={() => (activePanel = null)} />
+    <InfoPanel open={activePanel === 'info'} onclose={() => (activePanel = null)} />
+    <CachePanel open={activePanel === 'cache'} onclose={() => (activePanel = null)} />
+    <SettingsPanel open={activePanel === 'settings'} onclose={() => (activePanel = null)} {hiddenPanels} ontoggle={togglePanelVisibility} />
+    {#snippet failed()}{/snippet}
+  </svelte:boundary>
 
   <div class="bar" class:is-collapsed={collapsed}>
     <button

--- a/packages/mochi/src/debug-bar/MochiDebugBar.svelte
+++ b/packages/mochi/src/debug-bar/MochiDebugBar.svelte
@@ -157,13 +157,20 @@
   onDestroy(() => {
     cleanupHighlight();
   });
+
+  // The boundary swallows the fault to spare the host page, so log it here or it vanishes silently; build the bar with
+  // MOCHI_DEBUGBAR_DIAGNOSTIC=1 to get the offending key + an un-minified stack in that log.
+  function reportPanelError(error: unknown) {
+    const err = error as { message?: string; stack?: string } | undefined;
+    console.error('[mochi] debug-bar panel render fault:', err?.message ?? error, err?.stack ?? '');
+  }
 </script>
 
 <div class="mochi-debug-bar-root" bind:this={rootEl}>
   <!-- A panel renders from uncontrolled runtime state (live DOM scans, request headers, cache keys); a fault there — a
        keyed-each duplicate from that state, say — must degrade the non-essential debug UI, never throw an uncaught error
        onto the host page. The toolbar below stays outside so it keeps working when a panel fails. -->
-  <svelte:boundary>
+  <svelte:boundary onerror={reportPanelError}>
     <WarningsPanel open={activePanel === 'warnings'} onclose={() => (activePanel = null)} />
     <IslandsPanel open={activePanel === 'islands'} onclose={() => (activePanel = null)} />
     <ImagesPanel open={activePanel === 'images'} onclose={() => (activePanel = null)} />

--- a/scripts/site-health.ts
+++ b/scripts/site-health.ts
@@ -30,7 +30,7 @@ Arguments:
   base             Origin to check (default: https://mochi.fast)
   --concurrency N  Max tabs open at once (default: 4)
   --report PATH    Report output path (default: ./REPORT.md)
-  --timeout MS     Per-page budget for the load event (default: 30000)
+  --timeout MS     Per-page budget for the load event (default: 60000)
 
 Exits 1 if any page failed, 2 on a setup problem (no sitemap, no Chrome).`;
 
@@ -38,7 +38,7 @@ const parseArgs = (argv: string[]): Args => {
   const positional: string[] = [];
   let concurrency = 4;
   let report = 'REPORT.md';
-  let timeout = 30_000;
+  let timeout = 60_000;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === '-h' || a === '--help') {


### PR DESCRIPTION
## What

Hardens the dev debug bar so a panel that faults can't take down the host page, adds a way to diagnose such faults, and bumps the site-health timeout.

### Isolate panel render faults behind a boundary
Each debug-bar panel renders from uncontrolled runtime state (live DOM scans, request headers, cache keys), so a render fault — e.g. a keyed-`{#each}` duplicate arising from that state — could throw an uncaught error onto the host page. The panels are now wrapped in a `<svelte:boundary>`: a fault degrades that panel instead of the page, and the toolbar (outside the boundary) stays usable. The boundary's `onerror` logs the fault as `[mochi] debug-bar panel render fault: …` so it isn't swallowed silently.

### `MOCHI_DEBUGBAR_DIAGNOSTIC=1` diagnostic build mode
The bar ships as a production-Svelte, minified bundle, so `each_key_duplicate` throws with no key and an unreadable stack — a logged fault is unidentifiable. Restarting with `MOCHI_DEBUGBAR_DIAGNOSTIC=1` builds the bar with dev-Svelte, the `development` esm-env condition, `DEV: true`, and no minification, so the runtime names the offending key and the stack names the component. For temporary debugging only — it enlarges the bundle.

### site-health: bump per-page timeout 30s → 60s
More headroom for each page's load event.

## Docs
- New "Panel errors" section in `172-debug-bar.md` covering the boundary behavior and the diagnostic flag.

## Notes
- Local `.devcontainer/devcontainer.json` tweaks were intentionally left out of this PR.
- Branch name (`feat/warmup-image-cache`) is cosmetic — the originally-scoped warmup work was dropped earlier.
