### PR TITLE
build(devcontainer): replace docker-outside-of-docker with docker-in-docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
       "BUN_VERSION": "1.3.14"
     }
   },
-  "runArgs": ["--add-host=host.docker.internal:host-gateway"],
+  "runArgs": ["--add-host=host.docker.internal:host-gateway", "--privileged"],
   "forwardPorts": [3333, 3334, 3335, 3336, 5432],
   "portsAttributes": {
     "3333": {
@@ -75,7 +75,7 @@
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace,type=bind,consistency=delegated",
   "workspaceFolder": "/workspace",
   "postCreateCommand": "mkdir -p /home/node/.claude && [ -s /home/node/.claude/settings.json ] || echo '{}' > /home/node/.claude/settings.json && tmp=$(jq -s '.[0] * .[1] * {statusLine: {type: \"command\", command: \"bash /home/node/statusline.sh\"}}' /home/node/claude-settings.json /home/node/.claude/settings.json) && printf '%s\\n' \"$tmp\" > /home/node/.claude/settings.json",
-  "postStartCommand": "bash -c \"sudo bash /usr/local/share/docker-init.sh true >/dev/null 2>&1 || true; bash \\\"$PWD/.devcontainer/start-postgres.sh\\\"; bun install; mkdir -p ~/.local/share/code-server/User && cp -f \\\"$PWD/.devcontainer/code-server-settings.json\\\" ~/.local/share/code-server/User/settings.json 2>/dev/null; export SHELL=\\\"${SHELL:-/bin/bash}\\\"; pgrep -f 'code-server.*8080' >/dev/null 2>&1 || nohup code-server --bind-addr 0.0.0.0:8080 --auth none --disable-workspace-trust \\\"$PWD\\\" >/tmp/code-server.log 2>&1 &\"",
+  "postStartCommand": "bash -c \"bash \\\"$PWD/.devcontainer/start-dockerd.sh\\\" >/dev/null 2>&1 || true; bash \\\"$PWD/.devcontainer/start-postgres.sh\\\"; bun install; mkdir -p ~/.local/share/code-server/User && cp -f \\\"$PWD/.devcontainer/code-server-settings.json\\\" ~/.local/share/code-server/User/settings.json 2>/dev/null; export SHELL=\\\"${SHELL:-/bin/bash}\\\"; pgrep -f 'code-server.*8080' >/dev/null 2>&1 || nohup code-server --bind-addr 0.0.0.0:8080 --auth none --disable-workspace-trust \\\"$PWD\\\" >/tmp/code-server.log 2>&1 &\"",
   "waitFor": "postStartCommand",
   "features": {
     "ghcr.io/coder/devcontainer-features/code-server:1": {
@@ -83,7 +83,7 @@
       "port": 8080,
       "auth": "none"
     },
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "./codebay-tmux": {}
   },
   "appPort": ["127.0.0.1:8005:8080", "127.0.0.1:8007:3333", "127.0.0.1:8008:3334", "127.0.0.1:8009:3335", "127.0.0.1:8010:3336", "127.0.0.1:8045:5432"]

--- a/.devcontainer/start-dockerd.sh
+++ b/.devcontainer/start-dockerd.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Start the in-container Docker daemon (docker-in-docker feature).
+#
+# The feature registers dockerd via a container entrypoint, but the platform
+# harness owns PID 1, so that entrypoint never runs — start the daemon here on
+# each boot instead. `node` joins the docker group at image-build time, so once
+# the daemon is up its socket is reachable with plain group perms.
+#
+# The host provides netfilter NAT through the nftables backend only (nft_chain_nat
+# is loaded, legacy iptable_nat is not), but this image defaults `iptables` to the
+# legacy binary, whose empty nat table makes dockerd's bridge setup abort. Point
+# iptables at the nft backend first so the default NAT bridge comes up normally.
+set -u
+
+docker info >/dev/null 2>&1 && exit 0
+
+command -v dockerd >/dev/null 2>&1 || {
+  echo "start-dockerd: no dockerd found (is the docker-in-docker feature installed?)" >&2
+  exit 0
+}
+
+sudo update-alternatives --set iptables /usr/sbin/iptables-nft >/dev/null 2>&1 || true
+sudo update-alternatives --set ip6tables /usr/sbin/ip6tables-nft >/dev/null 2>&1 || true
+
+sudo sh -c 'nohup dockerd >/tmp/dockerd.log 2>&1 &'
+
+for _ in $(seq 1 30); do
+  docker info >/dev/null 2>&1 && exit 0
+  sleep 1
+done
+
+echo "start-dockerd: daemon not ready after 30s (see /tmp/dockerd.log)" >&2
+exit 0


### PR DESCRIPTION
## What

Switches the dev container from **docker-outside-of-docker** (mounting the host
Docker socket) to **docker-in-docker** (an isolated `dockerd` running inside the
container).

Three changes to `devcontainer.json` plus one new script:

- `runArgs`: add `--privileged` (a nested daemon needs to manage cgroups, devices, netns).
- `features`: `docker-outside-of-docker:1` → `docker-in-docker:2`.
- `postStartCommand`: call `start-dockerd.sh` instead of the dood `docker-init.sh`.
- **new** `start-dockerd.sh`: starts the daemon on boot and fixes the iptables backend.

## Why

With dood, the `docker` group's GID was reconciled against the host socket in
`postStart` (#278) — but that runs *after* the platform-owned PID 1 and the tmux
session tree already captured the old GID, and a `groupmod` never updates a
running process's group set. Net result: the host socket was unreachable from
any shell without a `newgrp`/`sg` wrapper. dind sidesteps this entirely: `node`
joins the `docker` group at image-build time and the daemon creates its own
socket at that same GID, so plain group perms work on first boot.

## Notes for reviewers

- **`--privileged` is now required.** Any host/context that builds this dev
  container must permit privileged, or the nested daemon won't start.
- **The daemon is isolated** — you no longer see the host's containers, and
  images live in the container's `/var/lib/docker` (persist across restarts,
  reset on a full rebuild).
- **iptables backend:** the daemon's entrypoint never runs here (the platform
  harness owns PID 1), so `start-dockerd.sh` starts it from `postStart`. The
  host provides netfilter NAT only through the **nftables** backend, while the
  image defaults `iptables` to the legacy binary whose empty `nat` table makes
  dockerd's bridge setup abort — so the script points `iptables`/`ip6tables` at
  the nft backend before starting `dockerd`. Networking is then fully normal
  (default bridge NAT; no `--network=host` needed).
- `devcontainer-lock.json` is gitignored, so it's not part of this PR; it
  regenerates for the new feature on the next build.

## Verified

Live in a privileged rebuild: `docker run hello-world`, default-network
`docker run`/`docker build` reaching the internet through NAT, and bare `docker`
as `node` with no wrapper.