### PR TITLE
feat(queues): add embedded pglite queue storage

### DIFF
--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -1,7 +1,7 @@
 ---
 title: 'Queues'
 slug: queues
-description: 'Run background jobs with Mochi.queue(), backed by bun-boss on memory, SQLite, or Postgres storage.'
+description: 'Run background jobs with Mochi.queue(), backed by bun-boss on memory, SQLite, Postgres, or embedded PGlite storage.'
 ---
 
 <script>
@@ -105,18 +105,37 @@ await Mochi.serve({
   queueStorage: 'memory', // the default
   // queueStorage: { sqlite: '.db/queue.sqlite' },
   // queueStorage: { postgres: process.env.DATABASE_URL },
+  // queueStorage: { pglite: await PGlite.create('.db/queue-pglite') },
 });
 ```
 
-| Storage             | Survives restarts | Scope                                            |
-| ------------------- | ----------------- | ------------------------------------------------ |
-| `'memory'`          | no                | single process                                   |
-| `{ sqlite: path }`  | yes               | single process, one durable file                 |
-| `{ postgres: url }` | yes               | shared — multiple processes can work one backlog |
+| Storage                | Survives restarts | Scope                                            |
+| ---------------------- | ----------------- | ------------------------------------------------ |
+| `'memory'`             | no                | single process                                   |
+| `{ sqlite: path }`     | yes               | single process, one durable file                 |
+| `{ postgres: url }`    | yes               | shared — multiple processes can work one backlog |
+| `{ pglite: instance }` | yes (on-disk)     | single process, embedded in-process Postgres     |
 
 Postgres storage installs its tables into a dedicated `mochi_queue` schema on first start, away from your application's tables. The schema name is fixed, so every app sharing one database shares one queue namespace — give each app its own database to keep their queues apart.
 
 On durable storage, queue options re-sync from your code on every boot — but only **additively**: an option you remove from `Mochi.queue()` keeps its previously stored value. Set the old value back explicitly (e.g. `retryLimit: 2`) rather than deleting the line; a removed `deadLetter` can only be repointed, not cleared.
+
+### PGlite
+
+`{ pglite: instance }` is the one storage that takes a live instance instead of a config string. Mochi recommends `{ postgres: url }` for production; PGlite — full Postgres compiled to WASM, running in your process with no server — covers dev and test environments while exercising the same Postgres storage path, including the `mochi_queue` schema, so jobs behave the way they will in production:
+
+```ts
+import { PGlite } from '@electric-sql/pglite';
+
+const db = await PGlite.create('.db/queue-pglite'); // or PGlite.create() for a throwaway in-memory store
+
+await Mochi.serve({
+  queues: {/* … */},
+  queueStorage: { pglite: db },
+});
+```
+
+Passing the instance keeps `@electric-sql/pglite` out of Mochi's dependencies and lets your app share one instance between queue jobs and its own tables. You own the instance, so make sure to close it at shutdown.
 
 ### Retries
 

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -59,7 +59,7 @@ import { resolveWarmupEnabled, markWarmupRequest, isWarmablePattern } from './ru
 import { createErrorResponder, DEFAULT_ERROR_PAGE_PATH } from './runtime/errors';
 import { requestContext } from './runtime/requestContext';
 import type { MochiRequestContext } from './runtime/requestContext';
-import { startQueueRuntime, mountQueues, getQueue, getBoss, closeAllQueueResources } from './queue';
+import { startQueueRuntime, mountQueues, getQueue, getBoss, closeAllQueueResources, isValidQueueStorage } from './queue';
 import { resetStartupMilestones } from './lifecycle';
 import type { MochiQueue, MochiQueueOptions, MochiQueueListeners, MochiProcessor } from './queue';
 import type { BunBoss } from 'bun-boss';
@@ -332,17 +332,8 @@ export class Mochi {
       }
     }
     const queueStorage = options.queueStorage ?? 'memory';
-    if (
-      queueStorage !== 'memory' &&
-      !(
-        typeof queueStorage === 'object' &&
-        queueStorage !== null &&
-        'sqlite' in queueStorage !== 'postgres' in queueStorage &&
-        (('sqlite' in queueStorage && typeof queueStorage.sqlite === 'string' && queueStorage.sqlite.length > 0) ||
-          ('postgres' in queueStorage && typeof queueStorage.postgres === 'string' && queueStorage.postgres.length > 0))
-      )
-    ) {
-      throw new Error(`Mochi.serve({ queueStorage }): expected 'memory', { sqlite: 'path/to.db' }, or { postgres: url }.`);
+    if (!isValidQueueStorage(queueStorage)) {
+      throw new Error(`Mochi.serve({ queueStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
     }
     if (options.queueStorage !== undefined && declaredQueues.length === 0) {
       logger.warn(`Mochi.serve({ queueStorage }) has no effect without a non-empty queues map — the queue runtime only starts when queues are declared.`);

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -108,7 +108,17 @@ export type {
   MochiCaptchaVerifyEvent,
   MochiCaptchaReason,
 } from './events';
-export type { MochiQueue, MochiJob, MochiJobOptions, MochiQueueOptions, MochiQueueRuntimeOptions, MochiQueueListeners, MochiProcessor, MochiQueueStorage } from './queue';
+export type {
+  MochiQueue,
+  MochiJob,
+  MochiJobOptions,
+  MochiQueueOptions,
+  MochiQueueRuntimeOptions,
+  MochiQueueListeners,
+  MochiProcessor,
+  MochiQueueStorage,
+  PGliteLike,
+} from './queue';
 export { DEFAULT_EXPIRE_IN_SECONDS } from './queue';
 export { json, error, apiError } from './utils';
 export { trailingSlashIt } from './runtime/trailingSlash';

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -1,7 +1,7 @@
 // The isolation boundary around bun-boss: the only module importing `bun-boss`, and the only one whose rewrite a
 // backend swap would need.
-import { BunBoss, fromBunSqlite } from 'bun-boss';
-import type { JobInsert, JobWithMetadata, SendOptions, UpdateQueueOptions } from 'bun-boss';
+import { BunBoss, fromBunSqlite, fromPglite } from 'bun-boss';
+import type { JobInsert, JobWithMetadata, PGliteLike, SendOptions, UpdateQueueOptions } from 'bun-boss';
 import { SQL } from 'bun';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
@@ -11,8 +11,37 @@ import { startupMilestoneReached } from './lifecycle';
 import { mochiEvents } from './events';
 import { logger } from './utils/log';
 
-/** Where queue jobs live: `'memory'` (SQLite `:memory:`, lost on restart), a SQLite file, or a Postgres database. */
-export type MochiQueueStorage = 'memory' | { sqlite: string } | { postgres: string };
+/**
+ * Where queue jobs live: `'memory'` (SQLite `:memory:`, lost on restart), a SQLite file, a Postgres database, or a
+ * caller-owned embedded PGlite instance (Mochi never closes it).
+ */
+export type MochiQueueStorage = 'memory' | { sqlite: string } | { postgres: string } | { pglite: PGliteLike };
+export type { PGliteLike };
+
+const storageChecks: Record<string, (value: unknown) => boolean> = {
+  sqlite: (value) => typeof value === 'string' && value.length > 0,
+  postgres: (value) => typeof value === 'string' && value.length > 0,
+  pglite: (value) => {
+    const instance = value as Partial<PGliteLike> | null;
+    return typeof instance === 'object' && instance !== null && typeof instance.query === 'function' && typeof instance.exec === 'function';
+  },
+};
+
+/** Runtime-validates what the types already promise, because `queueStorage` often arrives from untyped config. */
+export function isValidQueueStorage(storage: MochiQueueStorage): boolean {
+  if (storage === 'memory') {
+    return true;
+  }
+  if (typeof storage !== 'object' || storage === null) {
+    return false;
+  }
+  const [entry, ...extra] = Object.entries(storageChecks).filter(([key]) => key in storage);
+  if (!entry || extra.length > 0) {
+    return false;
+  }
+  const [key, check] = entry;
+  return check((storage as unknown as Record<string, unknown>)[key]);
+}
 
 /** Deliberately narrow — data, not bun-boss's job row — so userland can't reach behind the abstraction. */
 export interface MochiJob<T> {
@@ -183,6 +212,9 @@ export async function startQueueRuntime(storage: MochiQueueStorage, testOptions?
     // Registered before start() so the failure path in Mochi.serve (closeAllQueueResources) closes it too.
     registry.ownedSql = sql;
     boss = new BunBoss({ backend: 'sqlite', db: fromBunSqlite(sql), schedule: false, ...spies });
+  } else if ('pglite' in storage) {
+    // The caller constructs and owns the PGlite instance (bun-boss's adapter contract), so nothing is registered for closing.
+    boss = new BunBoss({ backend: 'pglite', db: fromPglite(storage.pglite), schema: 'mochi_queue', schedule: false, ...spies });
   } else {
     boss = new BunBoss({ url: storage.postgres, backend: 'postgres', schema: 'mochi_queue', schedule: false, ...spies });
   }

--- a/packages/mochi/src/queuePglite.test.ts
+++ b/packages/mochi/src/queuePglite.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
+import { startQueueRuntime, mountQueues, getQueue, closeAllQueueResources } from './queue';
+import type { MochiJob } from './queue';
+import { mochiEvents } from './events';
+import { resetStartupMilestones } from './lifecycle';
+
+// Exercises the `{ pglite: instance }` storage path — bun-boss's embedded pglite backend, no wire protocol —
+// proving the mochi_queue schema installs and jobs round-trip. The postgres path over the wire is covered by
+// queuePostgres.test.ts; the caller owns the PGlite instance, so this test closes it itself.
+describe('Mochi queue on pglite storage', () => {
+  let db: PGlite;
+
+  afterAll(async () => {
+    mochiEvents.all.clear();
+    resetStartupMilestones();
+    await closeAllQueueResources();
+    await db?.close();
+  });
+
+  test('installs its schema and roundtrips a job in-process', async () => {
+    db = await PGlite.create();
+    const seen: Array<MochiJob<{ n: number }>> = [];
+    let resolveDone!: () => void;
+    const done = new Promise<void>((r) => {
+      resolveDone = r;
+    });
+
+    await startQueueRuntime({ pglite: db });
+    await mountQueues([
+      [
+        'pglite-jobs',
+        {
+          process: async (job: MochiJob<{ n: number }>) => {
+            seen.push(job);
+            resolveDone();
+            return { ok: true };
+          },
+          options: { pollingIntervalSeconds: 0.5 },
+        },
+      ],
+    ]);
+
+    const jobId = await getQueue<{ n: number }>('pglite-jobs').add({ n: 41 });
+    expect(jobId).toBeString();
+    await done;
+    expect(seen).toHaveLength(1);
+    expect(seen[0]?.data).toEqual({ n: 41 });
+    expect(seen[0]?.attempt).toBe(1);
+
+    // The queue tables must live in the namespaced schema, not the user's public schema.
+    const { rows } = await db.query<{ table_schema: string }>("SELECT DISTINCT table_schema FROM information_schema.tables WHERE table_name = 'job'");
+    expect(rows.map((r) => r.table_schema)).toEqual(['mochi_queue']);
+
+    // Mochi must not close a caller-owned instance on teardown; prove it stays usable after the runtime drains.
+    await closeAllQueueResources();
+    const { rows: after } = await db.query<{ ok: number }>('SELECT 1 AS ok');
+    expect(after[0]?.ok).toBe(1);
+  }, 30_000);
+});

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -435,7 +435,8 @@ export interface MochiServeOptions {
   queues?: Record<string, MochiQueueConfig>;
   /**
    * Where queue jobs live: `'memory'` (default — lost on restart), `{ sqlite: 'path/to.db' }` for a durable
-   * single-process store, or `{ postgres: url }` for a shared multi-process store (installed into a `mochi_queue` schema).
+   * single-process store, `{ postgres: url }` for a shared multi-process store (installed into a `mochi_queue` schema),
+   * or `{ pglite: instance }` for an embedded in-process Postgres you construct and own (Mochi never closes it).
    */
   queueStorage?: MochiQueueStorage;
   fetch?: (req: Request, server: Server<undefined>) => Response | Promise<Response>;


### PR DESCRIPTION
- Adds a fourth `queueStorage` variant, `{ pglite: instance }`, wired to bun-boss's embedded pglite backend (`fromPglite` + `backend: 'pglite'`, same `mochi_queue` schema as Postgres)
- The caller constructs and owns the PGlite instance; Mochi never closes it
- Refactors `queueStorage` validation into per-backend checkers (`isValidQueueStorage` in `queue.ts`)
- Test: schema install + job roundtrip on a direct in-process PGlite, plus proof the instance survives `closeAllQueueResources()`
- Docs: storage table row + a `### PGlite` section (recommended for dev/test against the same Postgres path)