### PR TITLE
feat: add isBuilding constant, true during mochi-framework build

### DIFF
--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -75,7 +75,7 @@ if (!isBuilding) await db.connect();
 await Mochi.serve({ routes });
 ```
 
-Unlike the other constants it is a real runtime value, not a baked literal. Inside `.svelte` components it is always `false` — components are compiled but never executed during a build.
+Inside `.svelte` components it is always `false` — components are compiled but never executed during a build.
 
 ## Detecting hydration with `isHydratable()`
 

--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -1,7 +1,7 @@
 ---
 title: 'Environment constants'
 slug: environment-constants
-description: 'Build-time constants for branching on render target (isServer, isBrowser) and dev mode (isDev).'
+description: 'Build-time constants for branching on render target (isServer, isBrowser), dev mode (isDev), and the build itself (isBuilding).'
 ---
 
 <script>
@@ -61,6 +61,21 @@ export function trace(msg: string) {
   if (isDev) console.log('[trace]', msg);
 }
 ```
+
+### `isBuilding`
+
+`true` only while `mochi-framework build` runs your `index.ts`, `false` when serving (dev or prod). `mochi-framework build` executes your entry to capture its `Mochi.serve()` options, so top-level side effects in `index.ts` run at build time too. Gate the ones you don't want then — connecting a database, spawning workers, running migrations:
+
+```ts
+// file: src/index.ts
+import { Mochi, isBuilding } from 'mochi-framework';
+
+if (!isBuilding) await db.connect();
+
+await Mochi.serve({ routes });
+```
+
+Unlike the other constants it is a real runtime value, not a baked literal. Inside `.svelte` components it is always `false` — components are compiled but never executed during a build.
 
 ## Detecting hydration with `isHydratable()`
 

