### PR TITLE
fix(debug-bar): keep the install-store version segment in bundle input paths

### DIFF
--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -30,6 +30,7 @@ import { decodeSourcePath, encodeSourcePath } from './manifestPaths';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
 import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 import { registerServerOnlyComponentStubs, SSR_ONLY_COMPONENT_NAMESPACE } from './serverOnlyComponents';
+import { cleanInputs, SERVER_ONLY_MODULE_NAMESPACE } from './bundleInputPaths';
 import { renderMochiEnvServer } from './virtualModuleTemplate';
 import { buildDebugBarBundle, type DebugBarBundle } from './buildDebugBarBundle';
 import { formatBuildMessages } from './formatBuildMessages';
@@ -1152,9 +1153,9 @@ export class ComponentRegistry {
               resolved = tsPath;
             }
           }
-          return { path: resolved, namespace: 'mochi-server-only' };
+          return { path: resolved, namespace: SERVER_ONLY_MODULE_NAMESPACE };
         });
-        build.onLoad({ filter: /.*/, namespace: 'mochi-server-only' }, async (args) => {
+        build.onLoad({ filter: /.*/, namespace: SERVER_ONLY_MODULE_NAMESPACE }, async (args) => {
           const source = await Bun.file(args.path).text();
           const scan = scanServerOnlyExports(source);
           for (const w of scan.warnings) {
@@ -1625,11 +1626,11 @@ export class ComponentRegistry {
               label: 'Island runtime',
               sizeBytes: wcSize,
               kind: 'bootstrap',
-              inputs: ComponentRegistry.cleanInputs(wcInputs),
+              inputs: cleanInputs(wcInputs),
             });
           } else {
             const compName = urlToComponent.get(url);
-            const cleaned = ComponentRegistry.cleanInputs(output.inputs);
+            const cleaned = cleanInputs(output.inputs);
             const nonWc = cleaned.filter((i) => !i.path.includes('web-components/'));
             const wcDeduct = cleaned.reduce((s, i) => s + (i.path.includes('web-components/') ? i.size : 0), 0);
             if (compName) {
@@ -1694,14 +1695,6 @@ export class ComponentRegistry {
       hasServerIslands,
       debugBarData,
     };
-  }
-
-  private static cleanInputPath(p: string): string {
-    const stub = p.match(/^(?:mochi-ssr-only-component|mochi-server-only):(.*)$/);
-    if (stub) {
-      return `${stub[1]} (server-only stub)`;
-    }
-    return p.replace(/^(?:\.\.\/)*node_modules\/(?:\.bun\/[^/]+\/node_modules\/)?/, '');
   }
 
   /**
@@ -1780,15 +1773,6 @@ export class ComponentRegistry {
     } finally {
       this.pendingBarrels = [];
     }
-  }
-
-  private static cleanInputs(inputs: { path: string; size: number }[]): { path: string; size: number }[] {
-    // A fully tree-shaken `.server.svelte` stub ships nothing, so its row would only confuse the panel — but a stub
-    // with retained bytes means an island actually renders the component (it will throw at hydration), which is
-    // exactly what the panel should surface, so those rows stay.
-    return inputs
-      .filter((i) => i.size > 0 || !i.path.startsWith(`${SSR_ONLY_COMPONENT_NAMESPACE}:`))
-      .map((i) => ({ path: ComponentRegistry.cleanInputPath(i.path), size: i.size }));
   }
 
   /** Output names reachable from `roots` by following static imports, roots included. */

--- a/packages/mochi/src/compiler/bundleInputPaths.test.ts
+++ b/packages/mochi/src/compiler/bundleInputPaths.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'bun:test';
+import { cleanInputPath, cleanInputs } from './bundleInputPaths';
+import { SSR_ONLY_COMPONENT_NAMESPACE } from './serverOnlyComponents';
+
+describe('cleanInputPath', () => {
+  test('keeps the store version segment so two installed copies stay distinct', () => {
+    // The production regression: mode-watcher pulls runed@0.25.0 while svelte-toolbelt pulls runed@0.23.4, and both
+    // land in one island bundle. Dropping the version collapsed them onto one key and crashed the panel's keyed each.
+    const paths = ['../../node_modules/.bun/runed@0.25.0/node_modules/runed/dist/index.js', '../../node_modules/.bun/runed@0.23.4/node_modules/runed/dist/index.js'].map(
+      cleanInputPath,
+    );
+
+    expect(paths).toEqual(['runed@0.25.0/dist/index.js', 'runed@0.23.4/dist/index.js']);
+    expect(new Set(paths).size).toBe(2);
+  });
+
+  test('keeps the store segment for scoped packages', () => {
+    expect(cleanInputPath('../../node_modules/.bun/@scope+pkg@1.0.0/node_modules/@scope/pkg/dist/x.js')).toBe('@scope+pkg@1.0.0/dist/x.js');
+  });
+
+  test('strips a leading node_modules under the hoisted layout', () => {
+    expect(cleanInputPath('../../node_modules/runed/dist/index.js')).toBe('runed/dist/index.js');
+    expect(cleanInputPath('node_modules/svelte/src/index.js')).toBe('svelte/src/index.js');
+  });
+
+  test('leaves a nested node_modules copy addressable', () => {
+    const nested = 'node_modules/mode-watcher/node_modules/runed/dist/index.js';
+    expect(cleanInputPath(nested)).toBe('mode-watcher/node_modules/runed/dist/index.js');
+    expect(cleanInputPath(nested)).not.toBe(cleanInputPath('node_modules/svelte-toolbelt/node_modules/runed/dist/index.js'));
+  });
+
+  test('leaves a project-relative source path alone', () => {
+    expect(cleanInputPath('src/demos/mode-watcher/ModeControls.svelte')).toBe('src/demos/mode-watcher/ModeControls.svelte');
+  });
+
+  test('distinguishes the two virtual stub namespaces', () => {
+    const ssrOnly = cleanInputPath(`${SSR_ONLY_COMPONENT_NAMESPACE}:/app/src/Widget.server.svelte`);
+    const serverOnly = cleanInputPath('mochi-server-only:/app/src/Widget.server.svelte');
+
+    expect(ssrOnly).toBe('/app/src/Widget.server.svelte (SSR-only component stub)');
+    expect(serverOnly).toBe('/app/src/Widget.server.svelte (server-only stub)');
+    expect(ssrOnly).not.toBe(serverOnly);
+  });
+
+  test('renders Windows paths with forward slashes', () => {
+    const cleaned = cleanInputPath('..\\..\\node_modules\\.bun\\runed@0.25.0\\node_modules\\runed\\dist\\index.js');
+
+    expect(cleaned).toBe('runed@0.25.0/dist/index.js');
+    expect(cleaned).not.toContain('\\');
+  });
+});
+
+describe('cleanInputs', () => {
+  test('drops fully tree-shaken SSR-only stubs but keeps ones with retained bytes', () => {
+    const cleaned = cleanInputs([
+      { path: `${SSR_ONLY_COMPONENT_NAMESPACE}:/app/src/Gone.server.svelte`, size: 0 },
+      { path: `${SSR_ONLY_COMPONENT_NAMESPACE}:/app/src/Kept.server.svelte`, size: 42 },
+      { path: 'node_modules/svelte/src/index.js', size: 0 },
+    ]);
+
+    expect(cleaned).toEqual([
+      { path: '/app/src/Kept.server.svelte (SSR-only component stub)', size: 42 },
+      { path: 'svelte/src/index.js', size: 0 },
+    ]);
+  });
+
+  test('yields unique paths for a bundle holding two versions of one package', () => {
+    const paths = cleanInputs(
+      ['runed@0.25.0', 'runed@0.23.4'].flatMap((v) =>
+        ['dist/index.js', 'dist/utilities/watch/watch.svelte.js'].map((f) => ({ path: `../../node_modules/.bun/${v}/node_modules/runed/${f}`, size: 10 })),
+      ),
+    ).map((i) => i.path);
+
+    expect(new Set(paths).size).toBe(paths.length);
+  });
+});

--- a/packages/mochi/src/compiler/bundleInputPaths.ts
+++ b/packages/mochi/src/compiler/bundleInputPaths.ts
@@ -1,0 +1,38 @@
+/**
+ * Turns raw `Bun.build` metafile input paths into the rows the debug bar's JS Bundles panel shows. The panel keys its
+ * list on the cleaned string, so the transform must be injective: two distinct build inputs collapsing to one label
+ * both hides a real duplicate-dependency signal and crashes the keyed `{#each}` with `each_key_duplicate`.
+ */
+import { SSR_ONLY_COMPONENT_NAMESPACE } from './serverOnlyComponents';
+import { toPosixPath } from '../utils/index';
+
+/** Virtual namespace holding `.server.ts` / `.server.js` modules stripped out of the client graph. */
+export const SERVER_ONLY_MODULE_NAMESPACE = 'mochi-server-only';
+
+// Bun's isolated linker (the default) installs into a `node_modules/.bun/<pkg>@<version>/node_modules/<pkg>/` store, so
+// the version segment is the only thing telling two installed copies apart — keep it as the displayed prefix.
+const STORE_PATH = /^(?:\.\.\/)*node_modules\/\.bun\/([^/]+)\/node_modules\/(?:@[^/]+\/)?[^/]+\/(.+)$/;
+const LEADING_NODE_MODULES = /^(?:\.\.\/)*node_modules\//;
+
+export function cleanInputPath(p: string): string {
+  const posix = toPosixPath(p);
+
+  const stub = posix.match(/^(mochi-ssr-only-component|mochi-server-only):(.*)$/);
+  if (stub) {
+    const kind = stub[1] === SSR_ONLY_COMPONENT_NAMESPACE ? 'SSR-only component stub' : 'server-only stub';
+    return `${stub[2]} (${kind})`;
+  }
+
+  const store = posix.match(STORE_PATH);
+  if (store) {
+    return `${store[1]}/${store[2]}`;
+  }
+  return posix.replace(LEADING_NODE_MODULES, '');
+}
+
+export function cleanInputs(inputs: { path: string; size: number }[]): { path: string; size: number }[] {
+  // A fully tree-shaken `.server.svelte` stub ships nothing, so its row would only confuse the panel — but a stub
+  // with retained bytes means an island actually renders the component (it will throw at hydration), which is
+  // exactly what the panel should surface, so those rows stay.
+  return inputs.filter((i) => i.size > 0 || !i.path.startsWith(`${SSR_ONLY_COMPONENT_NAMESPACE}:`)).map((i) => ({ path: cleanInputPath(i.path), size: i.size }));
+}

--- a/packages/mochi/src/compiler/debugBarBundles.test.ts
+++ b/packages/mochi/src/compiler/debugBarBundles.test.ts
@@ -59,4 +59,16 @@ describe('debug bar bundle list — chunk reachability', () => {
     const heavyChunk = bundles.find((b) => b.kind === 'chunk' && (b.inputs ?? []).some((i) => i.path.includes('heavyOnlyOnB')));
     expect(heavyChunk).toBeDefined();
   });
+
+  // BundlesPanel renders one row per input, so a repeated path is a duplicate key in a keyed `{#each}`.
+  test('reports unique input paths within every bundle', async () => {
+    const result = await renderWithDebugBar(PAGE_B);
+    const bundles = result.debugBarData?.bundles ?? [];
+
+    expect(bundles.length).toBeGreaterThan(0);
+    for (const bundle of bundles) {
+      const paths = (bundle.inputs ?? []).map((i) => i.path);
+      expect(new Set(paths).size).toBe(paths.length);
+    }
+  });
 });

--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -80,7 +80,9 @@
       <span class="bundle-size">{formatSize(displaySize)}</span>
     </div>
     <div class="bundle-inputs">
-      {#each displayInputs as input (input.path)}
+      <!-- Keyed by index, not path: `cleanInputPath` is meant to be injective, but a collision there must degrade into
+           two identical rows rather than taking the whole bar down behind the boundary. The list never reorders. -->
+      {#each displayInputs as input, i (i)}
         <button class="input-row" class:selected={selectedInput === input.path} type="button" onclick={() => selectInput(input.path)}>
           <span class="input-path">{input.path}</span>
           <span class="input-size">{formatSize(input.size)}</span>


### PR DESCRIPTION
## The bug

`https://mochi.fast/demos/mode-watcher/` logs this on every page load, caught by the panel boundary from #274:

```
[mochi] debug-bar panel render fault: https://svelte.dev/e/each_key_duplicate
```

## Root cause

Confirmed from production's own payload, not inferred. Decoding the live base64url `window.__mochi_debug` (see `packages/site/src/lib/debugBarEncode.ts`) gives:

```
[island] ModeControls  inputs=151  unique=95  -> 56 duplicate keys
    x2  runed/dist/index.js
    x2  runed/dist/utilities/watch/watch.svelte.js
    ... 54 more
```

Those 56 duplicates feed `{#each displayInputs as input (input.path)}` in `BundlesPanel.svelte` — exactly what `each_key_duplicate` reports. `DebugPanel` only CSS-hides its children (`<div class="panel" class:open>`), so the block renders on mount and the fault fires with no panel ever opened.

The collision comes from `ComponentRegistry.cleanInputPath`, which was many-to-one:

```ts
return p.replace(/^(?:\.\.\/)*node_modules\/(?:\.bun\/[^/]+\/node_modules\/)?/, '');
```

Stripping Bun's `.bun/<pkg>@<version>/node_modules/` store segment discards the only thing distinguishing two installed copies. The mode-watcher island pulls in three `runed` versions (`0.37.1` direct, `0.25.0` via `mode-watcher`, `0.23.4` via `svelte-toolbelt`), two of which land in one bundle:

```
node_modules/.bun/runed@0.25.0/node_modules/runed/dist/index.js  ─┐
node_modules/.bun/runed@0.23.4/node_modules/runed/dist/index.js  ─┴─► "runed/dist/index.js"
```

## Why CI and local dev never saw it

Root `bunfig.toml` pins `linker = "hoisted"`, so locally the three copies sit at `node_modules/runed`, `node_modules/mode-watcher/node_modules/runed` and `node_modules/svelte-toolbelt/node_modules/runed`. The regex only stripped a *leading* `node_modules/`, so those stayed distinct — locally the same page yields **151 inputs / 151 unique**.

`Dockerfile`'s install stage copies only `package.json`, `bun.lock` and `packages/` — never `bunfig.toml` — so production installs under Bun's **default isolated linker** and takes the `.bun` store branch. Any npm consumer of `mochi-framework` who hasn't pinned the hoisted linker is in the same position, which makes this a framework bug rather than a site one.

## The fix

- `cleanInputPath` / `cleanInputs` move out of `ComponentRegistry`'s private statics into a new `compiler/bundleInputPaths.ts` (matching `manifestPaths.ts` / `metafileWalk.ts`), so they're directly unit-testable.
- `cleanInputPath` is now injective: the store segment is kept as the displayed prefix, `runed@0.25.0/dist/index.js` instead of `runed/dist/index.js`. Hoisted and nested-`node_modules` paths are unchanged.
- Two smaller injectivity fixes in the same function: the `mochi-ssr-only-component:` and `mochi-server-only:` namespaces no longer both render as `(server-only stub)`, and the path goes through `toPosixPath()` first so a Windows metafile path doesn't silently miss every branch (repo convention for user-facing paths).
- `BundlesPanel`'s `{#each}` keys on index rather than path — belt-and-braces, so a future collision degrades into two identical rows instead of taking the bar down.
- `SERVER_ONLY_MODULE_NAMESPACE` replaces the three bare `'mochi-server-only'` literals.

## Verification

- **Replayed the real production payload** through the new function: 151 raw inputs → **151 unique keys** (was 95, i.e. 56 collisions).
- New `bundleInputPaths.test.ts`: the two-`runed`-versions case, scoped store segments, hoisted/nested paths unchanged, the two stub namespaces, and a Windows-separator input asserting no `\` in the output.
- `debugBarBundles.test.ts` gains a case asserting every bundle's input paths are unique — the invariant the keyed `{#each}` depends on.
- Browser check against `PORT=4444 bun run dev:site` on `/demos/mode-watcher/`: no `panel render fault`, all 6 islands hydrate, 21 bundles and 151 `ModeControls` rows render.
- Hardening checked directly by injecting duplicates before the bar mounts (302 inputs / 151 unique): 302 rows rendered, all 8 panels alive, zero console errors — the exact production condition, now non-fatal.

## Follow-ups (not in this PR)

- `Dockerfile`'s install stage doesn't copy `bunfig.toml`, so production's `node_modules` layout differs from every developer's. Worth deciding deliberately either way.
- `ModeControls` genuinely ships ~12 kB of duplicated `runed` (of 39.5 kB); a root `overrides` entry would cut the island ~30%, with a compatibility risk for `mode-watcher` / `svelte-toolbelt`.
- `CachePanel.svelte` keys `{#each filtered as key (key)}` straight off an unvalidated `/image-cache/` fetch response with no dedupe on either side — same failure mode, reachable via a user-supplied `storage` backend.
