### PR TITLE
build(devcontainer): re-sync docker group GID on start

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -75,7 +75,7 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "mkdir -p /home/node/.claude && [ -s /home/node/.claude/settings.json ] || echo '{}' > /home/node/.claude/settings.json && tmp=$(jq -s '.[0] * .[1] * {statusLine: {type: \"command\", command: \"bash /home/node/statusline.sh\"}}' /home/node/claude-settings.json /home/node/.claude/settings.json) && printf '%s\\n' \"$tmp\" > /home/node/.claude/settings.json",
-  "postStartCommand": "bash -c \"bash \\\"$PWD/.devcontainer/start-postgres.sh\\\"; bun install; mkdir -p ~/.local/share/code-server/User && cp -f \\\"$PWD/.devcontainer/code-server-settings.json\\\" ~/.local/share/code-server/User/settings.json 2>/dev/null; export SHELL=\\\"${SHELL:-/bin/bash}\\\"; pgrep -f 'code-server.*8080' >/dev/null 2>&1 || nohup code-server --bind-addr 0.0.0.0:8080 --auth none --disable-workspace-trust \\\"$PWD\\\" >/tmp/code-server.log 2>&1 &\"",
+  "postStartCommand": "bash -c \"sudo bash /usr/local/share/docker-init.sh true >/dev/null 2>&1 || true; bash \\\"$PWD/.devcontainer/start-postgres.sh\\\"; bun install; mkdir -p ~/.local/share/code-server/User && cp -f \\\"$PWD/.devcontainer/code-server-settings.json\\\" ~/.local/share/code-server/User/settings.json 2>/dev/null; export SHELL=\\\"${SHELL:-/bin/bash}\\\"; pgrep -f 'code-server.*8080' >/dev/null 2>&1 || nohup code-server --bind-addr 0.0.0.0:8080 --auth none --disable-workspace-trust \\\"$PWD\\\" >/tmp/code-server.log 2>&1 &\"",
   "waitFor": "postStartCommand",
   "features": {
     "ghcr.io/coder/devcontainer-features/code-server:1": {


### PR DESCRIPTION
## What

Adds a one-line, idempotent re-sync of the Docker socket group to the front of `postStartCommand`:

```sh
sudo bash /usr/local/share/docker-init.sh true >/dev/null 2>&1 || true;
```

## Why

Commit #276 wired in the `docker-outside-of-docker` feature, but Docker was still broken at runtime: the container's `docker` group was GID 997 while the host socket (`/var/run/docker-host.sock`) is group-owned by GID 983, so `node` got `permission denied while trying to connect to the docker API`.

The feature's own boot init (`docker-init.sh`) is *supposed* to `groupmod --gid <socket-gid> docker`, but it can evaluate the socket GID before the host bind-mount settles — it logs "Success" without actually applying the groupmod, leaving the mismatch.

Re-running `docker-init.sh` at the start of `postStartCommand` re-does the `groupmod` on every boot, after the socket is in place. It's idempotent and failure-tolerant (`|| true`), so it's a no-op when the group is already correct.

## Verification

After running the init script manually in the current container:

- `getent group docker` → `docker:x:983:node`
- host socket now shows group `docker`
- `docker ps` / `docker info` succeed against the host daemon (docker-outside-of-docker working as intended)

Note: a terminal open *before* the groupmod keeps the stale GID for its lifetime; newly-opened terminals pick up the correct group automatically.