--- a/packages/mochi/src/cli/extractServeOptions.test.ts
+++ b/packages/mochi/src/cli/extractServeOptions.test.ts
@@ -15,6 +15,7 @@ describe('extractServeOptions', () => {
       rmSync(dir, { recursive: true, force: true });
       dir = undefined;
     }
+    delete (globalThis as Record<string, unknown>).__test_isBuilding;
   });
 
   function writeEntry(body: string): string {
@@ -53,6 +54,19 @@ throw new Error('serve should have halted execution before this line');`,
     expect(options?.queues?.emails?.__mochiQueue).toBe(true);
     expect(options?.queues?.emails?.options).toEqual({ concurrency: 2 });
     expect(options?.queueStorage).toBe('memory');
+  });
+
+  test('marks isBuilding true while executing the entry', async () => {
+    const entry = writeEntry(
+      `import { Mochi, isBuilding } from 'mochi-framework';
+globalThis.__test_isBuilding = isBuilding;
+await Mochi.serve({ routes: {} });
+throw new Error('serve should have halted execution before this line');`,
+    );
+
+    await extractServeOptions(entry);
+
+    expect((globalThis as Record<string, unknown>).__test_isBuilding).toBe(true);
   });
 
   test('returns null when the entry never calls serve()', async () => {

--- a/packages/mochi/src/cli/extractServeOptions.ts
+++ b/packages/mochi/src/cli/extractServeOptions.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { freshImport } from '../compiler/freshImport';
+import { markBuilding } from '../utils/buildFlag';
 import type { MochiServeOptions } from '../types';
 
 // Thrown by the capturing serve() stub to unwind the entry module's top-level
@@ -24,6 +25,11 @@ let captured: Partial<MochiServeOptions> | null = null;
  * Returns the captured options, or `null` if the entry never called `serve()`.
  */
 export async function extractServeOptions(entryPath: string, opts?: { fresh?: boolean }): Promise<Partial<MochiServeOptions> | null> {
+  // Flip `isBuilding` before importing the framework: the plugin below snapshots
+  // realMod's namespace into its `object`-loader exports, so the flag must
+  // already be true when that spread runs for the entry to observe it.
+  markBuilding();
+
   // The real framework entry, by absolute path — NOT the bare specifier, so the
   // plugin below does not intercept this import (no recursion). This file lives
   // in `src/cli/`, so climb one level to reach it.

--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
@@ -1,4 +1,6 @@
 export const isServer = false; export const isBrowser = true; export const DEV = __MOCHI_DEV__; export const isDev = __MOCHI_DEV__;
+// Always false in the browser: a build never runs client-side, so nothing that executes here is ever mid-build.
+export const isBuilding = false;
 // Shared thrower for the server-only stubs below. Each stub stays a pure
 // declaration (tree-shaken when unused); this helper is pulled in only if one is.
 const __serverOnly = (n) => { throw new Error(n + " is only available on the server"); };

--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
@@ -1,4 +1,6 @@
 export const isServer = true; export const isBrowser = false; export const DEV = __MOCHI_DEV__; export const isDev = __MOCHI_DEV__;
+// Always false in components: they are compiled but never executed during a build, so a compiled component only ever runs while serving.
+export const isBuilding = false;
 export function getRequestContext() {
   const ctx = globalThis.__mochi_request_context__?.getStore();
   if (!ctx) throw new Error("getRequestContext() called outside of a request.");

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -50,6 +50,7 @@ export type { ConsoleLoggerOptions } from './dev/consoleLogger';
 export { logger, setLogLevel, getLogLevel } from './utils/log';
 export type { LogLevel } from './utils/log';
 export { pinGlobal } from './utils/globalState';
+export { isBuilding } from './utils/buildFlag';
 export { mochiEvents, hasSubscribers } from './events';
 export type { MochiCompileError } from './compiler/ComponentRegistry';
 export type {

--- a/packages/mochi/src/utils/buildFlag.ts
+++ b/packages/mochi/src/utils/buildFlag.ts
@@ -1,0 +1,9 @@
+// A live-binding flag so `import { isBuilding }` reflects the value at access
+// time. `markBuilding()` is called by the build CLI (extractServeOptions) before
+// it executes the app entry, letting server-setup code skip real-boot side
+// effects during a `mochi-framework build`.
+export let isBuilding = false;
+
+export function markBuilding(): void {
+  isBuilding = true;
+}


### PR DESCRIPTION
## What

Adds an `isBuilding` constant to `mochi-framework`:

- **`true`** only while `mochi-framework build` executes your app entry, **`false`** when actually serving (dev or prod).
- `mochi-framework build` runs your `index.ts` for real (via `extractServeOptions`) to capture its `Mochi.serve()` options, so any top-level side effect in the entry runs at build time too. `isBuilding` lets server-setup code opt out of those:

```ts
// src/index.ts
import { Mochi, isBuilding } from 'mochi-framework';

if (!isBuilding) await db.connect(); // skipped during build

await Mochi.serve({ routes });
```

## Why it isn't shaped like `isDev`

`isServer`/`isBrowser`/`isDev` are **not** real runtime exports of `index.ts` — they only exist as literals baked into the virtual `mochi-env` module (the compiled Svelte graph) plus a TS augmentation, so they're unusable at runtime in a plain `index.ts` that Bun runs directly. `isBuilding`'s consumer **is** the entry, so it's a genuine runtime export backed by a process flag.

## How

- **`utils/buildFlag.ts`** (new) — a live-binding `export let isBuilding` + `markBuilding()`.
- **`index.ts`** — real re-export (no `.d.ts` change; TS infers the type via the exports map, like `logger`).
- **`extractServeOptions.ts`** — calls `markBuilding()` before importing the framework, so the value is already `true` when the `Bun.plugin` snapshots the framework namespace for the entry (load-bearing ordering).
- **Both `mochi-env` templates** — `export const isBuilding = false` with a why-comment: components are compiled but never executed during a build, so a compiled component only ever runs while serving. Exposed there only so `.svelte` imports don't fail the SSR build.
- **Docs** — new `### isBuilding` section in `80-environment-constants.md`.

## Verification

- New test in `extractServeOptions.test.ts` (6/6 pass) — confirms the flag flips true during extraction, exercising the plugin-spread ordering.
- Runtime smoke on `packages/minimal`: `build` → `isBuilding true`; `start` → `isBuilding false`.
- `.svelte` parity: a component importing `isBuilding` builds with no "No matching export" and renders `false`.
- `bun run checks` was running at PR-open time (draft).

Draft — opening now; will mark ready once `bun run checks` comes back clean.
