### PR TITLE
feat!: rework Mochi.queue into named, directly-usable descriptors

### DIFF
--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -106,10 +106,11 @@ const emails = Mochi.queue<{ to: string }>('emails', {
 });
 
 await emails.addBulk(jobs);
-await Mochi.stop();
+await emails.stop();
 ```
 
 - A producer creates the queue if missing and leaves stored options untouched — [option re-sync](#storage) stays with `Mochi.serve()`. To consume without a server, see [standalone workers](#standalone-workers).
+- `queue.stop()` stops that queue in this process — its worker deregisters after in-flight jobs finish, and the shared runtime closes once the last active queue stops. [`Mochi.stop()`](#mochistop) remains the whole-app teardown; under `Mochi.serve()` queues stop with the server.
 - Your app has **one queue storage**. Declare it on the descriptor (`storage`), app-wide via the serve-level [`queueStorage`](#storage) option, or both when they agree — conflicting declarations are a boot error. Standalone, a descriptor without `storage` throws on `add()`.
 - `Mochi.serve()` inherits the descriptors' storage when `queueStorage` is unset, and a serve on the same storage adopts an already-connected standalone runtime — on a different storage it refuses to start.
 - `mochi:queuesMounted` fires only under `Mochi.serve()`. For a standalone producer, readiness is the first `add()` resolving.

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -95,10 +95,10 @@ await emails.addBulk([{ data: { to: 'a@x.com' } }, { data: { to: 'b@x.com' }, op
 
 ### Standalone producers
 
-A script whose only job is _enqueueing_ — a cron job, a CLI backfill, a migration — does not need a server. Give the descriptor `storage` and its first `add()` lazily connects a **producer-only** runtime: no port, no workers, and no touching of queue options owned by the consuming deployment. Tear down with [`Mochi.stop()`](#mochistop):
+A script whose only job is _enqueueing_ — a cron job, a CLI backfill, a migration — can write straight to queue storage. Give the descriptor `storage` and its first `add()` lazily connects a **producer-only** runtime; tear down with [`Mochi.stop()`](#mochistop):
 
 ```ts
-// enqueue.ts — run with `bun enqueue.ts`, no Mochi.serve() anywhere
+// enqueue.ts — a standalone producer script
 import { Mochi } from 'mochi-framework';
 
 const emails = Mochi.queue<{ to: string }>('emails', {
@@ -109,14 +109,46 @@ await emails.addBulk(jobs);
 await Mochi.stop();
 ```
 
-- The queue is created if missing, but existing queue options are **never re-synced** from a producer — only `Mochi.serve()` mounting the queue rewrites them.
-- One queue runtime per process: every standalone descriptor must use the same storage, and a descriptor without `storage` throws on `add()`.
-- Under `Mochi.serve()`, the serve-level `queueStorage` wins (a differing descriptor `storage` logs a warning). A serve on the **same** storage adopts an already-connected standalone runtime; on a different storage it refuses to start.
-- `mochi:queuesMounted` is a serve milestone — it does not fire for standalone producers. Readiness is simply the first `add()` resolving.
+- A producer creates the queue if missing and leaves stored options untouched — [option re-sync](#storage) stays with `Mochi.serve()`. To consume without a server, see [standalone workers](#standalone-workers).
+- Your app has **one queue storage**. Declare it on the descriptor (`storage`), app-wide via the serve-level [`queueStorage`](#storage) option, or both when they agree — conflicting declarations are a boot error. Standalone, a descriptor without `storage` throws on `add()`.
+- `Mochi.serve()` inherits the descriptors' storage when `queueStorage` is unset, and a serve on the same storage adopts an already-connected standalone runtime — on a different storage it refuses to start.
+- `mochi:queuesMounted` fires only under `Mochi.serve()`. For a standalone producer, readiness is the first `add()` resolving.
+
+### Standalone workers
+
+`Mochi.worker()` is the consuming counterpart: a process that polls and runs `process` without serving HTTP. `start()` connects to the app's queue storage — from the descriptors, or the worker's own `storage` option — ensures the queues exist, and begins polling:
+
+```ts
+// worker.ts — a standalone worker script
+import { Mochi, consoleLogger } from 'mochi-framework';
+import { emails } from './queues';
+
+consoleLogger();
+
+const worker = Mochi.worker({ queues: [emails] });
+await worker.start();
+
+process.on('SIGINT', async () => {
+  await Mochi.stop();
+  process.exit(0);
+});
+process.on('SIGTERM', async () => {
+  await Mochi.stop();
+  process.exit(0);
+});
+```
+
+Like standalone producers, workers are ensure-only: stored queue options are trusted as-is, with no re-sync — declare the options you rely on wherever the queue is actually mounted by `Mochi.serve()`, or on a fresh queue's first creator. `worker.stop()` deregisters the worker's queues (waiting for in-flight jobs) while the runtime stays up for producing; `Mochi.stop()` tears the runtime down.
+
+<Callout type="info">
+
+**Standalone means standalone.** `Mochi.worker()` installs no signal handlers (wire them yourself, as above), fires no hooks or startup milestones, and subscribes no logger — call `consoleLogger()` for the `QUEUE` lines. A process that calls `Mochi.serve()` declares its queues there instead; `start()` refuses to run alongside it.
+
+</Callout>
 
 ### Batch processing
 
-By default a worker fetches one job per poll. `batchSize` fetches up to N at once — `process` still runs once per job, and each job settles on its own, so one throw fails (and retries) only that job while its batch siblings complete. `burst: true` keeps fetching with no poll delay while fetches come back full, which is what drains a large cross-process backlog fast:
+By default a worker fetches one job per poll. `batchSize` fetches up to N at once — `process` still runs once per job, and each job settles on its own, so one throw fails (and retries) only that job while its batch siblings complete. `burst: true` keeps fetching with zero poll delay while batches come back full — the fastest way to drain a cross-process backlog:
 
 ```ts
 Mochi.queue<PluginJob>('plugin-info', {
@@ -140,11 +172,11 @@ Mochi.queue('plugin-info', {
 });
 ```
 
-Mochi-owned settings (`batchSize`, `concurrency`, `pollingIntervalSeconds`, and the per-job settlement contract) always win where they overlap, and nothing in `worker` is persisted on the queue — these only shape how this worker fetches.
+Mochi-owned settings (`batchSize`, `concurrency`, `pollingIntervalSeconds`, and the per-job settlement contract) win where they overlap. `worker` options apply at fetch time only; stored queue options stay as declared.
 
 ### Storage
 
-One store serves every queue, selected by the serve-level `queueStorage` option:
+One store serves every queue — declared app-wide via the serve-level `queueStorage` option, or inherited from a [`storage`](#standalone-producers) declared on the descriptors:
 
 ```ts
 await Mochi.serve({
@@ -165,7 +197,7 @@ await Mochi.serve({
 
 Postgres storage installs its tables into a dedicated `mochi_queue` schema on first start, away from your application's tables. The schema name is fixed, so every app sharing one database shares one queue namespace — give each app its own database to keep their queues apart.
 
-On durable storage, queue options re-sync from your code on every `Mochi.serve()` boot — but only **additively**: an option you leave undeclared (including `expireInSeconds`) keeps its previously stored value. Set the old value back explicitly (e.g. `retryLimit: 2`) rather than deleting the line; a removed `deadLetter` can only be repointed, not cleared. [Standalone producers](#standalone-producers) never re-sync anything.
+On durable storage, queue options re-sync from your code on every `Mochi.serve()` boot — but only **additively**: an option you leave undeclared (including `expireInSeconds`) keeps its previously stored value. Set the old value back explicitly (e.g. `retryLimit: 2`) rather than deleting the line; a removed `deadLetter` can only be repointed, not cleared. [Standalone producers](#standalone-producers) leave stored options untouched.
 
 ### PGlite
 
@@ -263,7 +295,7 @@ mochiEvents.on('queue:completed', ({ queue, jobId, duration }) => {
 
 ### Shutdown
 
-Queues close gracefully on `SIGTERM`/`SIGINT`. In-flight jobs get up to 10 seconds to finish; a job still running after that is failed and follows its queue's retry policy from the store. A queue-only worker process is `Mochi.serve({ queues })` with no `routes`:
+Queues close gracefully on `SIGTERM`/`SIGINT`. In-flight jobs get up to 10 seconds to finish; a job still running after that is failed and follows its queue's retry policy from the store. For a worker process with an HTTP port (health checks, metrics), use `Mochi.serve({ queues })` with no `routes` — [`Mochi.worker()`](#standalone-workers) is the serverless alternative:
 
 ```ts
 // worker.ts — run with `bun worker.ts`
@@ -289,7 +321,7 @@ await Mochi.serve({
 
 ### `Mochi.stop()`
 
-`Mochi.stop()` runs the same graceful teardown as `SIGTERM`/`SIGINT` — the `mochi:shutdown` hook, queue drain, server stop — without exiting the process, so a finite-lifetime script or test ends naturally instead of signalling itself. In a process that never served, it just closes the standalone queue runtime. It is idempotent, and a stopped process cannot `Mochi.serve()` again.
+`Mochi.stop()` runs the same graceful teardown as `SIGTERM`/`SIGINT` — the `mochi:shutdown` hook, queue drain, server stop — without exiting the process, so a finite-lifetime script or test ends naturally. In a [standalone producer](#standalone-producers) process it closes the queue runtime. It is idempotent, and a stopped process cannot `Mochi.serve()` again.
 
 ```ts
 await Mochi.serve({ routes, queues });

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -161,6 +161,8 @@ Mochi.queue<PluginJob>('plugin-info', {
 
 Within a batch, jobs run sequentially — parallelism stays owned by `concurrency`, so `concurrency: 1` still means strictly serial processing whatever the batch size. `batchSize` is a fetch-efficiency knob, not a concurrency one.
 
+The [`expireInSeconds`](#long-running-jobs) budget covers the whole fetched batch, not each job — size it for a full batch (≈ `batchSize` × the per-job worst case). When the budget runs out mid-batch, the remaining jobs fail for retry while completed siblings keep their results.
+
 ### Worker tuning
 
 The rarely-needed bun-boss fetch options ride along in `worker`, forwarded to the worker verbatim: `orderByCreatedOn`, `priority`, `minPriority`, `maxPriority`, `ignoreStartAfter`, `notifyPollingIntervalSeconds`, `burstWhenReadyExceeds`, `heartbeatRefreshSeconds`.
@@ -257,7 +259,7 @@ A job may stay active for `expireInSeconds` (default **900**) before the store a
 Mochi.queue('transcode', { process: transcodeVideo, expireInSeconds: 3600 });
 ```
 
-A deployment can override every queue at once with the [`queue:expireInSeconds`](/docs/extensions/) filter.
+A deployment can override every queue at once with the [`queue:expireInSeconds`](/docs/extensions/) filter. With [`batchSize`](#batch-processing) > 1 the budget covers the whole fetched batch.
 
 ### `Mochi.boss()`
 

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -12,37 +12,36 @@ description: 'Run background jobs with Mochi.queue(), backed by bun-boss on memo
 
 ## Queues
 
-<VersionNote since="0.10.0" message="Mochi.queue API will be refactored in the next Mochi release (0.10.0), this page represents the new upcoming API." />
+<VersionNote since="0.10.0" message="Mochi.queue was reworked in 0.10.0: descriptors are named and directly usable, and the serve-level queues option takes an array of them. This page documents the new API." />
 
 Offload work that should not block a response — sending email, encoding media, calling slow APIs — to a background **queue**. A queue bundles a job channel with the `process` function that consumes it. Both run in your process, backed by [bun-boss](https://github.com/khromov/bun-boss).
 
-`Mochi.queue()` returns an inert config. Mount it in `Mochi.serve({ queues })`, keyed by name, so every background queue the server runs is declared in one place. Add jobs from anywhere with `Mochi.getQueue(name).add(...)`.
+`Mochi.queue(name, …)` returns a descriptor that is both the declaration and the producer handle. Mount it in the `Mochi.serve({ queues })` array to start its worker; call `.add()` on it from anywhere:
 
 ```ts
 import { Mochi } from 'mochi-framework';
 
-await Mochi.serve({
-  routes: {/* … */},
-  queues: {
-    // the map key is the queue name
-    emails: Mochi.queue<{ to: string }>({
-      concurrency: 10,
-      process: async (job) => {
-        await sendEmail(job.data.to);
-        return { sent: true };
-      },
-    }),
+export const emails = Mochi.queue<{ to: string }>('emails', {
+  concurrency: 10,
+  process: async (job) => {
+    await sendEmail(job.data.to);
+    return { sent: true };
   },
 });
 
+await Mochi.serve({
+  routes: {/* … */},
+  queues: [emails],
+});
+
 // from a page action, an API route, anywhere:
-await Mochi.getQueue<{ to: string }>('emails').add({ to: 'alice@example.com' });
+await emails.add({ to: 'alice@example.com' });
 ```
 
 ### `Mochi.queue()`
 
 ```ts
-const queueConfig = Mochi.queue<JobData, Result>({ process, ...options });
+const queue = Mochi.queue<JobData, Result>(name, { process, ...options });
 ```
 
 `process` receives a read-only `MochiJob<T>` and returns the job result. Omit it for a queue that only receives jobs — e.g. a [dead-letter](#dead-letter-queues) holding pen.
@@ -55,10 +54,10 @@ const queueConfig = Mochi.queue<JobData, Result>({ process, ...options });
 | `attempt`    | `number` | 1-based attempt number (1 on first run) |
 | `enqueuedAt` | `number` | epoch ms when enqueued                  |
 
-Queue-level options are inherited by every job: `concurrency`, `pollingIntervalSeconds`, [retries](#retries) (`retryLimit`, `retryDelay`, `retryBackoff`, `retryDelayMax`), `expireInSeconds`, `retentionSeconds`, `deleteAfterSeconds`, `deadLetter`. Every duration is in **seconds**. `on` registers lifecycle listeners:
+Queue-level options are inherited by every job: `concurrency`, `pollingIntervalSeconds`, [`batchSize` and `burst`](#batch-processing), [retries](#retries) (`retryLimit`, `retryDelay`, `retryBackoff`, `retryDelayMax`), `expireInSeconds`, `retentionSeconds`, `deleteAfterSeconds`, `deadLetter`, [`worker`](#worker-tuning), [`storage`](#standalone-producers). Every duration is in **seconds**. `on` registers lifecycle listeners:
 
 ```ts
-Mochi.queue({
+Mochi.queue('emails', {
   concurrency: 10,
   process,
   on: {
@@ -70,9 +69,9 @@ Mochi.queue({
 
 Or subscribe on the [`mochiEvents` bus](#observability) (filter by `queue` name) when the listener lives far from the queue declaration.
 
-### `Mochi.getQueue()`
+### Adding jobs
 
-`Mochi.getQueue<JobData>(name)` resolves a mounted queue's handle. Call `.add()` on it to add jobs. Pass the payload type explicitly. It throws if the name was never declared in `Mochi.serve({ queues })`, or if reached before `Mochi.serve()` mounted its queues.
+The descriptor itself is the producer handle — import it and add. `Mochi.getQueue<JobData>(name)` resolves the same handle by name, for call sites that should not import the declaring module; it throws for a name that was never declared, or before `Mochi.serve()` mounted its queues.
 
 | Method                                     | Returns                   | Notes                                       |
 | ------------------------------------------ | ------------------------- | ------------------------------------------- |
@@ -84,7 +83,6 @@ Or subscribe on the [`mochiEvents` bus](#observability) (filter by `queue` name)
 Per-job options override their queue-level counterparts: `priority`, `startAfter` (seconds, or a `Date`), `id`, `retryLimit`, `retryDelay`, `retryBackoff`, `retryDelayMax`, `expireInSeconds`.
 
 ```ts
-const emails = Mochi.getQueue<{ to: string }>('emails');
 await emails.add({ to: 'bob@example.com' }, { priority: 10, startAfter: 5 });
 await emails.addBulk([{ data: { to: 'a@x.com' } }, { data: { to: 'b@x.com' }, opts: { priority: 10 } }]);
 ```
@@ -95,13 +93,62 @@ await emails.addBulk([{ data: { to: 'a@x.com' } }, { data: { to: 'b@x.com' }, op
 
 </Callout>
 
+### Standalone producers
+
+A script whose only job is _enqueueing_ — a cron job, a CLI backfill, a migration — does not need a server. Give the descriptor `storage` and its first `add()` lazily connects a **producer-only** runtime: no port, no workers, and no touching of queue options owned by the consuming deployment. Tear down with [`Mochi.stop()`](#mochistop):
+
+```ts
+// enqueue.ts — run with `bun enqueue.ts`, no Mochi.serve() anywhere
+import { Mochi } from 'mochi-framework';
+
+const emails = Mochi.queue<{ to: string }>('emails', {
+  storage: { postgres: process.env.DATABASE_URL! },
+});
+
+await emails.addBulk(jobs);
+await Mochi.stop();
+```
+
+- The queue is created if missing, but existing queue options are **never re-synced** from a producer — only `Mochi.serve()` mounting the queue rewrites them.
+- One queue runtime per process: every standalone descriptor must use the same storage, and a descriptor without `storage` throws on `add()`.
+- Under `Mochi.serve()`, the serve-level `queueStorage` wins (a differing descriptor `storage` logs a warning). A serve on the **same** storage adopts an already-connected standalone runtime; on a different storage it refuses to start.
+- `mochi:queuesMounted` is a serve milestone — it does not fire for standalone producers. Readiness is simply the first `add()` resolving.
+
+### Batch processing
+
+By default a worker fetches one job per poll. `batchSize` fetches up to N at once — `process` still runs once per job, and each job settles on its own, so one throw fails (and retries) only that job while its batch siblings complete. `burst: true` keeps fetching with no poll delay while fetches come back full, which is what drains a large cross-process backlog fast:
+
+```ts
+Mochi.queue<PluginJob>('plugin-info', {
+  process: fetchPluginInfo,
+  batchSize: 5,
+  burst: true,
+});
+```
+
+Within a batch, jobs run sequentially — parallelism stays owned by `concurrency`, so `concurrency: 1` still means strictly serial processing whatever the batch size. `batchSize` is a fetch-efficiency knob, not a concurrency one.
+
+### Worker tuning
+
+The rarely-needed bun-boss fetch options ride along in `worker`, forwarded to the worker verbatim: `orderByCreatedOn`, `priority`, `minPriority`, `maxPriority`, `ignoreStartAfter`, `notifyPollingIntervalSeconds`, `burstWhenReadyExceeds`, `heartbeatRefreshSeconds`.
+
+```ts
+Mochi.queue('plugin-info', {
+  process: fetchPluginInfo,
+  batchSize: 5,
+  worker: { orderByCreatedOn: false, minPriority: 10 },
+});
+```
+
+Mochi-owned settings (`batchSize`, `concurrency`, `pollingIntervalSeconds`, and the per-job settlement contract) always win where they overlap, and nothing in `worker` is persisted on the queue — these only shape how this worker fetches.
+
 ### Storage
 
-One store serves every queue in the map, selected by the serve-level `queueStorage` option:
+One store serves every queue, selected by the serve-level `queueStorage` option:
 
 ```ts
 await Mochi.serve({
-  queues: {/* … */},
+  queues: [/* … */],
   queueStorage: 'memory', // the default
   // queueStorage: { sqlite: '.db/queue.sqlite' },
   // queueStorage: { postgres: process.env.DATABASE_URL },
@@ -118,7 +165,7 @@ await Mochi.serve({
 
 Postgres storage installs its tables into a dedicated `mochi_queue` schema on first start, away from your application's tables. The schema name is fixed, so every app sharing one database shares one queue namespace — give each app its own database to keep their queues apart.
 
-On durable storage, queue options re-sync from your code on every boot — but only **additively**: an option you remove from `Mochi.queue()` keeps its previously stored value. Set the old value back explicitly (e.g. `retryLimit: 2`) rather than deleting the line; a removed `deadLetter` can only be repointed, not cleared.
+On durable storage, queue options re-sync from your code on every `Mochi.serve()` boot — but only **additively**: an option you leave undeclared (including `expireInSeconds`) keeps its previously stored value. Set the old value back explicitly (e.g. `retryLimit: 2`) rather than deleting the line; a removed `deadLetter` can only be repointed, not cleared. [Standalone producers](#standalone-producers) never re-sync anything.
 
 ### PGlite
 
@@ -130,7 +177,7 @@ import { PGlite } from '@electric-sql/pglite';
 const db = await PGlite.create('.db/queue-pglite'); // or PGlite.create() for a throwaway in-memory store
 
 await Mochi.serve({
-  queues: {/* … */},
+  queues: [/* … */],
   queueStorage: { pglite: db },
 });
 ```
@@ -142,7 +189,7 @@ Passing the instance keeps `@electric-sql/pglite` out of Mochi's dependencies an
 Failed jobs retry **by default**: `retryLimit` is 2, so a job runs up to 3 times before it fails terminally. Set `retryLimit: 0` for exactly-once execution, and `retryDelay`/`retryBackoff` to space attempts out:
 
 ```ts
-Mochi.queue({
+Mochi.queue('webhooks', {
   process: deliverWebhook,
   retryLimit: 5,
   retryDelay: 5, // seconds; with retryBackoff it doubles per attempt, with jitter
@@ -155,15 +202,15 @@ Mochi.queue({
 
 ### Dead-letter queues
 
-Point `deadLetter` at another queue in the same map and terminally failed jobs move there — same payload — instead of parking in the failed state:
+Point `deadLetter` at another queue in the same array and terminally failed jobs move there — same payload — instead of parking in the failed state:
 
 ```ts
 await Mochi.serve({
-  queues: {
-    webhooks: Mochi.queue({ process: deliverWebhook, retryLimit: 3, deadLetter: 'webhooks-dlq' }),
+  queues: [
+    Mochi.queue('webhooks', { process: deliverWebhook, retryLimit: 3, deadLetter: 'webhooks-dlq' }),
     // No `process`: jobs wait here for inspection. Give it one to handle failures automatically.
-    'webhooks-dlq': Mochi.queue({}),
-  },
+    Mochi.queue('webhooks-dlq'),
+  ],
 });
 ```
 
@@ -174,7 +221,7 @@ Drain or replay a dead-letter queue through the [escape hatch](#mochiboss): `Moc
 A job may stay active for `expireInSeconds` (default **900**) before the store assumes the worker died and retries or fails it. Raise it above the **worst-case** runtime of `process`, not the typical one — a job that outlives it is handed out again while the original still runs, firing its side effects twice:
 
 ```ts
-Mochi.queue({ process: transcodeVideo, expireInSeconds: 3600 });
+Mochi.queue('transcode', { process: transcodeVideo, expireInSeconds: 3600 });
 ```
 
 A deployment can override every queue at once with the [`queue:expireInSeconds`](/docs/extensions/) filter.
@@ -188,7 +235,7 @@ const stats = await Mochi.boss().getQueueStats('emails');
 await Mochi.boss().cancel('emails', jobId);
 ```
 
-It is available from the [`mochi:queuesMounted`](/docs/extensions/#mochiqueuesmounted) hook onwards and throws before that, or when no queues are declared.
+It is available from the [`mochi:queuesMounted`](/docs/extensions/#mochiqueuesmounted) hook onwards (or once a standalone producer has connected) and throws before that, or when no queues are declared.
 
 <Callout type="info">
 
@@ -198,7 +245,7 @@ It is available from the [`mochi:queuesMounted`](/docs/extensions/#mochiqueuesmo
 
 ### Observability
 
-Queues emit [events](/docs/events/) on `mochiEvents`: `queue:added`, `queue:active`, `queue:completed`, `queue:failed`, `queue:error`. The [console logger](/docs/logging/) prints a `QUEUE` line for `added`, `completed`, `failed`, and `error` at `warn`. Wire your own metrics:
+Queues emit [events](/docs/events/) on `mochiEvents`: `queue:added`, `queue:addedBulk`, `queue:active`, `queue:completed`, `queue:failed`, `queue:error`. The [console logger](/docs/logging/) prints a `QUEUE` line for `added`, `addedBulk`, `completed`, `failed`, and `error` at `warn`. Wire your own metrics:
 
 ```ts
 import { mochiEvents } from 'mochi-framework';
@@ -208,7 +255,7 @@ mochiEvents.on('queue:completed', ({ queue, jobId, duration }) => {
 });
 ```
 
-`queue:completed` and `queue:failed` fire per attempt, as the processor settles — an immediate `Mochi.boss().findJobs()` from a listener may still see the job `active` for a beat.
+`queue:completed` and `queue:failed` fire per attempt, as the processor settles — an immediate `Mochi.boss().findJobs()` from a listener may still see the job `active` for a beat. An `addBulk` emits `queue:added` per inserted job (flagged `bulk: true`) plus one `queue:addedBulk` summary — the console logger prints only the summary, so a 100k-job bulk add logs one line.
 
 ### Dev mode & hot reload
 
@@ -216,7 +263,7 @@ mochiEvents.on('queue:completed', ({ queue, jobId, duration }) => {
 
 ### Shutdown
 
-Queues close gracefully on `SIGTERM`/`SIGINT`. In-flight jobs get up to 10 seconds to finish; a job still running after that is failed and follows its queue's retry policy from the store. A queue-only process is `Mochi.serve({ queues })` with no `routes`:
+Queues close gracefully on `SIGTERM`/`SIGINT`. In-flight jobs get up to 10 seconds to finish; a job still running after that is failed and follows its queue's retry policy from the store. A queue-only worker process is `Mochi.serve({ queues })` with no `routes`:
 
 ```ts
 // worker.ts — run with `bun worker.ts`
@@ -224,21 +271,31 @@ import { Mochi } from 'mochi-framework';
 
 await Mochi.serve({
   queueStorage: { postgres: process.env.DATABASE_URL },
-  queues: {
-    emails: Mochi.queue({
+  queues: [
+    Mochi.queue('emails', {
       process: async (job) => {
         await sendEmail(job.data.to);
       },
     }),
-  },
+  ],
 });
 ```
 
 <Callout type="info">
 
-**Dispatch is instant in-process, polled across processes.** An `add()` from the serving process wakes its worker immediately. Other processes sharing Postgres storage — and deferred or retried jobs everywhere — are picked up on the worker's poll, every `pollingIntervalSeconds` (default 2, minimum 0.5).
+**Dispatch is instant in-process, polled across processes.** An `add()` from the serving process wakes its worker immediately. Other processes sharing Postgres storage — and deferred or retried jobs everywhere — are picked up on the worker's poll, every `pollingIntervalSeconds` (default 2, minimum 0.5). To drain a backlog enqueued by another process quickly, give the worker [`batchSize` + `burst`](#batch-processing).
 
 </Callout>
+
+### `Mochi.stop()`
+
+`Mochi.stop()` runs the same graceful teardown as `SIGTERM`/`SIGINT` — the `mochi:shutdown` hook, queue drain, server stop — without exiting the process, so a finite-lifetime script or test ends naturally instead of signalling itself. In a process that never served, it just closes the standalone queue runtime. It is idempotent, and a stopped process cannot `Mochi.serve()` again.
+
+```ts
+await Mochi.serve({ routes, queues });
+// … later, from a test or an embedding script:
+await Mochi.stop();
+```
 
 <SeeItInAction
 demos={[{ href: "/demos/queue/", title: "Background jobs with queues", hook: "How background job queues work — offload work to a Mochi.queue() with an embedded worker, no Redis." }]}

--- a/packages/docs/116-email.md
+++ b/packages/docs/116-email.md
@@ -231,9 +231,9 @@ Delivery is slow and can fail. Offload the send to a [`Mochi.queue()`](/docs/que
 // jobs.server.ts
 import { Mochi } from 'mochi-framework';
 
-export const emailQueue = Mochi.queue<{ to: string; name: string }>({
+export const emailQueue = Mochi.queue<{ to: string; name: string }>('emails', {
   concurrency: 5,
-  defaultJobOptions: { attempts: 3 },
+  retryLimit: 2,
   process: async (job) => {
     await Mochi.email({
       to: job.data.to,

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -7,6 +7,7 @@ description: 'Subscribe to framework lifecycle events like requests, WebSocket a
 <script>
   import Callout from './_components/Callout.svelte';
   import SeeItInAction from './_components/SeeItInAction.svelte';
+  import VersionNote from './_components/VersionNote.svelte';
 </script>
 
 ## Events
@@ -165,6 +166,8 @@ Fires when the SSE stream closes. A client disconnect or an explicit close both 
 
 #### `queue:added`
 
+<VersionNote since="0.10.0" message="The bulk field is new in 0.10.0." />
+
 Fires after `queue.add()` / `queue.addBulk()` enqueues a job. See [Queues](/docs/queues/).
 
 | Field   | Type                   | Notes                                   |
@@ -174,6 +177,8 @@ Fires after `queue.add()` / `queue.addBulk()` enqueues a job. See [Queues](/docs
 | `bulk`  | `boolean \| undefined` | `true` when the add came from `addBulk` |
 
 #### `queue:addedBulk`
+
+<VersionNote since="0.10.0" message="queue:addedBulk is new in 0.10.0." />
 
 Fires once per `addBulk()` call that inserted at least one job, alongside the per-job `queue:added` events. The [console logger](/docs/logging/) prints this summary instead of the per-job lines.
 
@@ -262,6 +267,8 @@ Fires once after `Bun.serve()` binds the listening socket.
 | `routes`      | `{ page: number; api: number; ws: number; sse: number }` | route counts by kind              |
 
 #### `server:stop`
+
+<VersionNote since="0.10.0" message="The 'stop' reason is new in 0.10.0 — earlier versions emit this event only on signals." />
 
 Fires when the server shuts down — on `SIGTERM` / `SIGINT`, or a programmatic [`Mochi.stop()`](/docs/queues/#mochistop) — after the `mochi:shutdown` hook runs.
 

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -167,10 +167,21 @@ Fires when the SSE stream closes. A client disconnect or an explicit close both 
 
 Fires after `queue.add()` / `queue.addBulk()` enqueues a job. See [Queues](/docs/queues/).
 
-| Field   | Type     | Notes            |
-| ------- | -------- | ---------------- |
-| `queue` | `string` | queue name       |
-| `jobId` | `string` | generated job id |
+| Field   | Type                   | Notes                                   |
+| ------- | ---------------------- | --------------------------------------- |
+| `queue` | `string`               | queue name                              |
+| `jobId` | `string`               | generated job id                        |
+| `bulk`  | `boolean \| undefined` | `true` when the add came from `addBulk` |
+
+#### `queue:addedBulk`
+
+Fires once per `addBulk()` call that inserted at least one job, alongside the per-job `queue:added` events. The [console logger](/docs/logging/) prints this summary instead of the per-job lines.
+
+| Field    | Type       | Notes                                              |
+| -------- | ---------- | -------------------------------------------------- |
+| `queue`  | `string`   | queue name                                         |
+| `count`  | `number`   | jobs actually inserted (duplicate ids are skipped) |
+| `jobIds` | `string[]` | ids of the inserted jobs                           |
 
 #### `queue:active`
 
@@ -252,12 +263,12 @@ Fires once after `Bun.serve()` binds the listening socket.
 
 #### `server:stop`
 
-Fires when the server shuts down on `SIGTERM` / `SIGINT`, after the `mochi:shutdown` hook runs.
+Fires when the server shuts down — on `SIGTERM` / `SIGINT`, or a programmatic [`Mochi.stop()`](/docs/queues/#mochistop) — after the `mochi:shutdown` hook runs.
 
-| Field    | Type                                 | Notes                       |
-| -------- | ------------------------------------ | --------------------------- |
-| `reason` | `'signal'`                           | what initiated the shutdown |
-| `signal` | `'SIGTERM' \| 'SIGINT' \| undefined` | the signal received         |
+| Field    | Type                                 | Notes                                          |
+| -------- | ------------------------------------ | ---------------------------------------------- |
+| `reason` | `'signal' \| 'stop'`                 | signal, or programmatic `Mochi.stop()`         |
+| `signal` | `'SIGTERM' \| 'SIGINT' \| undefined` | the signal received; absent for `Mochi.stop()` |
 
 #### `warmup:start`
 

--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -38,7 +38,7 @@ In production (`development: false`), prebuilt JS/CSS bundles served from `asset
 
 <Callout type="info">
 
-**Shutdown signals.** `Mochi.serve()` installs `SIGTERM` and `SIGINT` listeners that fire the [`mochi:shutdown`](/docs/extensions/#mochishutdown) hook, drain queues, then stop the server and exit with code 0. In-flight requests get `shutdownTimeout` ms to finish. Anything still connected is force-closed. A second signal exits immediately with code 1. An open WebSocket never drains, so shutdown waits the full `shutdownTimeout` before force-closing. Keep the timeout tight enough for your orchestrator's grace period.
+**Shutdown signals.** `Mochi.serve()` installs `SIGTERM` and `SIGINT` listeners that fire the [`mochi:shutdown`](/docs/extensions/#mochishutdown) hook, drain queues, then stop the server and exit with code 0. In-flight requests get `shutdownTimeout` ms to finish. Anything still connected is force-closed. A second signal exits immediately with code 1. An open WebSocket never drains, so shutdown waits the full `shutdownTimeout` before force-closing. Keep the timeout tight enough for your orchestrator's grace period. A finite-lifetime embedder (script, test) can run the same teardown without exiting via [`Mochi.stop()`](/docs/queues/#mochistop).
 
 </Callout>
 

--- a/packages/docs/162-extensions.md
+++ b/packages/docs/162-extensions.md
@@ -49,7 +49,7 @@ Fires right after `Bun.serve()` returns the bound server, before queues mount an
 
 #### `mochi:queuesMounted`
 
-Fires once every queue is live. `ctx.queues` lists the mounted names. Earliest point at which [`Mochi.getQueue()`](/docs/queues/#mochigetqueue) and [`Mochi.boss()`](/docs/queues/#mochiboss) resolve. Async.
+Fires once every queue in the `Mochi.serve({ queues })` array is live. `ctx.queues` lists the mounted names. Earliest point at which [`Mochi.getQueue()`](/docs/queues/#adding-jobs) and [`Mochi.boss()`](/docs/queues/#mochiboss) resolve. A [standalone producer](/docs/queues/#standalone-producers) process never fires it — there, readiness is the first `add()` resolving. Async.
 
 #### `mochi:ready`
 
@@ -68,7 +68,7 @@ await Mochi.serve({
 
 #### `mochi:shutdown`
 
-Fires on `SIGTERM` or `SIGINT`. The framework awaits the hook, then calls `server.stop()`. A second signal force-exits with code 1. Async.
+Fires on `SIGTERM` or `SIGINT`, and on a programmatic [`Mochi.stop()`](/docs/queues/#mochistop) — `ctx.signal` is `undefined` in that case. The framework awaits the hook, then calls `server.stop()`. A second signal force-exits with code 1. Async.
 
 ```ts
 await Mochi.serve({
@@ -382,7 +382,7 @@ How long the widget spends actively solving before it offers a retry. Resolved o
 
 #### `queue:expireInSeconds`
 
-How many seconds a job may stay active before the store retries or fails it. Resolved once per queue at mount, after the per-queue [`expireInSeconds`](/docs/queues/#long-running-jobs) option. `explicit` says whether the value came from that option. Sync. Default `900` (15 minutes).
+How many seconds a job may stay active before the store retries or fails it. Resolved once per queue at mount, after the per-queue [`expireInSeconds`](/docs/queues/#long-running-jobs) option. `explicit` says whether the value came from that option. When the queue declared nothing and the filter leaves the default unchanged, nothing is sent to the store — an existing queue keeps its stored expiry. Sync. Default `900` (15 minutes).
 
 ```ts
 await Mochi.serve({

--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -75,6 +75,8 @@ if (!isBuilding) await db.connect();
 await Mochi.serve({ routes });
 ```
 
+The dev server re-imports `index.ts` on every rebuild to pick up route changes; that import sees `true` too, so gated side effects don't re-run on each save.
+
 Inside `.svelte` components it is always `false` — components are compiled but never executed during a build.
 
 ## Detecting hydration with `isHydratable()`

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -1990,7 +1990,10 @@ async function runShutdown(signal?: NodeJS.Signals): Promise<void> {
     });
     await Promise.race([graceful, Bun.sleep(timeout)]);
   }
-  await server.stop(true);
+  // Caught so a rejection can't escape the signal handler before its process.exit(0) or skip the clearing below.
+  await server.stop(true).catch((err: unknown) => {
+    logger.warn(`Forced stop failed: ${err instanceof Error ? err.message : err}`);
+  });
   // Cleared so a later stop() takes the no-server path instead of re-firing the hook against a dead server.
   shutdownState.server = null;
   shutdownState.options = null;

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -35,7 +35,6 @@ import type {
   MochiRouteValue,
   MochiServerPropsResolver,
   MochiServeOptions,
-  MochiQueueConfig,
   RouteRegistrationResult,
   MochiSseConfig,
   MochiSseHandler,
@@ -59,9 +58,20 @@ import { resolveWarmupEnabled, markWarmupRequest, isWarmablePattern } from './ru
 import { createErrorResponder, DEFAULT_ERROR_PAGE_PATH } from './runtime/errors';
 import { requestContext } from './runtime/requestContext';
 import type { MochiRequestContext } from './runtime/requestContext';
-import { startQueueRuntime, mountQueues, getQueue, getBoss, closeAllQueueResources, isValidQueueStorage } from './queue';
+import {
+  startQueueRuntime,
+  mountQueues,
+  getQueue,
+  getBoss,
+  closeAllQueueResources,
+  isValidQueueStorage,
+  createQueueDescriptor,
+  storageEquals,
+  assertNoConflictingStandaloneRuntime,
+} from './queue';
+import { pinGlobal } from './utils/globalState';
 import { resetStartupMilestones } from './lifecycle';
-import type { MochiQueue, MochiQueueOptions, MochiQueueListeners, MochiProcessor } from './queue';
+import type { MochiQueue, MochiQueueOptions, MochiQueueDescriptor } from './queue';
 import type { BunBoss } from 'bun-boss';
 import { finalizeCookieHeaders } from './runtime/cookies';
 import { makeRequestContextBuilder } from './runtime/requestSetup';
@@ -194,18 +204,13 @@ export class Mochi {
   }
 
   /**
-   * Declare a background job queue. Like `page`/`api`/`ws`/`sse`/`file` this returns an inert config; the live producer
-   * and consumer are created only once `Mochi.serve({ queues })` mounts the descriptor under its queue name. Add jobs from
-   * anywhere via `Mochi.getQueue(name).add(...)`, and the queue drains gracefully on shutdown.
+   * Declare a background job queue. The returned descriptor is both the declaration `Mochi.serve({ queues: [q] })`
+   * mounts (workers start there, and the queue drains gracefully on shutdown) and a directly-usable producer handle:
+   * `q.add(...)` works anywhere. In a process that never serves, give it `storage` and the first add lazily connects a
+   * producer-only runtime — no server, no workers, no option re-sync; tear down with `Mochi.stop()`.
    */
-  static queue<T = unknown, R = unknown>(config: MochiQueueOptions<T, R>): MochiQueueConfig {
-    const { process, on, ...options } = config;
-    return {
-      __mochiQueue: true,
-      process: process as MochiProcessor<unknown, unknown> | undefined,
-      options,
-      on: on as Partial<MochiQueueListeners<unknown, unknown>> | undefined,
-    };
+  static queue<T = unknown, R = unknown>(name: string, config: MochiQueueOptions<T, R> = {}): MochiQueueDescriptor<T, R> {
+    return createQueueDescriptor<T, R>(name, config);
   }
 
   /**
@@ -312,22 +317,29 @@ export class Mochi {
       }
     }
 
-    // Same fail-fast rule for the queue declarations: a bad name, deadLetter, or storage shape rejects here.
-    const declaredQueues = Object.entries(options.queues ?? {});
-    for (const [name, config] of declaredQueues) {
+    // Same fail-fast rule for the queue declarations: a bad descriptor, duplicate name, deadLetter, or storage shape rejects here.
+    const declaredQueues = options.queues ?? [];
+    const queueNames = new Set<string>();
+    for (const config of declaredQueues) {
       if (!isMochiQueue(config)) {
-        throw new Error(`Mochi.serve({ queues }): "${name}" is not a Mochi.queue(...) descriptor. Each value must be created with Mochi.queue().`);
+        throw new Error(`Mochi.serve({ queues }): every element must be a descriptor created with Mochi.queue(name, …).`);
       }
-      if (!/^[\w.\-/]+$/.test(name)) {
-        throw new Error(`Mochi.serve({ queues }): "${name}" is not a valid queue name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
+      if (typeof config.name !== 'string' || !/^[\w.\-/]+$/.test(config.name)) {
+        throw new Error(`Mochi.serve({ queues }): "${config.name}" is not a valid queue name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
       }
+      if (queueNames.has(config.name)) {
+        throw new Error(`Mochi.serve({ queues }): two queues are named "${config.name}". Queue names must be unique.`);
+      }
+      queueNames.add(config.name);
       const deadLetter = config.options?.deadLetter;
       if (deadLetter !== undefined) {
-        if (deadLetter === name) {
-          throw new Error(`Mochi.serve({ queues }): "${name}" names itself as its deadLetter queue.`);
+        if (deadLetter === config.name) {
+          throw new Error(`Mochi.serve({ queues }): "${config.name}" names itself as its deadLetter queue.`);
         }
-        if (!(options.queues && deadLetter in options.queues)) {
-          throw new Error(`Mochi.serve({ queues }): "${name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues map.`);
+        if (!declaredQueues.some((q) => q.name === deadLetter)) {
+          throw new Error(
+            `Mochi.serve({ queues }): "${config.name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues array.`,
+          );
         }
       }
     }
@@ -336,7 +348,18 @@ export class Mochi {
       throw new Error(`Mochi.serve({ queueStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
     }
     if (options.queueStorage !== undefined && declaredQueues.length === 0) {
-      logger.warn(`Mochi.serve({ queueStorage }) has no effect without a non-empty queues map — the queue runtime only starts when queues are declared.`);
+      logger.warn(`Mochi.serve({ queueStorage }) has no effect without a non-empty queues array — the queue runtime only starts when queues are declared.`);
+    }
+    for (const config of declaredQueues) {
+      if (config.storage !== undefined && !storageEquals(config.storage, queueStorage)) {
+        logger.warn(
+          `Mochi.serve({ queues }): "${config.name}" declares its own storage, but under serve the serve-level queueStorage wins — the descriptor's storage is only used standalone.`,
+        );
+      }
+    }
+    if (declaredQueues.length > 0) {
+      // Fail before the config singleton pins and the server binds — rejecting this deep in the boot would wedge the process.
+      assertNoConflictingStandaloneRuntime(queueStorage);
     }
 
     const { svelteVersion } = await checkEnvironment();
@@ -1788,7 +1811,8 @@ export class Mochi {
     // just-bound server down rather than leaving it listening half-started.
     try {
       if (declaredQueues.length > 0) {
-        await startQueueRuntime(queueStorage);
+        // kind 'serve' adopts a standalone producer runtime already connected to the same storage.
+        await startQueueRuntime(queueStorage, { kind: 'serve' });
         await mountQueues(declaredQueues);
       }
     } catch (err) {
@@ -1796,9 +1820,9 @@ export class Mochi {
       await server.stop(true);
       throw err;
     }
-    // Fires once every queue in the map is registered, so a user hook reaching for a handle (or `Mochi.boss()`)
+    // Fires once every declared queue is registered, so a user hook reaching for a handle (or `Mochi.boss()`)
     // gets it instead of a "not mounted yet" error.
-    await runHook('mochi:queuesMounted', { options, server, queues: declaredQueues.map(([name]) => name) });
+    await runHook('mochi:queuesMounted', { options, server, queues: declaredQueues.map((q) => q.name) });
 
     if (warmupHandlers.length > 0) {
       mochiEvents.emit('warmup:start', { routeCount: warmupHandlers.length });
@@ -1865,10 +1889,23 @@ export class Mochi {
   }
 
   /**
-   * Install one-shot SIGTERM/SIGINT listeners that fire the `mochi:shutdown` hook and stop the server, with a second
-   * signal force-exiting as most CLIs do.
+   * Gracefully stop everything Mochi is running — the `mochi:shutdown` hook, queue drain, and server stop — without
+   * exiting the process, so a finite-lifetime embedder (script, test) can end naturally instead of signalling itself.
+   * In a process that never served, it tears down a standalone producer queue runtime. Idempotent; the SIGTERM/SIGINT
+   * handlers run the same path. A stopped process cannot `Mochi.serve()` again.
+   */
+  static stop(): Promise<void> {
+    return performShutdown();
+  }
+
+  /**
+   * Install one-shot SIGTERM/SIGINT listeners that run the shared shutdown path, with a second signal force-exiting as
+   * most CLIs do.
    */
   private static installShutdownHandlers(options: MochiServeOptions, server: Server<undefined>, development: boolean): void {
+    shutdownState.server = server;
+    shutdownState.options = options;
+    shutdownState.development = development;
     let shuttingDown = false;
     const handle = async (signal: NodeJS.Signals): Promise<void> => {
       if (shuttingDown) {
@@ -1876,35 +1913,73 @@ export class Mochi {
       }
       shuttingDown = true;
       logger.info(`Received ${signal}, shutting down…`);
-      try {
-        await runHook('mochi:shutdown', { options, server, signal });
-      } catch (err) {
-        logger.error(`mochi:shutdown hook failed: ${err instanceof Error ? err.message : err}`);
-      }
-      await closeAllQueueResources();
-      resetStartupMilestones();
-      const stopEvent: MochiServerStopEvent = { reason: 'signal' };
-      if (signal === 'SIGTERM' || signal === 'SIGINT') {
-        stopEvent.signal = signal;
-      }
-      mochiEvents.emit('server:stop', stopEvent);
-
-      // A non-forced `stop()` waits for every connection to drain and Bun never resolves it while a WebSocket is open,
-      // so in dev a single tab holding the live-reload socket wedges the process; the graceful stop gets the grace
-      // period alone, then connections are cut regardless.
-      const timeout = options.shutdownTimeout ?? (development ? 0 : 5_000);
-      if (timeout > 0) {
-        // Once the grace period wins the race, a late rejection from the graceful stop has no one left to await it.
-        const graceful = server.stop().catch((err: unknown) => {
-          logger.warn(`Graceful stop failed: ${err instanceof Error ? err.message : err}`);
-        });
-        await Promise.race([graceful, Bun.sleep(timeout)]);
-      }
-      await server.stop(true);
+      await performShutdown(signal);
       // chokidar's dev watchers and any user timer still running would otherwise keep the event loop alive past the last socket.
       process.exit(0);
     };
     process.on('SIGTERM', handle);
     process.on('SIGINT', handle);
   }
+}
+
+interface ShutdownState {
+  server: Server<undefined> | null;
+  options: MochiServeOptions | null;
+  development: boolean;
+  stopping: Promise<void> | null;
+}
+
+// Pinned so `Mochi.stop()` reaches the serve context whichever bundled copy of this module registered it.
+const shutdownState = pinGlobal<ShutdownState>('__mochi_shutdown_state__', () => ({
+  server: null,
+  options: null,
+  development: false,
+  stopping: null,
+}));
+
+async function runShutdown(signal?: NodeJS.Signals): Promise<void> {
+  const { server, options } = shutdownState;
+  if (!server || !options) {
+    // Nothing served in this process — at most a standalone producer queue runtime is up.
+    await closeAllQueueResources();
+    resetStartupMilestones();
+    return;
+  }
+  try {
+    await runHook('mochi:shutdown', signal ? { options, server, signal } : { options, server });
+  } catch (err) {
+    logger.error(`mochi:shutdown hook failed: ${err instanceof Error ? err.message : err}`);
+  }
+  await closeAllQueueResources();
+  resetStartupMilestones();
+  const stopEvent: MochiServerStopEvent = { reason: signal ? 'signal' : 'stop' };
+  if (signal === 'SIGTERM' || signal === 'SIGINT') {
+    stopEvent.signal = signal;
+  }
+  mochiEvents.emit('server:stop', stopEvent);
+
+  // A non-forced `stop()` waits for every connection to drain and Bun never resolves it while a WebSocket is open,
+  // so in dev a single tab holding the live-reload socket wedges the process; the graceful stop gets the grace
+  // period alone, then connections are cut regardless.
+  const timeout = options.shutdownTimeout ?? (shutdownState.development ? 0 : 5_000);
+  if (timeout > 0) {
+    // Once the grace period wins the race, a late rejection from the graceful stop has no one left to await it.
+    const graceful = server.stop().catch((err: unknown) => {
+      logger.warn(`Graceful stop failed: ${err instanceof Error ? err.message : err}`);
+    });
+    await Promise.race([graceful, Bun.sleep(timeout)]);
+  }
+  await server.stop(true);
+  // Cleared so a later stop() takes the no-server path instead of re-firing the hook against a dead server.
+  shutdownState.server = null;
+  shutdownState.options = null;
+}
+
+function performShutdown(signal?: NodeJS.Signals): Promise<void> {
+  // Memoized while running so a signal racing a programmatic stop() awaits the same teardown; cleared on settle so a
+  // standalone runtime reconnected afterwards (tests) can be stopped again.
+  shutdownState.stopping ??= runShutdown(signal).finally(() => {
+    shutdownState.stopping = null;
+  });
+  return shutdownState.stopping;
 }

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -35,6 +35,7 @@ import type {
   MochiRouteValue,
   MochiServerPropsResolver,
   MochiServeOptions,
+  MochiWorkerOptions,
   RouteRegistrationResult,
   MochiSseConfig,
   MochiSseHandler,
@@ -66,12 +67,13 @@ import {
   closeAllQueueResources,
   isValidQueueStorage,
   createQueueDescriptor,
+  createWorker,
   storageEquals,
   assertNoConflictingStandaloneRuntime,
 } from './queue';
 import { pinGlobal } from './utils/globalState';
 import { resetStartupMilestones } from './lifecycle';
-import type { MochiQueue, MochiQueueOptions, MochiQueueDescriptor } from './queue';
+import type { MochiQueue, MochiQueueOptions, MochiQueueDescriptor, MochiQueueStorage, MochiWorker } from './queue';
 import type { BunBoss } from 'bun-boss';
 import { finalizeCookieHeaders } from './runtime/cookies';
 import { makeRequestContextBuilder } from './runtime/requestSetup';
@@ -222,6 +224,16 @@ export class Mochi {
   }
 
   /**
+   * Declare a standalone worker: consume queues in a process that never calls `Mochi.serve()`. `start()` connects to
+   * the app's queue storage (from the descriptors or the `storage` option) and begins polling. Ensure-only, like
+   * standalone producers — stored queue options are not re-synced, no hooks or milestones fire, and signal handling is
+   * yours to wire (`Mochi.stop()` drains and closes the runtime).
+   */
+  static worker(options: MochiWorkerOptions): MochiWorker {
+    return createWorker(options.queues, options.storage);
+  }
+
+  /**
    * The shared bun-boss instance behind `Mochi.serve({ queues })` — the escape hatch for everything Mochi doesn't wrap:
    * `fetch`, `cancel`, `retry`, `redrive`, `findJobs`, `getQueueStats`, …. Available from the `mochi:queuesMounted` hook
    * onwards; throws before that, or when no queues are declared.
@@ -343,19 +355,28 @@ export class Mochi {
         }
       }
     }
-    const queueStorage = options.queueStorage ?? 'memory';
+    // An app has one queue storage: declared on the descriptors, app-wide via queueStorage, or both when they agree.
+    let declaredStorage: { name: string; storage: MochiQueueStorage } | undefined;
+    for (const config of declaredQueues) {
+      if (config.storage === undefined) {
+        continue;
+      }
+      if (declaredStorage && !storageEquals(declaredStorage.storage, config.storage)) {
+        throw new Error(`Mochi.serve({ queues }): "${config.name}" and "${declaredStorage.name}" declare different storages — an app has one queue storage.`);
+      }
+      declaredStorage ??= { name: config.name, storage: config.storage };
+    }
+    if (options.queueStorage !== undefined && declaredStorage && !storageEquals(declaredStorage.storage, options.queueStorage)) {
+      throw new Error(
+        `Mochi.serve({ queueStorage }): "${declaredStorage.name}" declares a different storage — an app has one queue storage. Align the two declarations, or drop one.`,
+      );
+    }
+    const queueStorage = options.queueStorage ?? declaredStorage?.storage ?? 'memory';
     if (!isValidQueueStorage(queueStorage)) {
       throw new Error(`Mochi.serve({ queueStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
     }
     if (options.queueStorage !== undefined && declaredQueues.length === 0) {
       logger.warn(`Mochi.serve({ queueStorage }) has no effect without a non-empty queues array — the queue runtime only starts when queues are declared.`);
-    }
-    for (const config of declaredQueues) {
-      if (config.storage !== undefined && !storageEquals(config.storage, queueStorage)) {
-        logger.warn(
-          `Mochi.serve({ queues }): "${config.name}" declares its own storage, but under serve the serve-level queueStorage wins — the descriptor's storage is only used standalone.`,
-        );
-      }
     }
     if (declaredQueues.length > 0) {
       // Fail before the config singleton pins and the server binds — rejecting this deep in the boot would wedge the process.

--- a/packages/mochi/src/cli/cli.ts
+++ b/packages/mochi/src/cli/cli.ts
@@ -8,6 +8,7 @@ import { extractServeOptions } from './extractServeOptions';
 import { updateSkill, SKILL_TARGETS, SKILL_DESTS, DEFAULT_SKILL_TARGET, type SkillTarget } from './updateSkill';
 import { generateKey } from './generateKey';
 import { relForDisplay } from '../utils';
+import { markBuilding } from '../utils/buildFlag';
 
 const TARGET_ALIASES: Record<string, SkillTarget> = { agy: 'antigravity' };
 
@@ -149,6 +150,10 @@ async function main() {
     process.stderr.write(`[mochi] Unknown command: ${cmd}\n\n${HELP}`);
     process.exit(1);
   }
+
+  // Flipped before anything imports the app entry: this whole process is a build, so server-setup code must skip
+  // real-boot side effects for its entire lifetime, not just while the entry is being read.
+  markBuilding();
 
   const entryPath = path.resolve(process.cwd(), values.entry ?? './src/index.ts');
   let serveOptions: Awaited<ReturnType<typeof extractServeOptions>> = null;

--- a/packages/mochi/src/cli/extractServeOptions.test.ts
+++ b/packages/mochi/src/cli/extractServeOptions.test.ts
@@ -38,21 +38,22 @@ throw new Error('serve should have halted execution before this line');`,
     expect(options?.optimize).toEqual({ enabled: true, exclude: ['x.svelte'] });
   });
 
-  test('captures the queues map without starting the queue runtime', async () => {
+  test('captures the queues array without starting the queue runtime', async () => {
     // Mochi.queue() is inert config, so importing the entry for extraction must
     // not start a BunBoss instance (whose maintenance timers would hang the
     // build). The test simply completing proves nothing kept the event loop alive.
     const entry = writeEntry(
       `import { Mochi } from 'mochi-framework';
-await Mochi.serve({ routes: {}, queueStorage: 'memory', queues: { emails: Mochi.queue({ process: async () => ({ sent: true }), concurrency: 2 }) } });
+await Mochi.serve({ routes: {}, queueStorage: 'memory', queues: [Mochi.queue('emails', { process: async () => ({ sent: true }), concurrency: 2 })] });
 throw new Error('serve should have halted execution before this line');`,
     );
 
     const options = await extractServeOptions(entry);
 
     expect(options?.queues).toBeDefined();
-    expect(options?.queues?.emails?.__mochiQueue).toBe(true);
-    expect(options?.queues?.emails?.options).toEqual({ concurrency: 2 });
+    expect(options?.queues?.[0]?.__mochiQueue).toBe(true);
+    expect(options?.queues?.[0]?.name).toBe('emails');
+    expect(options?.queues?.[0]?.options).toEqual({ concurrency: 2 });
     expect(options?.queueStorage).toBe('memory');
   });
 

--- a/packages/mochi/src/cli/extractServeOptions.test.ts
+++ b/packages/mochi/src/cli/extractServeOptions.test.ts
@@ -3,6 +3,9 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { extractServeOptions } from './extractServeOptions';
+import { isBuilding } from '../utils/buildFlag';
+import { Mochi } from '../Mochi';
+import { startQueueRuntime, mountQueues, closeAllQueueResources } from '../queue';
 
 // The extractor registers a process-global Bun.plugin that overrides the
 // `mochi-framework` specifier. Keep these tests in their own file so the
@@ -68,6 +71,25 @@ throw new Error('serve should have halted execution before this line');`,
     await extractServeOptions(entry);
 
     expect((globalThis as Record<string, unknown>).__test_isBuilding).toBe(true);
+  });
+
+  test('leaves the process unmarked, so queue adds still work afterwards', async () => {
+    // The dev watcher extracts inside the running server on every entry rebuild; a process-wide `isBuilding` would
+    // silently swallow every subsequent `queue.add()` for the rest of the dev session.
+    const entry = writeEntry(`import { Mochi } from 'mochi-framework';
+await Mochi.serve({ routes: {} });`);
+
+    await extractServeOptions(entry);
+
+    expect(isBuilding).toBe(false);
+    const queue = Mochi.queue<{ n: number }>('after-extract');
+    await startQueueRuntime('memory');
+    await mountQueues([queue]);
+    try {
+      expect(await queue.add({ n: 1 })).toBeString();
+    } finally {
+      await closeAllQueueResources();
+    }
   });
 
   test('returns null when the entry never calls serve()', async () => {

--- a/packages/mochi/src/cli/extractServeOptions.ts
+++ b/packages/mochi/src/cli/extractServeOptions.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import { freshImport } from '../compiler/freshImport';
-import { markBuilding } from '../utils/buildFlag';
+import { runInEntryImportScope } from '../utils/buildFlag';
 import type { MochiServeOptions } from '../types';
 
 // Thrown by the capturing serve() stub to unwind the entry module's top-level
@@ -25,11 +25,6 @@ let captured: Partial<MochiServeOptions> | null = null;
  * Returns the captured options, or `null` if the entry never called `serve()`.
  */
 export async function extractServeOptions(entryPath: string, opts?: { fresh?: boolean }): Promise<Partial<MochiServeOptions> | null> {
-  // Flip `isBuilding` before importing the framework: the plugin below snapshots
-  // realMod's namespace into its `object`-loader exports, so the flag must
-  // already be true when that spread runs for the entry to observe it.
-  markBuilding();
-
   // The real framework entry, by absolute path — NOT the bare specifier, so the
   // plugin below does not intercept this import (no recursion). This file lives
   // in `src/cli/`, so climb one level to reach it.
@@ -72,6 +67,9 @@ export async function extractServeOptions(entryPath: string, opts?: { fresh?: bo
             ...realMod,
             default: (realMod as { default?: unknown }).default ?? realMod,
             Mochi: mochiProxy,
+            // Overridden rather than read from `realMod`, whose namespace is snapshotted here: only the module graph
+            // imported for extraction is "building", so a dev-watcher re-import must not flip the flag process-wide.
+            isBuilding: true,
           },
         }));
       },
@@ -81,11 +79,15 @@ export async function extractServeOptions(entryPath: string, opts?: { fresh?: bo
 
   captured = null;
   try {
-    if (opts?.fresh) {
-      await freshImport(entryPath);
-    } else {
-      await import(Bun.pathToFileURL(entryPath).href);
-    }
+    // Scoped, not a process-wide flag: the dev watcher calls this inside a live server, where the entry's side effects
+    // must be suppressed only for the duration of the import.
+    await runInEntryImportScope(async () => {
+      if (opts?.fresh) {
+        await freshImport(entryPath);
+      } else {
+        await import(Bun.pathToFileURL(entryPath).href);
+      }
+    });
   } catch (err) {
     if (!isHalt(err)) {
       throw err;

--- a/packages/mochi/src/dev/consoleLogger.ts
+++ b/packages/mochi/src/dev/consoleLogger.ts
@@ -63,10 +63,13 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
 
   // `source` is auto-built from the event name and payload, so call sites describe only the formatted line. The cast
   // widens `{name: K; payload: M[K]}` to the distributed `ConsoleLoggerSource` union, which TypeScript can't infer
-  // through a generic closure.
-  function subscribe<K extends keyof MochiEventMap>(name: K, format: (payload: MochiEventMap[K]) => Omit<EmitInput, 'source'>): void {
+  // through a generic closure. A `null` from the formatter suppresses the line (e.g. per-job adds inside a bulk add).
+  function subscribe<K extends keyof MochiEventMap>(name: K, format: (payload: MochiEventMap[K]) => Omit<EmitInput, 'source'> | null): void {
     mochiEvents.on(name, (payload) => {
-      emit({ ...format(payload), source: { name, payload } as ConsoleLoggerSource });
+      const formatted = format(payload);
+      if (formatted) {
+        emit({ ...formatted, source: { name, payload } as ConsoleLoggerSource });
+      }
     });
   }
 
@@ -239,10 +242,21 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
   // at `info` they'd vanish, leaving `completed` visible only when a job trips the slow-escalation. Per-attempt `active`
   // repeats on every retry and adds nothing, so it stays on `logger.debug`. The `consoleLogger:level` filter demotes any
   // of it for apps that find the lifecycle chatty.
-  subscribe('queue:added', ({ queue, jobId }) => ({
+  subscribe('queue:added', ({ queue, jobId, bulk }) =>
+    // Bulk adds print one `queue:addedBulk` summary instead of a line per job — a 100k addBulk must not log 100k lines.
+    bulk
+      ? null
+      : {
+          label: 'QUEUE',
+          path: queue,
+          note: styleText('dim', `+ ${jobId}`),
+          level: 'warn',
+        },
+  );
+  subscribe('queue:addedBulk', ({ queue, count }) => ({
     label: 'QUEUE',
     path: queue,
-    note: styleText('dim', `+ ${jobId}`),
+    note: styleText('dim', `+ ${count} jobs (bulk)`),
     level: 'warn',
   }));
   subscribe('queue:active', ({ queue }) => ({

--- a/packages/mochi/src/events.ts
+++ b/packages/mochi/src/events.ts
@@ -176,6 +176,16 @@ export interface MochiCacheErrorEvent {
 export interface MochiQueueAddedEvent {
   queue: string;
   jobId: string;
+  /** True when this add came from an `addBulk` call — see `queue:addedBulk` for the one-per-call summary. */
+  bulk?: boolean;
+}
+
+/** Emitted once per `addBulk` call that inserted at least one job, alongside the per-job `queue:added` events. */
+export interface MochiQueueAddedBulkEvent {
+  queue: string;
+  /** Jobs actually inserted (duplicates by explicit id are skipped). */
+  count: number;
+  jobIds: string[];
 }
 
 export interface MochiQueueActiveEvent {
@@ -238,7 +248,8 @@ export interface MochiServerStartEvent {
 }
 
 export interface MochiServerStopEvent {
-  reason: 'signal';
+  /** `'signal'` for SIGTERM/SIGINT, `'stop'` for a programmatic `Mochi.stop()`. */
+  reason: 'signal' | 'stop';
   signal?: 'SIGTERM' | 'SIGINT';
 }
 
@@ -395,6 +406,7 @@ export type MochiEventMap = {
   'cache:revalidate:failed': MochiCacheRevalidateFailedEvent;
   'cache:error': MochiCacheErrorEvent;
   'queue:added': MochiQueueAddedEvent;
+  'queue:addedBulk': MochiQueueAddedBulkEvent;
   'queue:active': MochiQueueActiveEvent;
   'queue:completed': MochiQueueCompletedEvent;
   'queue:failed': MochiQueueFailedEvent;

--- a/packages/mochi/src/extensions.ts
+++ b/packages/mochi/src/extensions.ts
@@ -61,7 +61,8 @@ export interface MochiHookContext {
   'mochi:shutdown': {
     options: MochiServeOptions;
     server: Server<undefined>;
-    signal: NodeJS.Signals;
+    /** Absent when the shutdown came from a programmatic `Mochi.stop()` rather than SIGTERM/SIGINT. */
+    signal?: NodeJS.Signals;
   };
   'route:matched': {
     pattern: string;

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -113,6 +113,7 @@ export type {
 export type {
   MochiQueue,
   MochiQueueDescriptor,
+  MochiWorker,
   MochiJob,
   MochiJobOptions,
   MochiQueueOptions,
@@ -195,6 +196,7 @@ export type {
   MochiSubmitCallback,
   HttpMethod,
   MochiServeOptions,
+  MochiWorkerOptions,
   MochiWarmupOptions,
   MochiRouteValue,
   MochiWsConfig,

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -82,6 +82,7 @@ export type {
   MochiCacheRevalidateFailedEvent,
   MochiCacheErrorEvent,
   MochiQueueAddedEvent,
+  MochiQueueAddedBulkEvent,
   MochiQueueActiveEvent,
   MochiQueueCompletedEvent,
   MochiQueueFailedEvent,
@@ -111,10 +112,12 @@ export type {
 } from './events';
 export type {
   MochiQueue,
+  MochiQueueDescriptor,
   MochiJob,
   MochiJobOptions,
   MochiQueueOptions,
   MochiQueueRuntimeOptions,
+  MochiWorkerTuning,
   MochiQueueListeners,
   MochiProcessor,
   MochiQueueStorage,

--- a/packages/mochi/src/queue.test.ts
+++ b/packages/mochi/src/queue.test.ts
@@ -513,6 +513,63 @@ describe('Mochi queue', () => {
     await getBoss().getSpy(name).waitForJobWithId(ids[1]!, 'completed');
   }, 15_000);
 
+  test('a batch outliving the shared expiry budget settles early: completed siblings keep their results', async () => {
+    const name = uniqueName();
+    const runs: number[] = [];
+    const failedMessages = new Map<string, string>();
+    mochiEvents.on('queue:failed', (e) => failedMessages.set(e.jobId, e.error));
+
+    await startWith({
+      [name]: {
+        process: async (job: MochiJob<{ n: number }>) => {
+          runs.push(job.data.n);
+          if (job.data.n === 2) {
+            await Bun.sleep(1_500);
+          }
+          return { n: job.data.n };
+        },
+        // bun-boss times the whole batch out at max(expireInSeconds)=1s; job 2 alone outlives it.
+        options: { batchSize: 3, retryLimit: 0, expireInSeconds: 1, pollingIntervalSeconds: 0.5 },
+      },
+    });
+
+    // Priorities pin the in-batch order to 1, 2, 3 — fetch order is otherwise backend-dependent.
+    const ids = await getQueue<{ n: number }>(name).addBulk([
+      { data: { n: 1 }, opts: { priority: 3 } },
+      { data: { n: 2 }, opts: { priority: 2 } },
+      { data: { n: 3 }, opts: { priority: 1 } },
+    ]);
+    const spy = getBoss().getSpy(name);
+    await spy.waitForJobWithId(ids[0]!, 'completed');
+    await spy.waitForJobWithId(ids[1]!, 'failed');
+    await spy.waitForJobWithId(ids[2]!, 'failed');
+
+    // The wholesale alternative fails all three, re-running the completed job 1 on retry; job 3 must never start.
+    expect(runs).toEqual([1, 2]);
+    expect((await getBoss().getJobById(name, ids[0]!))?.state).toBe('completed');
+    expect(failedMessages.get(ids[1]!)).toMatch(/ran out mid-job/);
+    expect(failedMessages.get(ids[2]!)).toMatch(/before this job started/);
+  }, 15_000);
+
+  test('a failed job stores the full error, stack included', async () => {
+    const name = uniqueName();
+    await startWith({
+      [name]: {
+        process: async () => {
+          throw new Error('kablam');
+        },
+        options: { retryLimit: 0 },
+      },
+    });
+
+    const jobId = await getQueue(name).add({ n: 1 } as never);
+    await getBoss().getSpy(name).waitForJobWithId(jobId!, 'failed');
+    const output = (await getBoss().getJobById(name, jobId!))?.output as Record<string, unknown>;
+    expect(output.message).toBe('kablam');
+    expect(output.name).toBe('Error');
+    expect(String(output.stack)).toContain('queue.test');
+  }, 15_000);
+
   test('worker tuning reaches boss.work, with Mochi-owned keys winning over the escape hatch', async () => {
     const name = uniqueName();
     await startWith({

--- a/packages/mochi/src/queue.test.ts
+++ b/packages/mochi/src/queue.test.ts
@@ -1,10 +1,11 @@
-import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, describe, expect, spyOn, test } from 'bun:test';
 import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
 import { startQueueRuntime, mountQueues, getQueue, getBoss, closeAllQueueResources, DEFAULT_EXPIRE_IN_SECONDS } from './queue';
 import type { MochiJob, MochiQueueStorage } from './queue';
 import { mochiEvents } from './events';
 import { initExtensions } from './extensions';
+import { logger } from './utils/log';
 import { markStartupMilestone, resetStartupMilestones } from './lifecycle';
 
 const dataDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-queue-test-'));
@@ -26,10 +27,10 @@ interface TestQueueConfig {
   on?: Record<string, unknown>;
 }
 
-// Mirrors what Mochi.serve does for a non-empty queues map, with spies on for deterministic waits.
+// Mirrors what Mochi.serve does for a non-empty queues array, with spies on for deterministic waits.
 async function startWith(queues: Record<string, TestQueueConfig>, storage: MochiQueueStorage = 'memory'): Promise<void> {
   await startQueueRuntime(storage, { enableSpies: true });
-  await mountQueues(Object.entries(queues) as Parameters<typeof mountQueues>[0]);
+  await mountQueues(Object.entries(queues).map(([name, config]) => ({ name, ...config })) as Parameters<typeof mountQueues>[0]);
 }
 
 afterEach(async () => {
@@ -162,8 +163,14 @@ describe('Mochi queue', () => {
     const name = uniqueName();
     const eventAttempts: number[] = [];
     const listenerAttempts: number[] = [];
+    const lastAttempt = deferred<void>();
 
-    mochiEvents.on('queue:failed', (e) => eventAttempts.push(e.attempt));
+    mochiEvents.on('queue:failed', (e) => {
+      eventAttempts.push(e.attempt);
+      if (e.attempt === 2) {
+        lastAttempt.resolve();
+      }
+    });
 
     await startWith({
       [name]: {
@@ -179,13 +186,20 @@ describe('Mochi queue', () => {
       },
     });
 
-    const spy = getBoss().getSpy(name);
     const jobId = await getQueue(name).add({ y: 1 } as never);
-    // The spy's `failed` state fires only on the terminal failure, so intermediate attempts are observed off the bus.
-    await spy.waitForJobWithId(jobId!, 'failed');
+    await lastAttempt.promise;
 
     expect(eventAttempts).toEqual([1, 2]);
     expect(listenerAttempts).toEqual([1, 2]);
+    // The per-job settlement lands the terminal state just after the event, so poll briefly for it.
+    let state: string | undefined;
+    for (let i = 0; i < 50 && state !== 'failed'; i++) {
+      state = (await getBoss().getJobById(name, jobId!))?.state;
+      if (state !== 'failed') {
+        await Bun.sleep(100);
+      }
+    }
+    expect(state).toBe('failed');
   }, 15_000);
 
   test('a throwing completed listener does not fail or retry the job', async () => {
@@ -272,7 +286,7 @@ describe('Mochi queue', () => {
 
   test('addBulk skips jobs whose explicit id already exists and resolves only the inserted ids', async () => {
     const name = uniqueName();
-    const added: Array<{ queue: string; jobId: string }> = [];
+    const added: Array<{ queue: string; jobId: string; bulk?: boolean }> = [];
     mochiEvents.on('queue:added', (e) => added.push(e));
 
     await startWith({ [name]: {} });
@@ -288,7 +302,7 @@ describe('Mochi queue', () => {
     // One from the original add, one for the single job addBulk actually inserted — none for the skipped duplicate.
     expect(added).toEqual([
       { queue: name, jobId: taken! },
-      { queue: name, jobId: fresh },
+      { queue: name, jobId: fresh, bulk: true },
     ]);
   });
 
@@ -464,5 +478,127 @@ describe('Mochi queue', () => {
     expect(() => getQueue(name)).toThrow(/queues are not mounted yet/);
     // A second call must not throw even though the registry is already empty.
     await expect(closeAllQueueResources()).resolves.toBeUndefined();
+  });
+
+  test('batchSize > 1 settles each job on its own: one failure retries alone', async () => {
+    const name = uniqueName();
+    const completions: Array<{ n: number; attempt: number }> = [];
+    const failedEvents: Array<{ jobId: string; attempt: number }> = [];
+    const done = deferred<void>();
+    mochiEvents.on('queue:failed', (e) => failedEvents.push({ jobId: e.jobId, attempt: e.attempt }));
+
+    await startWith({
+      [name]: {
+        process: async (job: MochiJob<{ n: number }>) => {
+          if (job.data.n === 2 && job.attempt === 1) {
+            throw new Error('flaky');
+          }
+          completions.push({ n: job.data.n, attempt: job.attempt });
+          if (completions.length === 3) {
+            done.resolve();
+          }
+        },
+        options: { batchSize: 3, retryLimit: 1, retryDelay: 0, pollingIntervalSeconds: 0.5 },
+      },
+    });
+
+    // One insert() call, then one notify — the worker's next fetch sees all three jobs as a single batch.
+    const ids = await getQueue<{ n: number }>(name).addBulk([{ data: { n: 1 } }, { data: { n: 2 } }, { data: { n: 3 } }]);
+    await done.promise;
+
+    // The whole-batch alternative would have retried jobs 1 and 3 alongside the thrown job 2.
+    expect(completions.filter((c) => c.n !== 2).every((c) => c.attempt === 1)).toBe(true);
+    expect(completions.find((c) => c.n === 2)?.attempt).toBe(2);
+    expect(failedEvents).toEqual([{ jobId: ids[1]!, attempt: 1 }]);
+    await getBoss().getSpy(name).waitForJobWithId(ids[1]!, 'completed');
+  }, 15_000);
+
+  test('worker tuning reaches boss.work, with Mochi-owned keys winning over the escape hatch', async () => {
+    const name = uniqueName();
+    await startWith({
+      [name]: {
+        process: async () => null,
+        options: {
+          concurrency: 2,
+          batchSize: 4,
+          burst: true,
+          // The sneaked-in batchSize/includeMetadata must lose to the Mochi-owned keys.
+          worker: { orderByCreatedOn: false, minPriority: 5, batchSize: 99, includeMetadata: false } as never,
+        },
+      },
+    });
+
+    const worker = getBoss()
+      .getWipData()
+      .find((w) => w.name === name);
+    expect(worker).toBeDefined();
+    expect(worker!.options).toMatchObject({
+      batchSize: 4,
+      includeMetadata: true,
+      perJobResults: true,
+      burstWhenBatchFull: true,
+      localConcurrency: 2,
+      orderByCreatedOn: false,
+      minPriority: 5,
+    });
+  });
+
+  test('burst without a real batch size warns at mount', async () => {
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const name = uniqueName();
+      await startWith({ [name]: { process: async () => null, options: { burst: true } } });
+      expect(warn.mock.calls.flat().some((m) => String(m).includes('burst has no effect with batchSize 1'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test('an undeclared expiry is no longer re-sent: a bare remount keeps stored options', async () => {
+    const name = uniqueName();
+    const file = path.join(dataDir, 'expiry.sqlite');
+    await startWith({ [name]: { options: { expireInSeconds: 42, retryLimit: 7 } } }, { sqlite: file });
+    expect((await getBoss().getQueue(name))?.expireInSeconds).toBe(42);
+    await closeAllQueueResources();
+
+    // A second process mounting the same queue with a bare Mochi.queue(name) must keep 42, not reset it to the default.
+    await startWith({ [name]: {} }, { sqlite: file });
+    const queue = await getBoss().getQueue(name);
+    expect(queue?.expireInSeconds).toBe(42);
+    expect(queue?.retryLimit).toBe(7);
+  }, 15_000);
+
+  test('a fresh queue with no declared expiry lands on the default via bun-boss, not an explicit send', async () => {
+    const name = uniqueName();
+    await startWith({ [name]: {} });
+    expect((await getBoss().getQueue(name))?.expireInSeconds).toBe(DEFAULT_EXPIRE_IN_SECONDS);
+  });
+
+  test('a filter-overridden default expiry is still sent', async () => {
+    initExtensions({ filters: { 'queue:expireInSeconds': (value, ctx) => (ctx.explicit ? value : 300) } });
+    const name = uniqueName();
+    await startWith({ [name]: {} });
+    expect((await getBoss().getQueue(name))?.expireInSeconds).toBe(300);
+  });
+
+  test('addBulk emits per-job bulk-flagged adds plus one queue:addedBulk summary', async () => {
+    const name = uniqueName();
+    const added: unknown[] = [];
+    const bulks: unknown[] = [];
+    mochiEvents.on('queue:added', (e) => added.push(e));
+    mochiEvents.on('queue:addedBulk', (e) => bulks.push(e));
+
+    await startWith({ [name]: {} });
+    const queue = getQueue<{ n: number }>(name);
+    const ids = await queue.addBulk([{ data: { n: 1 } }, { data: { n: 2 } }, { data: { n: 3 } }]);
+    const solo = await queue.add({ n: 4 });
+
+    expect(added).toEqual([
+      { queue: name, jobId: ids[0]!, bulk: true },
+      { queue: name, jobId: ids[1]!, bulk: true },
+      { queue: name, jobId: ids[2]!, bulk: true },
+      { queue: name, jobId: solo! },
+    ]);
+    expect(bulks).toEqual([{ queue: name, count: 3, jobIds: ids }]);
   });
 });

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -1,10 +1,11 @@
 // The isolation boundary around bun-boss: the only module importing `bun-boss`, and the only one whose rewrite a
 // backend swap would need.
 import { BunBoss, fromBunSqlite, fromPglite } from 'bun-boss';
-import type { JobInsert, JobWithMetadata, PGliteLike, SendOptions, UpdateQueueOptions } from 'bun-boss';
+import type { JobInsert, JobResult, JobWithMetadata, PGliteLike, SendOptions, UpdateQueueOptions, WorkOptions } from 'bun-boss';
 import { SQL } from 'bun';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
+import { toPosixPath } from './utils';
 import { pinGlobal } from './utils/globalState';
 import { applyFilter } from './extensions';
 import { startupMilestoneReached } from './lifecycle';
@@ -81,12 +82,41 @@ export interface MochiQueueListeners<T, R> {
   failed: (job: MochiJob<T>, error: Error) => void;
 }
 
-/** The non-processor settings of a queue — what survives on the inert `MochiQueueConfig.options`. */
+/**
+ * Advanced fetch-time worker tuning, forwarded to bun-boss verbatim; Mochi-owned settings win where they overlap.
+ * Nothing here is persisted on the queue — these only shape how a worker fetches.
+ */
+export interface MochiWorkerTuning {
+  /** Skip the created-on sort when fetching, trading strict FIFO for a cheaper fetch. bun-boss default: true. */
+  orderByCreatedOn?: boolean;
+  /** Fetch higher-priority jobs first. bun-boss default: true. */
+  priority?: boolean;
+  /** Only fetch jobs with at least this priority. */
+  minPriority?: number;
+  /** Only fetch jobs with at most this priority. */
+  maxPriority?: number;
+  /** Also fetch jobs whose `startAfter` has not been reached yet. */
+  ignoreStartAfter?: boolean;
+  /** Seconds between polls while LISTEN/NOTIFY is active. */
+  notifyPollingIntervalSeconds?: number;
+  /** Fetch continuously, with no poll delay, while the queue's cached ready-count exceeds this. */
+  burstWhenReadyExceeds?: number;
+  /** Seconds between heartbeat refreshes; must be less than the queue's `heartbeatSeconds`. */
+  heartbeatRefreshSeconds?: number;
+}
+
+/** The non-processor settings of a queue — what survives on `MochiQueueConfig.options`. */
 export interface MochiQueueRuntimeOptions {
   /** Jobs of this queue processed in parallel in this process. */
   concurrency?: number;
   /** Seconds between idle fetches; must be >= 0.5. Adds from this process wake the worker immediately regardless. */
   pollingIntervalSeconds?: number;
+  /** Jobs fetched per poll (default 1). `process` still runs once per job, each settled and retried on its own. */
+  batchSize?: number;
+  /** Keep fetching with no poll delay while fetches return full batches — drains cross-process backlogs fast. Needs `batchSize` > 1. */
+  burst?: boolean;
+  /** Advanced fetch-time worker tuning; see `MochiWorkerTuning`. */
+  worker?: MochiWorkerTuning;
   /** Times a failed job is retried before it fails terminally. bun-boss default: 2. */
   retryLimit?: number;
   /** Seconds between retries. bun-boss default: 0. */
@@ -105,14 +135,19 @@ export interface MochiQueueRuntimeOptions {
   deadLetter?: string;
 }
 
-/** The full config object passed to `Mochi.queue({ process, … })`. */
+/** The full config object passed to `Mochi.queue(name, { process, … })`. */
 export interface MochiQueueOptions<T, R = unknown> extends MochiQueueRuntimeOptions {
   /** Optional so a queue can exist purely to receive jobs — e.g. a dead-letter holding pen drained via `Mochi.boss()`. */
   process?: MochiProcessor<T, R>;
   on?: Partial<MochiQueueListeners<T, R>>;
+  /**
+   * Where to connect when this queue is produced to standalone (no `Mochi.serve()`): the first `add*()` lazily starts a
+   * producer-only runtime against it. Under `Mochi.serve()`, the serve-level `queueStorage` wins.
+   */
+  storage?: MochiQueueStorage;
 }
 
-/** Handle returned by `Mochi.getQueue(name)` — what you add jobs through. */
+/** The producer surface of a queue — what you add jobs through. */
 export interface MochiQueue<T> {
   readonly name: string;
   /** Resolves the job id, or `null` when the add was suppressed (duplicate explicit `id`). */
@@ -125,13 +160,27 @@ export interface MochiQueue<T> {
 }
 
 /**
- * Matches `MochiQueueConfig` in types.ts without importing it — types.ts imports from this module, not the reverse.
- * `never` keeps a caller's typed processor assignable (contravariance) without an unsafe cast at every call site.
+ * What `Mochi.queue(name, …)` returns: both the declaration `Mochi.serve({ queues })` mounts and a directly-usable
+ * producer handle. In a process that never serves, the first `add*()` lazily connects to the declared `storage`.
  */
-interface MountableQueueConfig {
+export interface MochiQueueDescriptor<T = unknown, R = unknown> extends MochiQueue<T> {
+  readonly __mochiQueue: true;
+  readonly process?: MochiProcessor<T, R>;
+  readonly options?: MochiQueueRuntimeOptions;
+  readonly on?: Partial<MochiQueueListeners<T, R>>;
+  readonly storage?: MochiQueueStorage;
+}
+
+/**
+ * Matches `MochiQueueConfig` in types.ts without importing it — types.ts imports from this module, not the reverse.
+ * `never` keeps a caller's typed processor/listeners assignable (contravariance) without an unsafe cast at every call site.
+ */
+interface MountableQueue {
+  name: string;
   process?: MochiProcessor<never, unknown>;
   options?: MochiQueueRuntimeOptions;
-  on?: Partial<MochiQueueListeners<never, unknown>>;
+  on?: Partial<MochiQueueListeners<never, never>>;
+  storage?: MochiQueueStorage;
 }
 
 interface QueueRegistry {
@@ -142,6 +191,14 @@ interface QueueRegistry {
   byName: Map<string, MochiQueue<unknown>>;
   /** Worker ids per queue, so adds from this process can skip the poll delay via `notifyWorker`. */
   workIds: Map<string, string>;
+  /** Who started the runtime: serve owns workers and the option re-sync; standalone is producer-only. */
+  kind: 'serve' | 'standalone' | null;
+  /** Storage the running boss was started with, for identity checks against later connect attempts. */
+  storage: MochiQueueStorage | null;
+  /** In-flight standalone boot, so concurrent first-adds share one `start()`. */
+  starting: Promise<void> | null;
+  /** Per-queue ensure-exists memo for standalone producers. */
+  ensured: Map<string, Promise<void>>;
 }
 
 // Pinned so every duplicate bundled copy of this module shares one registry, since `closeAllQueueResources` must see
@@ -151,7 +208,44 @@ const registry = pinGlobal<QueueRegistry>('__mochi_queue_registry__', () => ({
   ownedSql: null,
   byName: new Map(),
   workIds: new Map(),
+  kind: null,
+  storage: null,
+  starting: null,
+  ensured: new Map(),
 }));
+
+export function storageEquals(a: MochiQueueStorage | null, b: MochiQueueStorage): boolean {
+  if (a === null) {
+    return false;
+  }
+  if (a === 'memory' || b === 'memory') {
+    return a === b;
+  }
+  if ('sqlite' in a && 'sqlite' in b) {
+    return path.resolve(a.sqlite) === path.resolve(b.sqlite);
+  }
+  if ('postgres' in a && 'postgres' in b) {
+    return a.postgres === b.postgres;
+  }
+  if ('pglite' in a && 'pglite' in b) {
+    return a.pglite === b.pglite;
+  }
+  return false;
+}
+
+// Postgres URLs carry credentials and PGlite instances aren't printable, so those are identified by kind alone.
+function describeStorage(storage: MochiQueueStorage | null): string {
+  if (storage === null) {
+    return '(none)';
+  }
+  if (storage === 'memory') {
+    return "'memory'";
+  }
+  if ('sqlite' in storage) {
+    return `{ sqlite: "${toPosixPath(storage.sqlite)}" }`;
+  }
+  return 'pglite' in storage ? '{ pglite: … }' : '{ postgres: … }';
+}
 
 export const DEFAULT_EXPIRE_IN_SECONDS = 900;
 
@@ -176,10 +270,13 @@ function toBossQueueOptions(name: string, options: MochiQueueRuntimeOptions | un
   // Filtered per queue after whatever the queue declared for itself, so a deployment can move the expiry for every
   // queue at once and still see via `explicit` which ones chose a value themselves.
   const declared = options?.expireInSeconds;
-  const expireInSeconds = applyFilter('queue:expireInSeconds', declared ?? DEFAULT_EXPIRE_IN_SECONDS, {
+  const filtered = applyFilter('queue:expireInSeconds', declared ?? DEFAULT_EXPIRE_IN_SECONDS, {
     queue: name,
     explicit: declared !== undefined,
   });
+  // Sent only when declared or filter-overridden: an unchanged default stays omitted so a bare mount on shared durable
+  // storage keeps (not resets) another deployment's stored expiry, matching every other option's COALESCE semantics.
+  const expireInSeconds = declared !== undefined || filtered !== DEFAULT_EXPIRE_IN_SECONDS ? filtered : undefined;
   const { retryLimit, retryDelay, retryBackoff, retryDelayMax, retentionSeconds, deleteAfterSeconds, deadLetter } = options ?? {};
   return omitUndefined({ expireInSeconds, retryLimit, retryDelay, retryBackoff, retryDelayMax, retentionSeconds, deleteAfterSeconds, deadLetter });
 }
@@ -187,21 +284,43 @@ function toBossQueueOptions(name: string, options: MochiQueueRuntimeOptions | un
 function requireBoss(): BunBoss {
   if (!registry.boss) {
     throw new Error(
-      'Mochi.boss(): the queue runtime is not running. It starts when Mochi.serve({ queues }) mounts a non-empty queues map — call it from the "mochi:queuesMounted" hook onwards.',
+      'Mochi.boss(): the queue runtime is not running. It starts when Mochi.serve({ queues }) mounts a non-empty queues array (call from the "mochi:queuesMounted" hook onwards), or when a standalone Mochi.queue(name, { storage }) descriptor performs its first add.',
     );
   }
   return registry.boss;
 }
 
 /**
- * Create and start the shared BunBoss instance for the given storage. Called once by `Mochi.serve()` when its `queues`
- * map is non-empty; `start()` installs bun-boss's schema on first run against a fresh store.
+ * Create and start the shared BunBoss instance for the given storage — one per process. Called by `Mochi.serve()` when
+ * its `queues` array is non-empty and by the lazy standalone-producer path; `start()` installs bun-boss's schema on
+ * first run against a fresh store.
  */
-export async function startQueueRuntime(storage: MochiQueueStorage, testOptions?: { enableSpies?: boolean }): Promise<void> {
+/**
+ * Reject a serve whose queueStorage differs from an already-connected standalone producer runtime. Called by
+ * `Mochi.serve()` during fail-fast validation — before the config singleton pins and the server binds — and again by
+ * `startQueueRuntime` as a belt-and-braces for a standalone connect racing the serve boot.
+ */
+export function assertNoConflictingStandaloneRuntime(storage: MochiQueueStorage): void {
+  if (registry.boss && registry.kind === 'standalone' && !storageEquals(registry.storage, storage)) {
+    throw new Error(
+      `Mochi.serve({ queueStorage }): a standalone queue runtime is already connected to ${describeStorage(registry.storage)}, which is not the serve queueStorage ${describeStorage(storage)}. Use the same storage in both, or Mochi.stop() first.`,
+    );
+  }
+}
+
+export async function startQueueRuntime(storage: MochiQueueStorage, opts?: { kind?: 'serve' | 'standalone'; enableSpies?: boolean }): Promise<void> {
+  const kind = opts?.kind ?? 'serve';
   if (registry.boss) {
+    if (kind === 'serve' && registry.kind === 'standalone') {
+      assertNoConflictingStandaloneRuntime(storage);
+      // Serve adopts a standalone producer runtime on the same storage; mountQueues then layers workers and the
+      // option re-sync on top of it.
+      registry.kind = 'serve';
+      return;
+    }
     throw new Error('The Mochi queue runtime is already running — Mochi.serve() starts it once per process.');
   }
-  const spies = testOptions?.enableSpies ? { __test__enableSpies: true } : {};
+  const spies = opts?.enableSpies ? { __test__enableSpies: true } : {};
   let boss: BunBoss;
   if (storage === 'memory' || 'sqlite' in storage) {
     const file = storage === 'memory' ? ':memory:' : storage.sqlite;
@@ -237,6 +356,8 @@ export async function startQueueRuntime(storage: MochiQueueStorage, testOptions?
     throw err;
   }
   registry.boss = boss;
+  registry.kind = kind;
+  registry.storage = storage;
 }
 
 // A throwing listener or bus subscriber must not decide a job's fate — only `process` may — nor reject an add()
@@ -250,37 +371,39 @@ function notifySafely(queue: string, fn: () => void): void {
 }
 
 function makeHandler<T, R>(name: string, process: MochiProcessor<T, R>, listeners?: Partial<MochiQueueListeners<T, R>>) {
-  return async (batch: JobWithMetadata<T>[]): Promise<R> => {
-    const raw = batch[0];
-    if (!raw) {
-      throw new Error(`[queue] ${name}: bun-boss delivered an empty batch`);
+  // Sequential on purpose: parallelism is owned by `concurrency` (workers), so a batch never multiplies it — and jobs
+  // settle per-job via `perJobResults`, so one throw fails only its own job while siblings complete.
+  return async (batch: JobWithMetadata<T>[]): Promise<JobResult[]> => {
+    const results: JobResult[] = [];
+    for (const raw of batch) {
+      const job: MochiJob<T> = {
+        id: raw.id,
+        data: raw.data,
+        queue: name,
+        attempt: raw.retryCount + 1,
+        // The sqlite backend may hand timestamps back as ISO strings rather than Dates.
+        enqueuedAt: new Date(raw.createdOn).getTime(),
+      };
+      const start = performance.now();
+      notifySafely(name, () => mochiEvents.emit('queue:active', { queue: name, jobId: job.id, attempt: job.attempt }));
+      notifySafely(name, () => listeners?.active?.(job));
+      try {
+        const result = await process(job);
+        notifySafely(name, () => mochiEvents.emit('queue:completed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start }));
+        notifySafely(name, () => listeners?.completed?.(job, result));
+        results.push({ id: raw.id, status: 'completed', output: result });
+      } catch (err) {
+        const error = err instanceof Error ? err : new Error(String(err));
+        notifySafely(name, () => mochiEvents.emit('queue:failed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start, error: error.message }));
+        notifySafely(name, () => listeners?.failed?.(job, error));
+        results.push({ id: raw.id, status: 'failed', output: { message: error.message } });
+      }
     }
-    const job: MochiJob<T> = {
-      id: raw.id,
-      data: raw.data,
-      queue: name,
-      attempt: raw.retryCount + 1,
-      // The sqlite backend may hand timestamps back as ISO strings rather than Dates.
-      enqueuedAt: new Date(raw.createdOn).getTime(),
-    };
-    const start = performance.now();
-    notifySafely(name, () => mochiEvents.emit('queue:active', { queue: name, jobId: job.id, attempt: job.attempt }));
-    notifySafely(name, () => listeners?.active?.(job));
-    try {
-      const result = await process(job);
-      notifySafely(name, () => mochiEvents.emit('queue:completed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start }));
-      notifySafely(name, () => listeners?.completed?.(job, result));
-      return result;
-    } catch (err) {
-      const error = err instanceof Error ? err : new Error(String(err));
-      notifySafely(name, () => mochiEvents.emit('queue:failed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start, error: error.message }));
-      notifySafely(name, () => listeners?.failed?.(job, error));
-      throw error;
-    }
+    return results;
   };
 }
 
-function buildProducer<T>(name: string): MochiQueue<T> {
+function producerMethods<T>(name: string): MochiQueue<T> {
   // Adds wake this process's worker immediately; bun-boss itself only polls (pollingIntervalSeconds), which stays the
   // floor for other processes and for deferred/retried jobs.
   const notify = () => {
@@ -310,9 +433,11 @@ function buildProducer<T>(name: string): MochiQueue<T> {
           { returnId: true },
         )) ?? [];
       for (const jobId of ids) {
-        notifySafely(name, () => mochiEvents.emit('queue:added', { queue: name, jobId }));
+        notifySafely(name, () => mochiEvents.emit('queue:added', { queue: name, jobId, bulk: true }));
       }
       if (ids.length > 0) {
+        // One summary event per call — the console logger prints this instead of the N `bulk`-flagged per-job lines.
+        notifySafely(name, () => mochiEvents.emit('queue:addedBulk', { queue: name, count: ids.length, jobIds: ids }));
         notify();
       }
       return ids;
@@ -330,13 +455,115 @@ function buildProducer<T>(name: string): MochiQueue<T> {
   };
 }
 
+const QUEUE_NAME_RE = /^[\w.\-/]+$/;
+
+function noStorageError(name: string): Error {
+  return new Error(
+    `Mochi.queue("${name}"): this queue has no storage and no Mochi.serve({ queues }) has mounted it. Declare it as Mochi.queue("${name}", { storage: … }) to produce to it standalone, or include it in the Mochi.serve({ queues }) array.`,
+  );
+}
+
+/**
+ * Make a descriptor's producer methods callable: a no-op when the queue is already mounted/ensured, otherwise the lazy
+ * standalone path — boot a producer-only runtime against the descriptor's storage and ensure the queue exists.
+ */
+async function ensureUsable(descriptor: MountableQueue): Promise<void> {
+  const { name, storage } = descriptor;
+  if (registry.boss && registry.byName.has(name)) {
+    return;
+  }
+  if (registry.starting) {
+    await registry.starting;
+  }
+  if (!registry.boss) {
+    if (!storage) {
+      throw noStorageError(name);
+    }
+    registry.starting = startQueueRuntime(storage, { kind: 'standalone' }).finally(() => {
+      registry.starting = null;
+    });
+    await registry.starting;
+  } else if (!registry.byName.has(name)) {
+    if (registry.kind === 'serve') {
+      throw new Error(
+        `Mochi.queue("${name}"): this queue is not in this process's Mochi.serve({ queues }) array (mounted: ${[...registry.byName.keys()].join(', ') || 'none'}). One queue runtime per process — declare it there to produce to it here.`,
+      );
+    }
+    if (!storage) {
+      throw noStorageError(name);
+    }
+    if (!storageEquals(registry.storage, storage)) {
+      throw new Error(
+        `Mochi.queue("${name}"): a standalone queue runtime is already connected to ${describeStorage(registry.storage)}, but this queue declares storage ${describeStorage(storage)}. One queue runtime per process — give every standalone queue the same storage.`,
+      );
+    }
+  }
+  // Ensure-only creation (createQueue is ON CONFLICT DO NOTHING) and never updateQueue: a producer must not rewrite
+  // options the consuming deployment owns. deadLetter is dropped because its target queue may not exist here.
+  let ensured = registry.ensured.get(name);
+  if (!ensured) {
+    const { deadLetter: _, ...createOptions } = toBossQueueOptions(name, descriptor.options);
+    ensured = requireBoss()
+      .createQueue(name, createOptions)
+      .catch((err: unknown) => {
+        registry.ensured.delete(name);
+        throw err;
+      });
+    registry.ensured.set(name, ensured);
+  }
+  await ensured;
+  if (!registry.byName.has(name)) {
+    registry.byName.set(name, producerMethods(name));
+  }
+}
+
+/** Implements `Mochi.queue(name, config)` — see its JSDoc there. */
+export function createQueueDescriptor<T = unknown, R = unknown>(name: string, config: MochiQueueOptions<T, R> = {}): MochiQueueDescriptor<T, R> {
+  if (!QUEUE_NAME_RE.test(name)) {
+    throw new Error(`Mochi.queue("${name}"): not a valid queue name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
+  }
+  const { process, on, storage, ...options } = config;
+  if (storage !== undefined && !isValidQueueStorage(storage)) {
+    throw new Error(`Mochi.queue("${name}", { storage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
+  }
+  if (options.batchSize !== undefined && (!Number.isInteger(options.batchSize) || options.batchSize < 1)) {
+    throw new Error(`Mochi.queue("${name}", { batchSize }): expected an integer >= 1.`);
+  }
+  const base = producerMethods<T>(name);
+  const descriptor: MochiQueueDescriptor<T, R> = {
+    __mochiQueue: true,
+    name,
+    process,
+    on,
+    storage,
+    options,
+    async add(data, opts) {
+      await ensureUsable(descriptor);
+      return base.add(data, opts);
+    },
+    async addBulk(jobs) {
+      await ensureUsable(descriptor);
+      return base.addBulk(jobs);
+    },
+    async addThrottled(data, seconds, key, opts) {
+      await ensureUsable(descriptor);
+      return base.addThrottled(data, seconds, key, opts);
+    },
+    async addDebounced(data, seconds, key, opts) {
+      await ensureUsable(descriptor);
+      return base.addDebounced(data, seconds, key, opts);
+    },
+  };
+  return descriptor;
+}
+
 /**
  * Mount every queue declared in `Mochi.serve({ queues })` on the running boss: ensure each exists with its declared
  * config, then start a worker for each that has a processor.
  */
-export async function mountQueues(entries: Array<[string, MountableQueueConfig]>): Promise<void> {
+export async function mountQueues(queues: MountableQueue[]): Promise<void> {
   const boss = requireBoss();
-  const resolved = entries.map(([name, config]) => ({ name, config, bossOptions: toBossQueueOptions(name, config.options) }));
+  const resolved = queues.map((config) => ({ name: config.name, config, bossOptions: toBossQueueOptions(config.name, config.options) }));
   // createQueue validates that a deadLetter target already exists and is ON CONFLICT DO NOTHING, so pass 1 creates
   // every queue without deadLetter and pass 2 updates with the full set — declaration order stops mattering. The
   // re-sync is additive only: updateQueue COALESCEs absent keys, so an option *removed* from code (deadLetter
@@ -346,18 +573,30 @@ export async function mountQueues(entries: Array<[string, MountableQueueConfig]>
     await boss.createQueue(name, createOptions);
   }
   for (const { name, bossOptions } of resolved) {
-    await boss.updateQueue(name, bossOptions);
+    // A queue declaring nothing has nothing to re-sync (bun-boss asserts on an empty update).
+    if (Object.keys(bossOptions).length > 0) {
+      await boss.updateQueue(name, bossOptions);
+    }
   }
   for (const { name, config } of resolved) {
-    registry.byName.set(name, buildProducer(name));
+    registry.byName.set(name, producerMethods(name));
     if (config.process) {
+      const o = config.options;
+      const batchSize = o?.batchSize ?? 1;
+      if (o?.burst && batchSize === 1) {
+        logger.warn(`[queue] ${name}: burst has no effect with batchSize 1 — raise batchSize so there are full fetches to burst on.`);
+      }
       const workOptions = omitUndefined({
-        batchSize: 1,
-        includeMetadata: true as const,
-        localConcurrency: config.options?.concurrency,
-        pollingIntervalSeconds: config.options?.pollingIntervalSeconds,
-      });
-      const workId = await boss.work(name, workOptions, makeHandler(name, config.process, config.on));
+        // Escape hatch first; Mochi-owned keys below win where they overlap.
+        ...omitUndefined({ ...(o?.worker ?? {}) }),
+        batchSize,
+        includeMetadata: true,
+        perJobResults: true,
+        localConcurrency: o?.concurrency,
+        pollingIntervalSeconds: o?.pollingIntervalSeconds,
+        burstWhenBatchFull: o?.burst,
+      }) as WorkOptions & { includeMetadata: true; perJobResults: true };
+      const workId = await boss.work(name, workOptions, makeHandler(name, config.process, config.on as Partial<MochiQueueListeners<never, unknown>> | undefined));
       registry.workIds.set(name, workId);
     }
   }
@@ -374,14 +613,14 @@ export function getQueue<T = unknown>(name: string): MochiQueue<T> {
     // can't distinguish them, since an empty registry means "too early" for one app and "declared nothing" for another.
     if (!startupMilestoneReached('mochi:queuesMounted')) {
       throw new Error(
-        `Mochi.getQueue("${name}"): queues are not mounted yet. Mochi.serve({ queues }) mounts them after the "mochi:init" hook and after the server binds, so call getQueue() somewhere that runs later: the "mochi:ready" hook, or any request handler.`,
+        `Mochi.getQueue("${name}"): queues are not mounted yet. Mochi.serve({ queues }) mounts them after the "mochi:init" hook and after the server binds, so call getQueue() somewhere that runs later: the "mochi:ready" hook, or any request handler. In a process that never serves, add jobs through the Mochi.queue("${name}", { storage }) descriptor itself — getQueue() resolves a standalone queue only after its first add connects it.`,
       );
     }
     if (registry.byName.size === 0) {
-      throw new Error(`Mochi.getQueue("${name}"): no queues were declared. Add it to Mochi.serve({ queues: { "${name}": Mochi.queue(...) } }) before adding jobs to it.`);
+      throw new Error(`Mochi.getQueue("${name}"): no queues were declared. Add it to Mochi.serve({ queues: [Mochi.queue("${name}", …)] }) before adding jobs to it.`);
     }
     throw new Error(
-      `Mochi.getQueue("${name}"): no such queue. Declare it via Mochi.serve({ queues: { "${name}": Mochi.queue(...) } }) before adding jobs to it. Mounted queues: ${[...registry.byName.keys()].join(', ')}.`,
+      `Mochi.getQueue("${name}"): no such queue. Declare it via Mochi.serve({ queues: [Mochi.queue("${name}", …)] }) before adding jobs to it. Mounted queues: ${[...registry.byName.keys()].join(', ')}.`,
     );
   }
   return handle as MochiQueue<T>;
@@ -402,8 +641,12 @@ export async function closeAllQueueResources(): Promise<void> {
   // close below fails.
   registry.boss = null;
   registry.ownedSql = null;
+  registry.kind = null;
+  registry.storage = null;
+  registry.starting = null;
   registry.byName.clear();
   registry.workIds.clear();
+  registry.ensured.clear();
   if (boss) {
     try {
       await boss.stop({ graceful: true, timeout: 10_000 });

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -141,8 +141,9 @@ export interface MochiQueueOptions<T, R = unknown> extends MochiQueueRuntimeOpti
   process?: MochiProcessor<T, R>;
   on?: Partial<MochiQueueListeners<T, R>>;
   /**
-   * Where to connect when this queue is produced to standalone (no `Mochi.serve()`): the first `add*()` lazily starts a
-   * producer-only runtime against it. Under `Mochi.serve()`, the serve-level `queueStorage` wins.
+   * The app's queue storage, declared on the descriptor: a standalone producer's first `add*()` lazily connects a
+   * producer-only runtime to it, and `Mochi.serve()` inherits it when `queueStorage` is unset. An app has one queue
+   * storage — a conflicting declaration anywhere is a boot error.
    */
   storage?: MochiQueueStorage;
 }
@@ -498,11 +499,18 @@ async function ensureUsable(descriptor: MountableQueue): Promise<void> {
       );
     }
   }
-  // Ensure-only creation (createQueue is ON CONFLICT DO NOTHING) and never updateQueue: a producer must not rewrite
-  // options the consuming deployment owns. deadLetter is dropped because its target queue may not exist here.
+  await ensureQueueExists(name, descriptor.options);
+  if (!registry.byName.has(name)) {
+    registry.byName.set(name, producerMethods(name));
+  }
+}
+
+// Ensure-only creation (createQueue is ON CONFLICT DO NOTHING) and never updateQueue: the standalone paths must not
+// rewrite options a Mochi.serve() deployment owns. deadLetter is dropped because its target queue may not exist here.
+async function ensureQueueExists(name: string, options: MochiQueueRuntimeOptions | undefined): Promise<void> {
   let ensured = registry.ensured.get(name);
   if (!ensured) {
-    const { deadLetter: _, ...createOptions } = toBossQueueOptions(name, descriptor.options);
+    const { deadLetter: _, ...createOptions } = toBossQueueOptions(name, options);
     ensured = requireBoss()
       .createQueue(name, createOptions)
       .catch((err: unknown) => {
@@ -512,9 +520,6 @@ async function ensureUsable(descriptor: MountableQueue): Promise<void> {
     registry.ensured.set(name, ensured);
   }
   await ensured;
-  if (!registry.byName.has(name)) {
-    registry.byName.set(name, producerMethods(name));
-  }
 }
 
 /** Implements `Mochi.queue(name, config)` — see its JSDoc there. */
@@ -581,25 +586,126 @@ export async function mountQueues(queues: MountableQueue[]): Promise<void> {
   for (const { name, config } of resolved) {
     registry.byName.set(name, producerMethods(name));
     if (config.process) {
-      const o = config.options;
-      const batchSize = o?.batchSize ?? 1;
-      if (o?.burst && batchSize === 1) {
-        logger.warn(`[queue] ${name}: burst has no effect with batchSize 1 — raise batchSize so there are full fetches to burst on.`);
-      }
-      const workOptions = omitUndefined({
-        // Escape hatch first; Mochi-owned keys below win where they overlap.
-        ...omitUndefined({ ...(o?.worker ?? {}) }),
-        batchSize,
-        includeMetadata: true,
-        perJobResults: true,
-        localConcurrency: o?.concurrency,
-        pollingIntervalSeconds: o?.pollingIntervalSeconds,
-        burstWhenBatchFull: o?.burst,
-      }) as WorkOptions & { includeMetadata: true; perJobResults: true };
-      const workId = await boss.work(name, workOptions, makeHandler(name, config.process, config.on as Partial<MochiQueueListeners<never, unknown>> | undefined));
-      registry.workIds.set(name, workId);
+      await registerQueueWorker(boss, config);
     }
   }
+}
+
+async function registerQueueWorker(boss: BunBoss, config: MountableQueue): Promise<void> {
+  if (!config.process) {
+    return;
+  }
+  const o = config.options;
+  const batchSize = o?.batchSize ?? 1;
+  if (o?.burst && batchSize === 1) {
+    logger.warn(`[queue] ${config.name}: burst has no effect with batchSize 1 — raise batchSize so there are full fetches to burst on.`);
+  }
+  const workOptions = omitUndefined({
+    // Escape hatch first; Mochi-owned keys below win where they overlap.
+    ...omitUndefined({ ...(o?.worker ?? {}) }),
+    batchSize,
+    includeMetadata: true,
+    perJobResults: true,
+    localConcurrency: o?.concurrency,
+    pollingIntervalSeconds: o?.pollingIntervalSeconds,
+    burstWhenBatchFull: o?.burst,
+  }) as WorkOptions & { includeMetadata: true; perJobResults: true };
+  const workId = await boss.work(config.name, workOptions, makeHandler(config.name, config.process, config.on as Partial<MochiQueueListeners<never, unknown>> | undefined));
+  registry.workIds.set(config.name, workId);
+}
+
+/** The handle returned by `Mochi.worker()` — start/stop consuming declared queues in a serverless process. */
+export interface MochiWorker {
+  /** Connect to storage (reusing a standalone runtime on the same storage), ensure the queues exist, and start polling. */
+  start(): Promise<void>;
+  /** Deregister this worker's queues, waiting for in-flight jobs. The runtime stays up for producers; `Mochi.stop()` tears it down. */
+  stop(): Promise<void>;
+}
+
+/** Implements `Mochi.worker(options)` — see its JSDoc there. */
+export function createWorker(queues: MountableQueue[], storage?: MochiQueueStorage): MochiWorker {
+  if (queues.length === 0) {
+    throw new Error('Mochi.worker(): declare at least one queue.');
+  }
+  const names = new Set<string>();
+  let declared: { name: string; storage: MochiQueueStorage } | undefined;
+  for (const q of queues) {
+    if (names.has(q.name)) {
+      throw new Error(`Mochi.worker(): two queues are named "${q.name}". Queue names must be unique.`);
+    }
+    names.add(q.name);
+    if (q.storage !== undefined) {
+      if (declared && !storageEquals(declared.storage, q.storage)) {
+        throw new Error(`Mochi.worker(): "${q.name}" and "${declared.name}" declare different storages — an app has one queue storage.`);
+      }
+      declared ??= { name: q.name, storage: q.storage };
+    }
+  }
+  if (storage !== undefined) {
+    if (!isValidQueueStorage(storage)) {
+      throw new Error(`Mochi.worker({ storage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
+    }
+    if (declared && !storageEquals(declared.storage, storage)) {
+      throw new Error(`Mochi.worker({ storage }): "${declared.name}" declares a different storage — an app has one queue storage.`);
+    }
+  }
+  const workerStorage = storage ?? declared?.storage;
+  let started = false;
+  return {
+    async start() {
+      if (started) {
+        throw new Error('Mochi.worker(): this worker was already started.');
+      }
+      if (registry.kind === 'serve') {
+        throw new Error('Mochi.worker(): this process is serving — declare the queues in Mochi.serve({ queues }) instead.');
+      }
+      if (!workerStorage) {
+        throw new Error('Mochi.worker(): no storage declared. Give a queue descriptor (or the worker) a storage to connect to.');
+      }
+      started = true;
+      try {
+        if (registry.starting) {
+          await registry.starting;
+        }
+        if (registry.boss) {
+          if (!storageEquals(registry.storage, workerStorage)) {
+            throw new Error(
+              `Mochi.worker(): the queue runtime is already connected to ${describeStorage(registry.storage)}, which is not this worker's storage ${describeStorage(workerStorage)}. An app has one queue storage.`,
+            );
+          }
+        } else {
+          registry.starting = startQueueRuntime(workerStorage, { kind: 'standalone' }).finally(() => {
+            registry.starting = null;
+          });
+          await registry.starting;
+        }
+        const boss = requireBoss();
+        for (const q of queues) {
+          await ensureQueueExists(q.name, q.options);
+          if (!registry.byName.has(q.name)) {
+            registry.byName.set(q.name, producerMethods(q.name));
+          }
+          await registerQueueWorker(boss, q);
+        }
+      } catch (err) {
+        started = false;
+        throw err;
+      }
+    },
+    async stop() {
+      const boss = registry.boss;
+      if (!boss) {
+        return;
+      }
+      for (const q of queues) {
+        const workId = registry.workIds.get(q.name);
+        if (workId) {
+          await boss.offWork(q.name, { id: workId, wait: true }).catch(() => {});
+          registry.workIds.delete(q.name);
+        }
+      }
+    },
+  };
 }
 
 /**

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -6,7 +6,7 @@ import { SQL } from 'bun';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { toPosixPath } from './utils';
-import { isBuilding } from './utils/buildFlag';
+import { isBuildingEntry } from './utils/buildFlag';
 import { pinGlobal } from './utils/globalState';
 import { applyFilter } from './extensions';
 import { startupMilestoneReached } from './lifecycle';
@@ -663,35 +663,35 @@ export function createQueueDescriptor<T = unknown, R = unknown>(name: string, co
     async add(data, opts) {
       // A `mochi-framework build` imports the app entry for real; adds are suppressed there so a build never connects
       // to (or writes into) the app's production storage.
-      if (isBuilding) {
+      if (isBuildingEntry()) {
         return null;
       }
       await ensureUsable(descriptor);
       return base.add(data, opts);
     },
     async addBulk(jobs) {
-      if (isBuilding) {
+      if (isBuildingEntry()) {
         return [];
       }
       await ensureUsable(descriptor);
       return base.addBulk(jobs);
     },
     async addThrottled(data, seconds, key, opts) {
-      if (isBuilding) {
+      if (isBuildingEntry()) {
         return null;
       }
       await ensureUsable(descriptor);
       return base.addThrottled(data, seconds, key, opts);
     },
     async addDebounced(data, seconds, key, opts) {
-      if (isBuilding) {
+      if (isBuildingEntry()) {
         return null;
       }
       await ensureUsable(descriptor);
       return base.addDebounced(data, seconds, key, opts);
     },
     async stop() {
-      if (isBuilding) {
+      if (isBuildingEntry()) {
         return;
       }
       await stopQueue(name);
@@ -794,7 +794,7 @@ export function createWorker(queues: MountableQueue[], storage?: MochiQueueStora
       if (started) {
         throw new Error('Mochi.worker(): this worker was already started.');
       }
-      if (isBuilding) {
+      if (isBuildingEntry()) {
         return;
       }
       if (!workerStorage) {

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -170,6 +170,12 @@ export interface MochiQueueDescriptor<T = unknown, R = unknown> extends MochiQue
   readonly options?: MochiQueueRuntimeOptions;
   readonly on?: Partial<MochiQueueListeners<T, R>>;
   readonly storage?: MochiQueueStorage;
+  /**
+   * Stop this queue in this process: deregister its worker (waiting for in-flight jobs) and release its claim on the
+   * shared runtime — the runtime closes when the last active queue stops. Standalone only; under `Mochi.serve()`
+   * queues stop with the server.
+   */
+  stop(): Promise<void>;
 }
 
 /**
@@ -505,6 +511,27 @@ async function ensureUsable(descriptor: MountableQueue): Promise<void> {
   }
 }
 
+async function stopQueue(name: string): Promise<void> {
+  const boss = registry.boss;
+  if (!boss) {
+    return;
+  }
+  if (registry.kind === 'serve') {
+    throw new Error(`Mochi.queue("${name}").stop(): this process is serving — queues stop with the server (SIGTERM/SIGINT or Mochi.stop()).`);
+  }
+  const workId = registry.workIds.get(name);
+  if (workId) {
+    await boss.offWork(name, { id: workId, wait: true }).catch(() => {});
+    registry.workIds.delete(name);
+  }
+  registry.byName.delete(name);
+  registry.ensured.delete(name);
+  // The runtime is shared, so it closes only when the last active queue lets go.
+  if (registry.byName.size === 0) {
+    await closeAllQueueResources();
+  }
+}
+
 // Ensure-only creation (createQueue is ON CONFLICT DO NOTHING) and never updateQueue: the standalone paths must not
 // rewrite options a Mochi.serve() deployment owns. deadLetter is dropped because its target queue may not exist here.
 async function ensureQueueExists(name: string, options: MochiQueueRuntimeOptions | undefined): Promise<void> {
@@ -557,6 +584,9 @@ export function createQueueDescriptor<T = unknown, R = unknown>(name: string, co
     async addDebounced(data, seconds, key, opts) {
       await ensureUsable(descriptor);
       return base.addDebounced(data, seconds, key, opts);
+    },
+    async stop() {
+      await stopQueue(name);
     },
   };
   return descriptor;

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -6,6 +6,7 @@ import { SQL } from 'bun';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { toPosixPath } from './utils';
+import { isBuilding } from './utils/buildFlag';
 import { pinGlobal } from './utils/globalState';
 import { applyFilter } from './extensions';
 import { startupMilestoneReached } from './lifecycle';
@@ -317,17 +318,36 @@ export function assertNoConflictingStandaloneRuntime(storage: MochiQueueStorage)
 
 export async function startQueueRuntime(storage: MochiQueueStorage, opts?: { kind?: 'serve' | 'standalone'; enableSpies?: boolean }): Promise<void> {
   const kind = opts?.kind ?? 'serve';
+  // Whoever booted first wins: waiting on the shared in-flight promise (each iteration a distinct one) is what keeps a
+  // lazy standalone connect racing a serve boot from creating two BunBoss instances and leaking the loser.
+  while (registry.starting) {
+    await registry.starting.catch(() => {});
+  }
   if (registry.boss) {
     if (kind === 'serve' && registry.kind === 'standalone') {
       assertNoConflictingStandaloneRuntime(storage);
       // Serve adopts a standalone producer runtime on the same storage; mountQueues then layers workers and the
-      // option re-sync on top of it.
+      // option re-sync on top of it. Producer handles reset so only queues the serve declares stay producible —
+      // otherwise whether an undeclared queue can produce would depend on whether it raced the boot.
       registry.kind = 'serve';
+      registry.byName.clear();
+      registry.ensured.clear();
+      return;
+    }
+    if (kind === 'standalone') {
+      // A concurrent caller booted while we waited; callers re-validate storage/name against the registry.
       return;
     }
     throw new Error('The Mochi queue runtime is already running — Mochi.serve() starts it once per process.');
   }
-  const spies = opts?.enableSpies ? { __test__enableSpies: true } : {};
+  registry.starting = bootQueueRuntime(storage, kind, opts?.enableSpies ?? false).finally(() => {
+    registry.starting = null;
+  });
+  await registry.starting;
+}
+
+async function bootQueueRuntime(storage: MochiQueueStorage, kind: 'serve' | 'standalone', enableSpies: boolean): Promise<void> {
+  const spies = enableSpies ? { __test__enableSpies: true } : {};
   let boss: BunBoss;
   if (storage === 'memory' || 'sqlite' in storage) {
     const file = storage === 'memory' ? ':memory:' : storage.sqlite;
@@ -356,10 +376,14 @@ export async function startQueueRuntime(storage: MochiQueueStorage, opts?: { kin
     await boss.start();
   } catch (err) {
     // bun-boss defers cleanup of a partially-started instance (maintenance intervals, the postgres pool) to stop(),
-    // and registry.boss is still null here, so closeAllQueueResources() could never reach it; the owned SQL handle
-    // is released on the same path so a failed boot leaves nothing running.
+    // and registry.boss is still null here, so it must be stopped inline; the owned SQL handle likewise — calling
+    // closeAllQueueResources() here would deadlock, since it awaits this very boot promise.
     await boss.stop({ graceful: false }).catch(() => {});
-    await closeAllQueueResources();
+    const sql = registry.ownedSql;
+    registry.ownedSql = null;
+    if (sql) {
+      await sql.close().catch(() => {});
+    }
     throw err;
   }
   registry.boss = boss;
@@ -377,11 +401,44 @@ function notifySafely(queue: string, fn: () => void): void {
   }
 }
 
+/**
+ * bun-boss times the whole handler invocation out at the batch's max `expireInSeconds` — not the sum — and that
+ * timeout fails every job in the batch wholesale, completed ones included. Multi-job batches therefore get an
+ * in-handler deadline just under bun-boss's, so the handler settles early and completed siblings keep their results;
+ * a single-job batch has no siblings to protect and keeps bun-boss's own expiry semantics.
+ */
+function batchDeadline(batch: JobWithMetadata<unknown>[]): number {
+  if (batch.length < 2) {
+    return Infinity;
+  }
+  const budgetMs = batch.reduce((acc, job) => Math.max(acc, job.expireInSeconds), 0) * 1000;
+  if (budgetMs <= 0) {
+    return Infinity;
+  }
+  return performance.now() + budgetMs - Math.min(1_000, budgetMs * 0.1);
+}
+
+async function withDeadline<R>(work: R | Promise<R>, deadlineAt: number, onTimeout: () => Error): Promise<R> {
+  if (deadlineAt === Infinity) {
+    return work;
+  }
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expiry = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(onTimeout()), Math.max(0, deadlineAt - performance.now()));
+  });
+  try {
+    return await Promise.race([work, expiry]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
 function makeHandler<T, R>(name: string, process: MochiProcessor<T, R>, listeners?: Partial<MochiQueueListeners<T, R>>) {
   // Sequential on purpose: parallelism is owned by `concurrency` (workers), so a batch never multiplies it — and jobs
   // settle per-job via `perJobResults`, so one throw fails only its own job while siblings complete.
   return async (batch: JobWithMetadata<T>[]): Promise<JobResult[]> => {
     const results: JobResult[] = [];
+    const deadlineAt = batchDeadline(batch);
     for (const raw of batch) {
       const job: MochiJob<T> = {
         id: raw.id,
@@ -392,10 +449,21 @@ function makeHandler<T, R>(name: string, process: MochiProcessor<T, R>, listener
         enqueuedAt: new Date(raw.createdOn).getTime(),
       };
       const start = performance.now();
+      if (start >= deadlineAt) {
+        const error = new Error(`the batch's shared expireInSeconds budget ran out before this job started; it is failed for retry`);
+        notifySafely(name, () => mochiEvents.emit('queue:failed', { queue: name, jobId: job.id, attempt: job.attempt, duration: 0, error: error.message }));
+        notifySafely(name, () => listeners?.failed?.(job, error));
+        results.push({ id: raw.id, status: 'failed', output: error });
+        continue;
+      }
       notifySafely(name, () => mochiEvents.emit('queue:active', { queue: name, jobId: job.id, attempt: job.attempt }));
       notifySafely(name, () => listeners?.active?.(job));
       try {
-        const result = await process(job);
+        const result = await withDeadline(
+          process(job),
+          deadlineAt,
+          () => new Error(`the batch's shared expireInSeconds budget ran out mid-job; it is failed for retry (its processor may still be running)`),
+        );
         notifySafely(name, () => mochiEvents.emit('queue:completed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start }));
         notifySafely(name, () => listeners?.completed?.(job, result));
         results.push({ id: raw.id, status: 'completed', output: result });
@@ -403,7 +471,9 @@ function makeHandler<T, R>(name: string, process: MochiProcessor<T, R>, listener
         const error = err instanceof Error ? err : new Error(String(err));
         notifySafely(name, () => mochiEvents.emit('queue:failed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start, error: error.message }));
         notifySafely(name, () => listeners?.failed?.(job, error));
-        results.push({ id: raw.id, status: 'failed', output: { message: error.message } });
+        // The raw Error, not a plucked message: bun-boss serializes an Error output with name/stack/cause intact, so
+        // the durable store keeps the full failure detail.
+        results.push({ id: raw.id, status: 'failed', output: error });
       }
     }
     return results;
@@ -470,6 +540,12 @@ function noStorageError(name: string): Error {
   );
 }
 
+function storageMismatchError(name: string, storage: MochiQueueStorage): Error {
+  return new Error(
+    `Mochi.queue("${name}"): the queue runtime is already connected to ${describeStorage(registry.storage)}, but this descriptor declares storage ${describeStorage(storage)}. One queue runtime per process — give every declaration of a queue the same storage.`,
+  );
+}
+
 /**
  * Make a descriptor's producer methods callable: a no-op when the queue is already mounted/ensured, otherwise the lazy
  * standalone path — boot a producer-only runtime against the descriptor's storage and ensure the queue exists.
@@ -477,38 +553,53 @@ function noStorageError(name: string): Error {
 async function ensureUsable(descriptor: MountableQueue): Promise<void> {
   const { name, storage } = descriptor;
   if (registry.boss && registry.byName.has(name)) {
+    // The hot-path early return still checks storage identity: a same-name descriptor declaring a different storage
+    // would otherwise silently write its jobs into whichever store connected first.
+    if (storage !== undefined && !storageEquals(registry.storage, storage)) {
+      throw storageMismatchError(name, storage);
+    }
     return;
   }
-  if (registry.starting) {
-    await registry.starting;
+  while (!registry.boss) {
+    if (registry.starting) {
+      await registry.starting.catch(() => {});
+      continue;
+    }
+    if (!storage) {
+      throw noStorageError(name);
+    }
+    await startQueueRuntime(storage, { kind: 'standalone' });
   }
-  if (!registry.boss) {
-    if (!storage) {
-      throw noStorageError(name);
-    }
-    registry.starting = startQueueRuntime(storage, { kind: 'standalone' }).finally(() => {
-      registry.starting = null;
-    });
-    await registry.starting;
-  } else if (!registry.byName.has(name)) {
-    if (registry.kind === 'serve') {
-      throw new Error(
-        `Mochi.queue("${name}"): this queue is not in this process's Mochi.serve({ queues }) array (mounted: ${[...registry.byName.keys()].join(', ') || 'none'}). One queue runtime per process — declare it there to produce to it here.`,
-      );
-    }
-    if (!storage) {
-      throw noStorageError(name);
-    }
+  assertProducibleUnderServe(name);
+  if (storage !== undefined) {
     if (!storageEquals(registry.storage, storage)) {
-      throw new Error(
-        `Mochi.queue("${name}"): a standalone queue runtime is already connected to ${describeStorage(registry.storage)}, but this queue declares storage ${describeStorage(storage)}. One queue runtime per process — give every standalone queue the same storage.`,
-      );
+      throw storageMismatchError(name, storage);
     }
+  } else if (!registry.byName.has(name)) {
+    throw noStorageError(name);
   }
   await ensureQueueExists(name, descriptor.options);
+  // Re-checked after the await: a serve boot may have adopted the runtime mid-ensure, and registering an undeclared
+  // producer past the adoption would make producibility depend on who won that race.
+  assertProducibleUnderServe(name);
   if (!registry.byName.has(name)) {
     registry.byName.set(name, producerMethods(name));
   }
+}
+
+function assertProducibleUnderServe(name: string): void {
+  if (registry.kind !== 'serve' || registry.byName.has(name)) {
+    return;
+  }
+  // Told apart by the startup milestone: during the boot window "not mounted" is transient, not a declaration error.
+  if (!startupMilestoneReached('mochi:queuesMounted')) {
+    throw new Error(
+      `Mochi.queue("${name}"): Mochi.serve() is still booting — queues mount right after the server binds. Add jobs from the "mochi:queuesMounted" hook (or "mochi:ready", or any request handler) onwards.`,
+    );
+  }
+  throw new Error(
+    `Mochi.queue("${name}"): this queue is not in this process's Mochi.serve({ queues }) array (mounted: ${[...registry.byName.keys()].join(', ') || 'none'}). One queue runtime per process — declare it there to produce to it here.`,
+  );
 }
 
 async function stopQueue(name: string): Promise<void> {
@@ -570,22 +661,39 @@ export function createQueueDescriptor<T = unknown, R = unknown>(name: string, co
     storage,
     options,
     async add(data, opts) {
+      // A `mochi-framework build` imports the app entry for real; adds are suppressed there so a build never connects
+      // to (or writes into) the app's production storage.
+      if (isBuilding) {
+        return null;
+      }
       await ensureUsable(descriptor);
       return base.add(data, opts);
     },
     async addBulk(jobs) {
+      if (isBuilding) {
+        return [];
+      }
       await ensureUsable(descriptor);
       return base.addBulk(jobs);
     },
     async addThrottled(data, seconds, key, opts) {
+      if (isBuilding) {
+        return null;
+      }
       await ensureUsable(descriptor);
       return base.addThrottled(data, seconds, key, opts);
     },
     async addDebounced(data, seconds, key, opts) {
+      if (isBuilding) {
+        return null;
+      }
       await ensureUsable(descriptor);
       return base.addDebounced(data, seconds, key, opts);
     },
     async stop() {
+      if (isBuilding) {
+        return;
+      }
       await stopQueue(name);
     },
   };
@@ -686,28 +794,29 @@ export function createWorker(queues: MountableQueue[], storage?: MochiQueueStora
       if (started) {
         throw new Error('Mochi.worker(): this worker was already started.');
       }
-      if (registry.kind === 'serve') {
-        throw new Error('Mochi.worker(): this process is serving — declare the queues in Mochi.serve({ queues }) instead.');
+      if (isBuilding) {
+        return;
       }
       if (!workerStorage) {
         throw new Error('Mochi.worker(): no storage declared. Give a queue descriptor (or the worker) a storage to connect to.');
       }
       started = true;
       try {
-        if (registry.starting) {
-          await registry.starting;
-        }
-        if (registry.boss) {
-          if (!storageEquals(registry.storage, workerStorage)) {
-            throw new Error(
-              `Mochi.worker(): the queue runtime is already connected to ${describeStorage(registry.storage)}, which is not this worker's storage ${describeStorage(workerStorage)}. An app has one queue storage.`,
-            );
+        while (!registry.boss) {
+          if (registry.starting) {
+            await registry.starting.catch(() => {});
+            continue;
           }
-        } else {
-          registry.starting = startQueueRuntime(workerStorage, { kind: 'standalone' }).finally(() => {
-            registry.starting = null;
-          });
-          await registry.starting;
+          await startQueueRuntime(workerStorage, { kind: 'standalone' });
+        }
+        // Checked after the boot loop on purpose: it also catches a racing Mochi.serve() that won an in-flight boot.
+        if (registry.kind === 'serve') {
+          throw new Error('Mochi.worker(): this process is serving — declare the queues in Mochi.serve({ queues }) instead.');
+        }
+        if (!storageEquals(registry.storage, workerStorage)) {
+          throw new Error(
+            `Mochi.worker(): the queue runtime is already connected to ${describeStorage(registry.storage)}, which is not this worker's storage ${describeStorage(workerStorage)}. An app has one queue storage.`,
+          );
         }
         const boss = requireBoss();
         for (const q of queues) {
@@ -772,6 +881,11 @@ export function getBoss(): BunBoss {
  * safe on both the serve shutdown path and the build drain path.
  */
 export async function closeAllQueueResources(): Promise<void> {
+  // A stop racing an in-flight lazy connect must wait for it, so the resulting runtime is torn down here rather than
+  // registering itself — live timers, open pool — after the stop reported done.
+  while (registry.starting) {
+    await registry.starting.catch(() => {});
+  }
   const { boss, ownedSql } = registry;
   // Cleared first so a fresh serve in this process (e.g. a test that restarts) can re-mount its queues even if a
   // close below fails.

--- a/packages/mochi/src/queueBuildFlag.test.ts
+++ b/packages/mochi/src/queueBuildFlag.test.ts
@@ -1,0 +1,34 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { Mochi } from './Mochi';
+import { getBoss } from './queue';
+import { markBuilding } from './utils/buildFlag';
+
+// Dedicated file: markBuilding() is irreversible for the process, so no other queue test can share it.
+const dataDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-queue-buildflag-'));
+
+afterAll(() => {
+  rmSync(dataDir, { recursive: true, force: true });
+});
+
+describe('queues during a mochi-framework build', () => {
+  test('adds are suppressed: no runtime boots, no storage is touched', async () => {
+    markBuilding();
+    const file = path.join(dataDir, 'never-created.sqlite');
+    const q = Mochi.queue<{ n: number }>('build-q', { storage: { sqlite: file } });
+
+    expect(await q.add({ n: 1 })).toBeNull();
+    expect(await q.addBulk([{ data: { n: 2 } }])).toEqual([]);
+    expect(await q.addThrottled({ n: 3 }, 60)).toBeNull();
+    expect(await q.addDebounced({ n: 4 }, 60)).toBeNull();
+    await q.stop();
+
+    const worker = Mochi.worker({ queues: [q] });
+    await worker.start();
+    await worker.stop();
+
+    expect(() => getBoss()).toThrow(/queue runtime is not running/);
+    expect(existsSync(file)).toBe(false);
+  });
+});

--- a/packages/mochi/src/queuePglite.test.ts
+++ b/packages/mochi/src/queuePglite.test.ts
@@ -28,17 +28,15 @@ describe('Mochi queue on pglite storage', () => {
 
     await startQueueRuntime({ pglite: db });
     await mountQueues([
-      [
-        'pglite-jobs',
-        {
-          process: async (job: MochiJob<{ n: number }>) => {
-            seen.push(job);
-            resolveDone();
-            return { ok: true };
-          },
-          options: { pollingIntervalSeconds: 0.5 },
+      {
+        name: 'pglite-jobs',
+        process: async (job: MochiJob<{ n: number }>) => {
+          seen.push(job);
+          resolveDone();
+          return { ok: true };
         },
-      ],
+        options: { pollingIntervalSeconds: 0.5 },
+      },
     ]);
 
     const jobId = await getQueue<{ n: number }>('pglite-jobs').add({ n: 41 });

--- a/packages/mochi/src/queuePostgres.test.ts
+++ b/packages/mochi/src/queuePostgres.test.ts
@@ -28,17 +28,15 @@ describe('Mochi queue on postgres storage', () => {
 
     await startQueueRuntime({ postgres: pg.url });
     await mountQueues([
-      [
-        'pg-jobs',
-        {
-          process: async (job: MochiJob<{ n: number }>) => {
-            seen.push(job);
-            resolveDone();
-            return { ok: true };
-          },
-          options: { pollingIntervalSeconds: 0.5 },
+      {
+        name: 'pg-jobs',
+        process: async (job: MochiJob<{ n: number }>) => {
+          seen.push(job);
+          resolveDone();
+          return { ok: true };
         },
-      ],
+        options: { pollingIntervalSeconds: 0.5 },
+      },
     ]);
 
     const jobId = await getQueue<{ n: number }>('pg-jobs').add({ n: 41 });

--- a/packages/mochi/src/queueStandalone.test.ts
+++ b/packages/mochi/src/queueStandalone.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { Mochi } from './Mochi';
+import { closeAllQueueResources, getBoss, getQueue, mountQueues, startQueueRuntime } from './queue';
+import { mochiEvents } from './events';
+import { initExtensions } from './extensions';
+import { resetStartupMilestones, startupMilestoneReached } from './lifecycle';
+
+const dataDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-queue-standalone-'));
+
+let counter = 0;
+const uniqueName = (): string => `standalone-${counter++}`;
+
+afterEach(async () => {
+  mochiEvents.all.clear();
+  resetStartupMilestones();
+  initExtensions({});
+  await closeAllQueueResources();
+});
+
+afterAll(async () => {
+  for (let attempt = 0; attempt < 25; attempt++) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+      return;
+    } catch {
+      await Bun.sleep(100);
+    }
+  }
+});
+
+describe('standalone queue producers', () => {
+  test('a descriptor without storage cannot produce outside serve', async () => {
+    const q = Mochi.queue<{ n: number }>(uniqueName());
+    expect(q.add({ n: 1 })).rejects.toThrow(/has no storage and no Mochi\.serve/);
+  });
+
+  test('the first add lazily connects a producer-only runtime', async () => {
+    const name = uniqueName();
+    const file = path.join(dataDir, 'lazy.sqlite');
+    const q = Mochi.queue<{ n: number }>(name, { storage: { sqlite: file } });
+    const added: unknown[] = [];
+    mochiEvents.on('queue:added', (e) => added.push(e));
+
+    const jobId = await q.add({ n: 1 });
+    expect(jobId).toBeString();
+    expect(added).toEqual([{ queue: name, jobId }]);
+
+    // Producer-only: the runtime is up, but no worker was registered, so the job just sits there.
+    expect(getBoss().getWipData()).toHaveLength(0);
+    const job = await getBoss().getJobById(name, jobId!);
+    expect(job?.state).toBe('created');
+
+    // The name-based lookup resolves the lazily-connected handle, and the serve milestone was never marked.
+    expect(getQueue(name).name).toBe(name);
+    expect(startupMilestoneReached('mochi:queuesMounted')).toBe(false);
+  });
+
+  test('concurrent first adds share one runtime boot', async () => {
+    const name = uniqueName();
+    const q = Mochi.queue<{ n: number }>(name, { storage: { sqlite: path.join(dataDir, 'race.sqlite') } });
+
+    const ids = await Promise.all([q.add({ n: 1 }), q.add({ n: 2 }), q.addBulk([{ data: { n: 3 } }])]);
+    expect(ids[0]).toBeString();
+    expect(ids[1]).toBeString();
+    expect(ids[2]).toHaveLength(1);
+    expect(typeof getBoss().send).toBe('function');
+  });
+
+  test('a second descriptor with different storage is rejected', async () => {
+    const first = Mochi.queue<{ n: number }>(uniqueName(), { storage: { sqlite: path.join(dataDir, 'first.sqlite') } });
+    await first.add({ n: 1 });
+
+    const other = Mochi.queue<{ n: number }>(uniqueName(), { storage: { sqlite: path.join(dataDir, 'other.sqlite') } });
+    expect(other.add({ n: 1 })).rejects.toThrow(/already connected to .* One queue runtime per process/);
+
+    // Same storage is fine — the runtime is shared.
+    const sibling = Mochi.queue<{ n: number }>(uniqueName(), { storage: { sqlite: path.join(dataDir, 'first.sqlite') } });
+    expect(await sibling.add({ n: 2 })).toBeString();
+  });
+
+  test('a standalone producer never re-syncs consumer-owned queue options', async () => {
+    const name = uniqueName();
+    const file = path.join(dataDir, 'noresync.sqlite');
+    // A consumer deployment mounts the queue with its own expiry/retry settings...
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name, options: { expireInSeconds: 42, retryLimit: 7 } }]);
+    expect((await getBoss().getQueue(name))?.expireInSeconds).toBe(42);
+    await closeAllQueueResources();
+
+    // ...then a bare producer (different options in code) enqueues: the stored options must survive untouched.
+    const producer = Mochi.queue<{ n: number }>(name, { storage: { sqlite: file }, expireInSeconds: 900, retryLimit: 1 });
+    await producer.add({ n: 1 });
+    const stored = await getBoss().getQueue(name);
+    expect(stored?.expireInSeconds).toBe(42);
+    expect(stored?.retryLimit).toBe(7);
+  }, 15_000);
+
+  test('Mochi.stop() tears down a standalone runtime without a server and is idempotent', async () => {
+    const name = uniqueName();
+    const q = Mochi.queue<{ n: number }>(name, { storage: { sqlite: path.join(dataDir, 'stop.sqlite') } });
+    await q.add({ n: 1 });
+    expect(typeof getBoss().send).toBe('function');
+
+    await Mochi.stop();
+    expect(() => getBoss()).toThrow(/queue runtime is not running/);
+    await expect(Mochi.stop()).resolves.toBeUndefined();
+
+    // A later add reconnects lazily — the registry was fully reset.
+    expect(await q.add({ n: 2 })).toBeString();
+    await Mochi.stop();
+  }, 15_000);
+});

--- a/packages/mochi/src/queueStandalone.test.ts
+++ b/packages/mochi/src/queueStandalone.test.ts
@@ -80,6 +80,41 @@ describe('standalone queue producers', () => {
     expect(await sibling.add({ n: 2 })).toBeString();
   });
 
+  test('a same-name descriptor with different storage is rejected even after the name is connected', async () => {
+    const name = uniqueName();
+    const q1 = Mochi.queue<{ n: number }>(name, { storage: { sqlite: path.join(dataDir, 'fast.sqlite') } });
+    await q1.add({ n: 1 });
+
+    // The fast path for an already-registered name must still catch the mismatch — the silent alternative writes
+    // this descriptor's jobs into q1's store.
+    const q2 = Mochi.queue<{ n: number }>(name, { storage: { sqlite: path.join(dataDir, 'fast-other.sqlite') } });
+    await expect(q2.add({ n: 2 })).rejects.toThrow(/already connected to .* One queue runtime per process/);
+    await expect(q2.addBulk([{ data: { n: 3 } }])).rejects.toThrow(/already connected to/);
+  });
+
+  test('Mochi.stop() racing an in-flight lazy connect tears the runtime down, not past it', async () => {
+    const q = Mochi.queue<{ n: number }>(uniqueName(), { storage: { sqlite: path.join(dataDir, 'stop-race.sqlite') } });
+    const addP = q.add({ n: 1 });
+    await Mochi.stop();
+    await addP.catch(() => {});
+    // Without waiting for the connect, the boot would register a live runtime (timers, open handles) after stop resolved.
+    expect(() => getBoss()).toThrow(/queue runtime is not running/);
+  });
+
+  test('a serve boot racing an in-flight lazy connect adopts the runtime instead of double-booting', async () => {
+    const name = uniqueName();
+    const file = path.join(dataDir, 'adopt-race.sqlite');
+    const q = Mochi.queue<{ n: number }>(name, { storage: { sqlite: file } });
+    const addP = q.add({ n: 1 });
+    await startQueueRuntime({ sqlite: file }, { kind: 'serve' });
+    await addP.catch(() => {});
+
+    // Adopted: one serve-owned runtime, so an unmounted queue cannot produce until mountQueues declares it.
+    await expect(q.add({ n: 2 })).rejects.toThrow(/still booting|not in this process/);
+    await mountQueues([{ name }]);
+    expect(await q.add({ n: 3 })).toBeString();
+  });
+
   test('a standalone producer never re-syncs consumer-owned queue options', async () => {
     const name = uniqueName();
     const file = path.join(dataDir, 'noresync.sqlite');

--- a/packages/mochi/src/queueStandalone.test.ts
+++ b/packages/mochi/src/queueStandalone.test.ts
@@ -97,6 +97,34 @@ describe('standalone queue producers', () => {
     expect(stored?.retryLimit).toBe(7);
   }, 15_000);
 
+  test('queue.stop() releases the queue and closes the runtime when it was the last one', async () => {
+    const file = path.join(dataDir, 'per-queue-stop.sqlite');
+    const first = Mochi.queue<{ n: number }>(uniqueName(), { storage: { sqlite: file } });
+    const second = Mochi.queue<{ n: number }>(uniqueName(), { storage: { sqlite: file } });
+    await first.add({ n: 1 });
+    await second.add({ n: 1 });
+
+    // Two queues share the runtime: stopping one leaves it up for the other.
+    await first.stop();
+    expect(typeof getBoss().send).toBe('function');
+    expect(() => getQueue(first.name)).toThrow();
+    expect(await second.add({ n: 2 })).toBeString();
+
+    await second.stop();
+    expect(() => getBoss()).toThrow(/queue runtime is not running/);
+
+    // Idempotent, and a later add lazily reconnects.
+    await expect(second.stop()).resolves.toBeUndefined();
+    expect(await first.add({ n: 3 })).toBeString();
+    await first.stop();
+  }, 15_000);
+
+  test('queue.stop() refuses in a serving process', async () => {
+    await startQueueRuntime('memory');
+    const q = Mochi.queue<{ n: number }>(uniqueName(), { storage: 'memory' });
+    expect(q.stop()).rejects.toThrow(/this process is serving/);
+  });
+
   test('Mochi.stop() tears down a standalone runtime without a server and is idempotent', async () => {
     const name = uniqueName();
     const q = Mochi.queue<{ n: number }>(name, { storage: { sqlite: path.join(dataDir, 'stop.sqlite') } });

--- a/packages/mochi/src/queueStandalonePglite.test.ts
+++ b/packages/mochi/src/queueStandalonePglite.test.ts
@@ -1,0 +1,44 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { PGlite } from '@electric-sql/pglite';
+import { Mochi } from './Mochi';
+import { closeAllQueueResources, getBoss, mountQueues, startQueueRuntime } from './queue';
+import { mochiEvents } from './events';
+import { resetStartupMilestones } from './lifecycle';
+
+// The standalone lazy-connect + no-resync contract on the embedded pglite backend, mirroring queueStandalone.test.ts's
+// sqlite coverage; the caller owns the PGlite instance, so this test closes it itself.
+describe('standalone queue producer on pglite storage', () => {
+  let db: PGlite;
+
+  afterAll(async () => {
+    mochiEvents.all.clear();
+    resetStartupMilestones();
+    await closeAllQueueResources();
+    await db?.close();
+  });
+
+  test('lazily connects producer-only and never re-syncs consumer-owned options', async () => {
+    db = await PGlite.create();
+
+    // A consumer deployment mounts the queue with its own settings first.
+    await startQueueRuntime({ pglite: db });
+    await mountQueues([{ name: 'pglite-standalone', options: { expireInSeconds: 42, retryLimit: 7 } }]);
+    expect((await getBoss().getQueue('pglite-standalone'))?.expireInSeconds).toBe(42);
+    await closeAllQueueResources();
+
+    // A bare producer's first add reconnects lazily, registers no worker, and leaves the stored options alone.
+    const producer = Mochi.queue<{ n: number }>('pglite-standalone', { storage: { pglite: db }, expireInSeconds: 900, retryLimit: 1 });
+    const jobId = await producer.add({ n: 1 });
+    expect(jobId).toBeString();
+    expect(getBoss().getWipData()).toHaveLength(0);
+    expect((await getBoss().getJobById('pglite-standalone', jobId!))?.state).toBe('created');
+    const stored = await getBoss().getQueue('pglite-standalone');
+    expect(stored?.expireInSeconds).toBe(42);
+    expect(stored?.retryLimit).toBe(7);
+
+    // Mochi.stop() drains the runtime but must not close the caller-owned instance.
+    await Mochi.stop();
+    const { rows } = await db.query<{ ok: number }>('SELECT 1 AS ok');
+    expect(rows[0]?.ok).toBe(1);
+  }, 30_000);
+});

--- a/packages/mochi/src/queueWorker.test.ts
+++ b/packages/mochi/src/queueWorker.test.ts
@@ -1,0 +1,118 @@
+import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { Mochi } from './Mochi';
+import { closeAllQueueResources, getBoss, mountQueues, startQueueRuntime } from './queue';
+import type { MochiJob } from './queue';
+import { mochiEvents } from './events';
+import { initExtensions } from './extensions';
+import { resetStartupMilestones } from './lifecycle';
+
+const dataDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-queue-worker-'));
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+afterEach(async () => {
+  mochiEvents.all.clear();
+  resetStartupMilestones();
+  initExtensions({});
+  await closeAllQueueResources();
+});
+
+afterAll(async () => {
+  for (let attempt = 0; attempt < 25; attempt++) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+      return;
+    } catch {
+      await Bun.sleep(100);
+    }
+  }
+});
+
+describe('Mochi.worker()', () => {
+  test('consumes a backlog enqueued by a standalone producer, then stop() halts consumption', async () => {
+    const file = path.join(dataDir, 'worker.sqlite');
+    const processed: number[] = [];
+    const twoDone = deferred<void>();
+    const queue = Mochi.queue<{ n: number }>('worker-jobs', {
+      storage: { sqlite: file },
+      pollingIntervalSeconds: 0.5,
+      process: async (job: MochiJob<{ n: number }>) => {
+        processed.push(job.data.n);
+        if (processed.length === 2) {
+          twoDone.resolve();
+        }
+      },
+    });
+
+    // Producer-only enqueue first: nothing consumes yet.
+    await queue.addBulk([{ data: { n: 1 } }, { data: { n: 2 } }]);
+
+    const worker = Mochi.worker({ queues: [queue] });
+    await worker.start();
+    await twoDone.promise;
+    expect(processed.toSorted()).toEqual([1, 2]);
+
+    await worker.stop();
+    const heldId = await queue.add({ n: 3 });
+    await Bun.sleep(1200);
+    expect(processed).toHaveLength(2);
+    expect((await getBoss().getJobById('worker-jobs', heldId!))?.state).toBe('created');
+  }, 20_000);
+
+  test('resolves storage from the worker option and rejects contradictions', async () => {
+    expect(() => Mochi.worker({ queues: [] })).toThrow(/at least one queue/);
+    expect(() => Mochi.worker({ queues: [Mochi.queue('a'), Mochi.queue('a')] })).toThrow(/two queues are named "a"/);
+    expect(() =>
+      Mochi.worker({
+        queues: [Mochi.queue('a', { storage: 'memory' }), Mochi.queue('b', { storage: { sqlite: path.join(dataDir, 'b.sqlite') } })],
+      }),
+    ).toThrow(/declare different storages/);
+    expect(() => Mochi.worker({ queues: [Mochi.queue('a', { storage: 'memory' })], storage: { sqlite: path.join(dataDir, 'c.sqlite') } })).toThrow(/declares a different storage/);
+
+    const worker = Mochi.worker({ queues: [Mochi.queue('storage-less')] });
+    expect(worker.start()).rejects.toThrow(/no storage declared/);
+  });
+
+  test('never re-syncs stored queue options and refuses a second start', async () => {
+    const file = path.join(dataDir, 'worker-noresync.sqlite');
+    // A serve-style deployment mounts the queue with its own settings first.
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'owned-jobs', options: { expireInSeconds: 42, retryLimit: 7 } }]);
+    await closeAllQueueResources();
+
+    const done = deferred<void>();
+    const worker = Mochi.worker({
+      queues: [
+        Mochi.queue('owned-jobs', {
+          pollingIntervalSeconds: 0.5,
+          expireInSeconds: 900,
+          retryLimit: 1,
+          process: async () => done.resolve(),
+        }),
+      ],
+      storage: { sqlite: file },
+    });
+    await worker.start();
+    expect(worker.start()).rejects.toThrow(/already started/);
+
+    await Mochi.getQueue<Record<string, never>>('owned-jobs').add({});
+    await done.promise;
+    const stored = await getBoss().getQueue('owned-jobs');
+    expect(stored?.expireInSeconds).toBe(42);
+    expect(stored?.retryLimit).toBe(7);
+  }, 20_000);
+
+  test('refuses to start in a serving process', async () => {
+    await startQueueRuntime('memory');
+    const worker = Mochi.worker({ queues: [Mochi.queue('served', { storage: 'memory' })] });
+    expect(worker.start()).rejects.toThrow(/this process is serving/);
+  });
+});

--- a/packages/mochi/src/queueWorker.test.ts
+++ b/packages/mochi/src/queueWorker.test.ts
@@ -65,6 +65,10 @@ describe('Mochi.worker()', () => {
     await Bun.sleep(1200);
     expect(processed).toHaveLength(2);
     expect((await getBoss().getJobById('worker-jobs', heldId!))?.state).toBe('created');
+
+    // Per-queue stop from a worker process: releases the last active queue, so the runtime closes with it.
+    await queue.stop();
+    expect(() => getBoss()).toThrow(/queue runtime is not running/);
   }, 20_000);
 
   test('resolves storage from the worker option and rejects contradictions', async () => {

--- a/packages/mochi/src/serveAdoptsStandalone.test.ts
+++ b/packages/mochi/src/serveAdoptsStandalone.test.ts
@@ -40,6 +40,7 @@ describe('Mochi.serve() over a standalone queue runtime', () => {
     // Standalone connect first (producer-only: nothing processes the job yet).
     await jobs.add({ n: 41 });
 
+    // The descriptor-vs-queueStorage contradiction rejects during validation, before the config singleton pins.
     await expect(
       Mochi.serve({
         port: 0,
@@ -50,7 +51,7 @@ describe('Mochi.serve() over a standalone queue runtime', () => {
         queueStorage: { sqlite: path.join(outDir, 'other.sqlite') },
         queues: [jobs],
       }),
-    ).rejects.toThrow(/standalone queue runtime is already connected/);
+    ).rejects.toThrow(/declares a different storage — an app has one queue storage/);
 
     // Same storage: serve adopts the running boss, mounts the worker, and the pre-added job drains.
     server = await Mochi.serve({

--- a/packages/mochi/src/serveAdoptsStandalone.test.ts
+++ b/packages/mochi/src/serveAdoptsStandalone.test.ts
@@ -1,0 +1,69 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+import { closeAllQueueResources } from './queue';
+import { resetStartupMilestones } from './lifecycle';
+
+// A producer script's lazy standalone runtime and a later Mochi.serve() in the same process: serve on the same
+// storage adopts the running boss (and its backlog); serve on a different storage must refuse.
+describe('Mochi.serve() over a standalone queue runtime', () => {
+  let server: Server<undefined> | undefined;
+  let outDir: string;
+
+  afterAll(async () => {
+    server?.stop(true);
+    await closeAllQueueResources();
+    resetStartupMilestones();
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('rejects a serve whose queueStorage differs from the connected standalone runtime', async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-serve-adopts-'));
+    const file = path.join(outDir, 'shared.sqlite');
+    const processed: Array<{ n: number }> = [];
+    let resolveProcessed!: () => void;
+    const firstProcessed = new Promise<void>((r) => {
+      resolveProcessed = r;
+    });
+
+    const jobs = Mochi.queue<{ n: number }>('adopted-jobs', {
+      storage: { sqlite: file },
+      pollingIntervalSeconds: 0.5,
+      process: async (job) => {
+        processed.push(job.data);
+        resolveProcessed();
+      },
+    });
+
+    // Standalone connect first (producer-only: nothing processes the job yet).
+    await jobs.add({ n: 41 });
+
+    await expect(
+      Mochi.serve({
+        port: 0,
+        development: false,
+        logger: { enabled: false },
+        outDir,
+        routes: {},
+        queueStorage: { sqlite: path.join(outDir, 'other.sqlite') },
+        queues: [jobs],
+      }),
+    ).rejects.toThrow(/standalone queue runtime is already connected/);
+
+    // Same storage: serve adopts the running boss, mounts the worker, and the pre-added job drains.
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      routes: {},
+      queueStorage: { sqlite: file },
+      queues: [jobs],
+    });
+
+    await firstProcessed;
+    expect(processed).toEqual([{ n: 41 }]);
+  }, 20_000);
+});

--- a/packages/mochi/src/serveQueues.test.ts
+++ b/packages/mochi/src/serveQueues.test.ts
@@ -1,11 +1,10 @@
-import { afterAll, describe, expect, spyOn, test } from 'bun:test';
+import { afterAll, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import type { Server } from 'bun';
 import { Mochi } from './Mochi';
 import { isMochiQueue } from './types';
 import { closeAllQueueResources } from './queue';
-import { logger } from './utils/log';
 import { reachedStartupMilestones, resetStartupMilestones } from './lifecycle';
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
@@ -128,7 +127,29 @@ describe('Mochi.serve({ queues })', () => {
     ).rejects.toThrow(/queueStorage/);
   });
 
-  test('mounts queues on sqlite storage, processes via the descriptor handle, and warns when a descriptor storage loses to serve', async () => {
+  test('rejects conflicting storage declarations before binding — an app has one queue storage', async () => {
+    expect(
+      Mochi.serve({
+        port: 0,
+        development: false,
+        logger: { enabled: false },
+        routes: {},
+        queues: [Mochi.queue('a', { storage: 'memory' }), Mochi.queue('b', { storage: { sqlite: 'other.sqlite' } })],
+      }),
+    ).rejects.toThrow(/"b" and "a" declare different storages/);
+    expect(
+      Mochi.serve({
+        port: 0,
+        development: false,
+        logger: { enabled: false },
+        routes: {},
+        queues: [Mochi.queue('a', { storage: 'memory' })],
+        queueStorage: { sqlite: 'other.sqlite' },
+      }),
+    ).rejects.toThrow(/"a" declares a different storage/);
+  });
+
+  test('mounts queues on the storage inherited from the descriptor and processes via its handle', async () => {
     outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-serve-queues-'));
     const sqliteFile = path.join(outDir, 'queue.sqlite');
     const processed: string[] = [];
@@ -136,8 +157,7 @@ describe('Mochi.serve({ queues })', () => {
 
     const jobs = Mochi.queue<{ to: string }>('serve-queue-jobs', {
       pollingIntervalSeconds: 0.5,
-      // Loses to the serve-level queueStorage below, which must produce a warning.
-      storage: 'memory',
+      storage: { sqlite: sqliteFile },
       process: async (job) => {
         processed.push(job.data.to);
         return { sent: true };
@@ -147,21 +167,15 @@ describe('Mochi.serve({ queues })', () => {
       },
     });
 
-    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
-    try {
-      server = await Mochi.serve({
-        port: 0,
-        development: false,
-        logger: { enabled: false },
-        outDir,
-        routes: {},
-        queueStorage: { sqlite: sqliteFile },
-        queues: [jobs],
-      });
-      expect(warn.mock.calls.flat().some((m) => String(m).includes('the serve-level queueStorage wins'))).toBe(true);
-    } finally {
-      warn.mockRestore();
-    }
+    // No queueStorage: serve inherits the descriptor's sqlite storage.
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      routes: {},
+      queues: [jobs],
+    });
 
     const jobId = await jobs.add({ to: 'alice' });
     expect(jobId).toBeString();

--- a/packages/mochi/src/serveQueues.test.ts
+++ b/packages/mochi/src/serveQueues.test.ts
@@ -1,10 +1,11 @@
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, describe, expect, spyOn, test } from 'bun:test';
 import { existsSync, mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import type { Server } from 'bun';
 import { Mochi } from './Mochi';
 import { isMochiQueue } from './types';
 import { closeAllQueueResources } from './queue';
+import { logger } from './utils/log';
 import { reachedStartupMilestones, resetStartupMilestones } from './lifecycle';
 
 function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
@@ -16,28 +17,40 @@ function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
 }
 
 describe('Mochi.queue descriptor', () => {
-  test('returns an inert config and does not start a queue', () => {
+  test('returns a named, inert descriptor and does not start a queue runtime', () => {
     const process = async (): Promise<{ ok: true }> => ({ ok: true });
-    const config = Mochi.queue({ process, concurrency: 3 });
+    const config = Mochi.queue('emails', { process, concurrency: 3 });
     expect(isMochiQueue(config)).toBe(true);
+    expect(config.name).toBe('emails');
     expect(config.process).toBe(process);
     expect(config.options).toEqual({ concurrency: 3 });
     expect(config.on).toBeUndefined();
+    // The descriptor is directly usable as a producer handle, but declaring it must not boot anything.
+    expect(typeof config.add).toBe('function');
+    expect(() => Mochi.boss()).toThrow(/queue runtime is not running/);
   });
 
-  test('splits `process` and `on` out of the runtime options', () => {
+  test('splits `process`, `on`, and `storage` out of the runtime options', () => {
     const completed = (): void => {};
-    const config = Mochi.queue({ process: async () => null, concurrency: 1, retryLimit: 4, on: { completed } });
-    // Anything left in `options` becomes bun-boss queue/worker configuration, so neither callback may leak through.
+    const config = Mochi.queue('split', { process: async () => null, concurrency: 1, retryLimit: 4, on: { completed }, storage: 'memory' });
+    // Anything left in `options` becomes bun-boss queue/worker configuration, so none of these may leak through.
     expect(config.options).toEqual({ concurrency: 1, retryLimit: 4 });
     expect(config.on?.completed).toBe(completed);
+    expect(config.storage).toBe('memory');
   });
 
   test('a processor-less descriptor is valid', () => {
-    const config = Mochi.queue({ deadLetter: 'other' });
+    const config = Mochi.queue('holding-pen', { deadLetter: 'other' });
     expect(isMochiQueue(config)).toBe(true);
     expect(config.process).toBeUndefined();
     expect(config.options).toEqual({ deadLetter: 'other' });
+  });
+
+  test('rejects an invalid name or batchSize at declaration', () => {
+    expect(() => Mochi.queue('bad name')).toThrow(/not a valid queue name/);
+    expect(() => Mochi.queue('q', { batchSize: 0 })).toThrow(/batchSize/);
+    expect(() => Mochi.queue('q', { batchSize: 1.5 })).toThrow(/batchSize/);
+    expect(() => Mochi.queue('q', { storage: { sqlite: '' } as never })).toThrow(/storage/);
   });
 });
 
@@ -52,26 +65,39 @@ describe('Mochi.serve({ queues })', () => {
     rmSync(outDir, { recursive: true, force: true });
   });
 
-  test('rejects a deadLetter naming a queue outside the map before binding', async () => {
+  test('rejects a deadLetter naming a queue outside the array before binding', async () => {
     expect(
       Mochi.serve({
         port: 0,
         development: false,
         logger: { enabled: false },
         routes: {},
-        queues: { orphan: Mochi.queue({ process: async () => null, deadLetter: 'not-declared' }) },
+        queues: [Mochi.queue('orphan', { process: async () => null, deadLetter: 'not-declared' })],
       }),
     ).rejects.toThrow(/names "not-declared" as its deadLetter queue/);
   });
 
-  test('rejects an invalid queue name before binding', async () => {
+  test('rejects duplicate queue names before binding', async () => {
     expect(
       Mochi.serve({
         port: 0,
         development: false,
         logger: { enabled: false },
         routes: {},
-        queues: { 'bad name': Mochi.queue({ process: async () => null }) },
+        queues: [Mochi.queue('dup', { process: async () => null }), Mochi.queue('dup')],
+      }),
+    ).rejects.toThrow(/two queues are named "dup"/);
+  });
+
+  test('rejects a hand-built descriptor with an invalid name before binding', async () => {
+    // Mochi.queue() validates at declaration, so only a hand-built object can smuggle a bad name this far.
+    expect(
+      Mochi.serve({
+        port: 0,
+        development: false,
+        logger: { enabled: false },
+        routes: {},
+        queues: [{ __mochiQueue: true, name: 'bad name' } as never],
       }),
     ).rejects.toThrow(/not a valid queue name/);
   });
@@ -83,7 +109,7 @@ describe('Mochi.serve({ queues })', () => {
         development: false,
         logger: { enabled: false },
         routes: {},
-        queues: { q: Mochi.queue({ process: async () => null }) },
+        queues: [Mochi.queue('q', { process: async () => null })],
         queueStorage: { sqlite: '' },
       }),
     ).rejects.toThrow(/queueStorage/);
@@ -96,48 +122,57 @@ describe('Mochi.serve({ queues })', () => {
         development: false,
         logger: { enabled: false },
         routes: {},
-        queues: { q: Mochi.queue({ process: async () => null }) },
+        queues: [Mochi.queue('q', { process: async () => null })],
         queueStorage: { sqlite: 'queue.sqlite', postgres: 'postgres://localhost/db' },
       }),
     ).rejects.toThrow(/queueStorage/);
   });
 
-  test('mounts a queue on sqlite storage that processes jobs and fires config.on listeners', async () => {
+  test('mounts queues on sqlite storage, processes via the descriptor handle, and warns when a descriptor storage loses to serve', async () => {
     outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-serve-queues-'));
     const sqliteFile = path.join(outDir, 'queue.sqlite');
-    const name = 'serve-queue-jobs';
     const processed: string[] = [];
     const completed = deferred<{ queue: string; result: unknown }>();
 
-    server = await Mochi.serve({
-      port: 0,
-      development: false,
-      logger: { enabled: false },
-      outDir,
-      routes: {},
-      queueStorage: { sqlite: sqliteFile },
-      queues: {
-        [name]: Mochi.queue<{ to: string }>({
-          pollingIntervalSeconds: 0.5,
-          process: async (job) => {
-            processed.push(job.data.to);
-            return { sent: true };
-          },
-          on: {
-            completed: (job, result) => completed.resolve({ queue: job.queue, result }),
-          },
-        }),
+    const jobs = Mochi.queue<{ to: string }>('serve-queue-jobs', {
+      pollingIntervalSeconds: 0.5,
+      // Loses to the serve-level queueStorage below, which must produce a warning.
+      storage: 'memory',
+      process: async (job) => {
+        processed.push(job.data.to);
+        return { sent: true };
+      },
+      on: {
+        completed: (job, result) => completed.resolve({ queue: job.queue, result }),
       },
     });
 
-    const jobId = await Mochi.getQueue<{ to: string }>(name).add({ to: 'alice' });
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      server = await Mochi.serve({
+        port: 0,
+        development: false,
+        logger: { enabled: false },
+        outDir,
+        routes: {},
+        queueStorage: { sqlite: sqliteFile },
+        queues: [jobs],
+      });
+      expect(warn.mock.calls.flat().some((m) => String(m).includes('the serve-level queueStorage wins'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+
+    const jobId = await jobs.add({ to: 'alice' });
     expect(jobId).toBeString();
 
     const done = await completed.promise;
     expect(processed).toEqual(['alice']);
-    expect(done.queue).toBe(name);
+    expect(done.queue).toBe('serve-queue-jobs');
     expect(done.result).toEqual({ sent: true });
     expect(existsSync(sqliteFile)).toBe(true);
+    // The name-based lookup resolves the same mounted queue.
+    expect(Mochi.getQueue('serve-queue-jobs').name).toBe('serve-queue-jobs');
   });
 
   test('Mochi.boss() resolves the shared bun-boss instance once queues are mounted', () => {

--- a/packages/mochi/src/serveStop.test.ts
+++ b/packages/mochi/src/serveStop.test.ts
@@ -1,0 +1,58 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+import { getBoss } from './queue';
+import { mochiEvents } from './events';
+import type { MochiServerStopEvent } from './events';
+import { reachedStartupMilestones } from './lifecycle';
+
+describe('Mochi.stop()', () => {
+  let outDir: string;
+
+  afterAll(() => {
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('stops the server and queue runtime without exiting the process', async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-serve-stop-'));
+    const stopEvents: MochiServerStopEvent[] = [];
+    const hookSignals: Array<unknown> = [];
+    mochiEvents.on('server:stop', (e) => stopEvents.push(e));
+
+    const jobs = Mochi.queue<{ n: number }>('stop-jobs', { process: async () => null });
+    const server: Server<undefined> = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      routes: {},
+      queueStorage: { sqlite: path.join(outDir, 'queue.sqlite') },
+      queues: [jobs],
+      shutdownTimeout: 0,
+      eventHooks: {
+        'mochi:shutdown': ({ signal }) => {
+          hookSignals.push(signal);
+        },
+      },
+    });
+    const url = `http://localhost:${server.port}/`;
+    expect((await fetch(url)).status).toBeGreaterThan(0);
+    expect(typeof getBoss().send).toBe('function');
+
+    await Mochi.stop();
+
+    // The hook saw a programmatic stop (no signal), the event says 'stop', and everything is torn down.
+    expect(hookSignals).toEqual([undefined]);
+    expect(stopEvents).toEqual([{ reason: 'stop' }]);
+    expect(() => getBoss()).toThrow(/queue runtime is not running/);
+    expect(reachedStartupMilestones()).toEqual([]);
+    expect(fetch(url)).rejects.toThrow();
+
+    // Idempotent: a second stop resolves without re-firing the hook or the event.
+    await expect(Mochi.stop()).resolves.toBeUndefined();
+    expect(hookSignals).toHaveLength(1);
+    expect(stopEvents).toHaveLength(1);
+  }, 15_000);
+});

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -252,14 +252,16 @@ export function isMochiSse(value: unknown): value is MochiSseConfig {
 }
 
 /**
- * Inert descriptor returned by `Mochi.queue()`. Non-generic so a heterogeneous `queues` map type-checks;
- * the live producer/consumer pair is created only when `Mochi.serve({ queues })` mounts it.
+ * Descriptor returned by `Mochi.queue(name, …)`. Non-generic so a heterogeneous `queues` array type-checks; the
+ * `never` parameter slots keep a caller's typed processor/listeners assignable (contravariance) without casts.
  */
 export interface MochiQueueConfig {
   readonly __mochiQueue: true;
-  readonly process?: MochiProcessor<unknown, unknown>;
+  readonly name: string;
+  readonly process?: MochiProcessor<never, unknown>;
   readonly options?: MochiQueueRuntimeOptions;
-  readonly on?: Partial<MochiQueueListeners<unknown, unknown>>;
+  readonly on?: Partial<MochiQueueListeners<never, never>>;
+  readonly storage?: MochiQueueStorage;
 }
 
 export function isMochiQueue(value: unknown): value is MochiQueueConfig {
@@ -429,10 +431,10 @@ export interface MochiServeOptions {
   manifest?: string;
   routes?: Record<string, MochiRouteValue>;
   /**
-   * Background job queues to start with the server, keyed by name; each value is a `Mochi.queue({ process, … })` descriptor.
-   * Add jobs from route code via `Mochi.getQueue(name).add(...)`. Queues drain gracefully on shutdown.
+   * Background job queues to start with the server: an array of `Mochi.queue(name, { process, … })` descriptors.
+   * Add jobs via the descriptor itself or `Mochi.getQueue(name)`. Queues drain gracefully on shutdown.
    */
-  queues?: Record<string, MochiQueueConfig>;
+  queues?: MochiQueueConfig[];
   /**
    * Where queue jobs live: `'memory'` (default — lost on restart), `{ sqlite: 'path/to.db' }` for a durable
    * single-process store, `{ postgres: url }` for a shared multi-process store (installed into a `mochi_queue` schema),

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -268,6 +268,13 @@ export function isMochiQueue(value: unknown): value is MochiQueueConfig {
   return typeof value === 'object' && value !== null && (value as MochiQueueConfig).__mochiQueue === true;
 }
 
+/** Options for `Mochi.worker()` — consume queues in a process that never calls `Mochi.serve()`. */
+export interface MochiWorkerOptions {
+  queues: MochiQueueConfig[];
+  /** The app's queue storage; may instead come from a `storage` declared on the descriptors. */
+  storage?: MochiQueueStorage;
+}
+
 export type MochiRouteValue = MochiPageConfig | MochiApiConfig | MochiWsConfig | MochiSseConfig | MochiFileConfig | BunRouteValue;
 
 /** `stack` is only populated when the server runs with `development: true`. */
@@ -439,6 +446,8 @@ export interface MochiServeOptions {
    * Where queue jobs live: `'memory'` (default — lost on restart), `{ sqlite: 'path/to.db' }` for a durable
    * single-process store, `{ postgres: url }` for a shared multi-process store (installed into a `mochi_queue` schema),
    * or `{ pglite: instance }` for an embedded in-process Postgres you construct and own (Mochi never closes it).
+   * Unset, it inherits a `storage` declared on the queue descriptors; an app has one queue storage, so conflicting
+   * declarations are a boot error.
    */
   queueStorage?: MochiQueueStorage;
   fetch?: (req: Request, server: Server<undefined>) => Response | Promise<Response>;

--- a/packages/mochi/src/utils/buildFlag.ts
+++ b/packages/mochi/src/utils/buildFlag.ts
@@ -1,9 +1,27 @@
 // A live-binding flag so `import { isBuilding }` reflects the value at access
-// time. `markBuilding()` is called by the build CLI (extractServeOptions) before
-// it executes the app entry, letting server-setup code skip real-boot side
-// effects during a `mochi-framework build`.
+// time. `markBuilding()` is called by the build CLI before it imports the app
+// entry, letting server-setup code skip real-boot side effects during a
+// `mochi-framework build`.
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { pinGlobal } from './globalState';
+
 export let isBuilding = false;
 
 export function markBuilding(): void {
   isBuilding = true;
+}
+
+// The dev watcher re-imports the entry inside the *running* server to hot-swap routes, so that import's side effects
+// must be suppressed without the process-wide flag — a sticky flag there would silently disable every queue add for the
+// rest of the dev session. Async-scoped rather than a toggle so a request adding a job mid-rebuild is unaffected.
+// Pinned for the same reason as the request context: duplicate bundled copies must share one instance.
+const entryImportScope = pinGlobal('__mochi_entry_import_scope__', () => new AsyncLocalStorage<true>());
+
+export function runInEntryImportScope<T>(fn: () => Promise<T>): Promise<T> {
+  return entryImportScope.run(true, fn);
+}
+
+/** True while a `mochi-framework build` runs, or while the app entry is being re-imported to extract its serve options. */
+export function isBuildingEntry(): boolean {
+  return isBuilding || entryImportScope.getStore() === true;
 }

--- a/packages/site/src/demos/queue/Queue.svelte
+++ b/packages/site/src/demos/queue/Queue.svelte
@@ -12,12 +12,13 @@
 
 <DemoPage
   title="Background jobs with queues"
-  description="A Mochi.queue() bundles a job channel with its process() consumer, declared once in the Mochi.serve() queues option. The form enqueues a job, the queue processes it ~700ms later, and the result streams back live."
+  description="A Mochi.queue(name) bundles a job channel with its process() consumer, declared once in the Mochi.serve() queues array. The form enqueues a job, the queue processes it ~700ms later, and the result streams back live."
   {sources}
 >
   <p>
-    The page action calls <code>Mochi.getQueue('demo-notifications').add({'{ user }'})</code>. The queue's <code>process</code> function — with
-    <code>concurrency: 2</code>, declared as <code>queues: {'{'} 'demo-notifications': … }</code> in
+    The page action calls <code>notificationQueue.add({'{ user }'})</code> on the descriptor returned by
+    <code>Mochi.queue('demo-notifications', …)</code>. Its <code>process</code> function — with
+    <code>concurrency: 2</code>, mounted via <code>queues: [notificationQueue]</code> in
     <code>Mochi.serve()</code> — picks the job up and records it. Initial state comes from
     <code>serverProps</code>; a <code>Mochi.sse()</code> route then pushes each completion in realtime — no polling.
   </p>

--- a/packages/site/src/demos/queue/queue.server.ts
+++ b/packages/site/src/demos/queue/queue.server.ts
@@ -1,5 +1,4 @@
 import { Mochi, mochiEvents } from 'mochi-framework';
-import type { MochiQueueConfig } from 'mochi-framework';
 import type { NotificationJob, ProcessedEntry, QueueStatus } from './types';
 
 export const QUEUE_NAME = 'demo-notifications';
@@ -24,7 +23,7 @@ mochiEvents.on('queue:failed', settle);
 
 // The site rides the default `queueStorage: 'memory'`, so the demo writes no queue file into the working dir;
 // set `Mochi.serve({ queueStorage })` to persist.
-export const notificationQueue: MochiQueueConfig = Mochi.queue<NotificationJob>({
+export const notificationQueue = Mochi.queue<NotificationJob>(QUEUE_NAME, {
   concurrency: 2,
   process: async (job) => {
     // Simulate delivery latency so the UI shows the queued → processing → done transition.

--- a/packages/site/src/demos/queue/routes.ts
+++ b/packages/site/src/demos/queue/routes.ts
@@ -1,13 +1,10 @@
 import { Mochi, success, mochiEvents } from 'mochi-framework';
 import type { MochiRouteValue, MochiQueueConfig } from 'mochi-framework';
 import { notificationQueue, queueStatus, QUEUE_NAME } from './queue.server';
-import type { NotificationJob } from './types';
 import { randomUsername } from './usernames';
 
 // Mounted in the site's Mochi.serve({ queues }) call — see src/routes.ts.
-export const queues: Record<string, MochiQueueConfig> = {
-  [QUEUE_NAME]: notificationQueue,
-};
+export const queues: MochiQueueConfig[] = [notificationQueue];
 
 export const routes: Record<string, MochiRouteValue> = {
   '/demos/queue': Mochi.page('./src/demos/queue/Queue.svelte', {
@@ -20,7 +17,7 @@ export const routes: Record<string, MochiRouteValue> = {
         const user = String(formData.get('username') ?? '')
           .trim()
           .slice(0, 64);
-        await Mochi.getQueue<NotificationJob>(QUEUE_NAME).add({ user: user || 'anonymous' });
+        await notificationQueue.add({ user: user || 'anonymous' });
         return success({ queued: user || 'anonymous' });
       },
     },

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -365,6 +365,4 @@ export const routes: Record<string, MochiRouteValue> = {
 };
 
 // Background job queues, mounted in Mochi.serve({ queues }) (see src/index.ts).
-export const queues: Record<string, MochiQueueConfig> = {
-  ...queueQueues,
-};
+export const queues: MochiQueueConfig[] = [...queueQueues];

--- a/packages/support/src/index.ts
+++ b/packages/support/src/index.ts
@@ -3,7 +3,7 @@ import type { MochiEmailTransportConfig } from 'mochi-framework';
 import { analytics } from 'mochi-shared';
 import { routes } from './routes';
 import { adminAuth } from './adminAuth';
-import { SUPPORT_EMAIL_QUEUE, supportEmailQueue } from './jobs.server';
+import { supportEmailQueue } from './jobs.server';
 
 const PORT = Number(process.env.PORT) || 3336;
 const DEVELOPMENT = process.env.MODE === 'development';
@@ -35,7 +35,7 @@ await Mochi.serve({
   proxy: { origin: ORIGIN, addressHeader: 'x-forwarded-for', xffDepth: 1 },
   // Auth first, so an unauthorised /admin hit is never counted as a pageview.
   handle: sequence(adminAuth, analytics()),
-  queues: { [SUPPORT_EMAIL_QUEUE]: supportEmailQueue },
+  queues: [supportEmailQueue],
   // A separate file from SUPPORT_DB on purpose: the app holds its own bun:sqlite handle on support.sqlite, and sharing
   // one file across two drivers invites writer contention for no benefit.
   queueStorage: { sqlite: process.env.SUPPORT_QUEUE_DB || '.db/queue.sqlite' },

--- a/packages/support/src/jobs.server.ts
+++ b/packages/support/src/jobs.server.ts
@@ -1,5 +1,4 @@
 import { Mochi, logger } from 'mochi-framework';
-import type { MochiQueueConfig } from 'mochi-framework';
 import { appendEmailLog, getSubmission, markEmailFailed, markEmailSent, noteEmailAttemptError } from './db.server';
 
 export const SUPPORT_TO = process.env.SUPPORT_TO || 'support@mochi.fast';
@@ -15,7 +14,7 @@ export interface SupportEmailJob {
 
 // Jobs live in the durable queue store (`queueStorage: { sqlite }` in index.ts), so an email queued before a crash or
 // restart is retried from there — the submissions table only tracks delivery status for the admin panel.
-export const supportEmailQueue: MochiQueueConfig = Mochi.queue<SupportEmailJob>({
+export const supportEmailQueue = Mochi.queue<SupportEmailJob>(SUPPORT_EMAIL_QUEUE, {
   concurrency: 2,
   retryLimit: MAX_ATTEMPTS - 1,
   retryDelay: 5,

--- a/packages/support/src/routes.ts
+++ b/packages/support/src/routes.ts
@@ -2,8 +2,7 @@ import { Mochi, fail, redirect, success, logger, mintCaptcha, verifyCaptcha, con
 import type { MochiRouteValue } from 'mochi-framework';
 import { authFailureDelay, credentialsMatch } from './adminAuth';
 import { appendEmailLog, emailLogsBySubmission, insertSubmission, listSubmissions, setHandled } from './db.server';
-import { SUPPORT_EMAIL_QUEUE, SUPPORT_TO } from './jobs.server';
-import type { SupportEmailJob } from './jobs.server';
+import { SUPPORT_TO, supportEmailQueue } from './jobs.server';
 
 export const routes: Record<string, MochiRouteValue> = {
   '/': Mochi.page('./src/Support.svelte', {
@@ -45,7 +44,7 @@ export const routes: Record<string, MochiRouteValue> = {
         // Logged before enqueuing so the entry can't be ordered after the worker's own `sending` line.
         appendEmailLog(id, { attempt: 0, event: 'queued', detail: `Queued for delivery to ${SUPPORT_TO}` });
         try {
-          await Mochi.getQueue<SupportEmailJob>(SUPPORT_EMAIL_QUEUE).add({ id });
+          await supportEmailQueue.add({ id });
         } catch (err) {
           // The row stays `pending` and visible in the admin panel for manual follow-up — telling the visitor it failed would be wrong.
           logger.error('support: could not enqueue delivery', err);

--- a/packages/support/src/support.test.ts
+++ b/packages/support/src/support.test.ts
@@ -14,7 +14,7 @@ process.env.ADMIN_PASSWORD = 'letmein';
 process.env.ADMIN_AUTH_DELAY_MS = '80';
 
 const { routes } = await import('./routes');
-const { SUPPORT_EMAIL_QUEUE, supportEmailQueue } = await import('./jobs.server');
+const { supportEmailQueue } = await import('./jobs.server');
 const { closeDb, emailLogsBySubmission, listSubmissions } = await import('./db.server');
 const { adminAuth } = await import('./adminAuth');
 
@@ -83,7 +83,7 @@ describe('support form action', () => {
         },
       },
       handle: adminAuth,
-      queues: { [SUPPORT_EMAIL_QUEUE]: supportEmailQueue },
+      queues: [supportEmailQueue],
       // Mirrors src/index.ts's durable storage; the file joins the temp dir the afterAll retry-loop already cleans up.
       queueStorage: { sqlite: path.join(outDir, 'queue.sqlite') },
       routes,


### PR DESCRIPTION
Incorporates the wp-metrics bulk-ingest feedback on `Mochi.queue()` (105k-job pipeline: worker tuning unreachable, enqueueing required a full server, plus three paper cuts). Lands the queue API rework announced for 0.10.0 on the docs page.

## Breaking changes

- `Mochi.queue(options)` → **`Mochi.queue(name, options)`** — the name moves into the descriptor, which is now directly usable as a producer handle (`add` / `addBulk` / `addThrottled` / `addDebounced`).
- `Mochi.serve({ queues })` takes an **array of descriptors** instead of a `{name: config}` map.
- `MochiQueueConfig` gains `name` / `storage` and its callback slots use `never`-variance (typed descriptors assign without casts).
- `mochi:shutdown` hook context: `signal` is now optional (absent on programmatic `Mochi.stop()`).
- `server:stop` event: `reason` is now `'signal' | 'stop'`.

## Features

- **Worker tuning (hybrid).** First-class `batchSize` + `burst` on the queue options; `worker:` escape hatch (`MochiWorkerTuning`, Mochi-owned mirror — no bun-boss types on the public surface) for the inert fetch extras (`orderByCreatedOn`, `minPriority`, `notifyPollingIntervalSeconds`, …). Mochi-owned keys always win. With `batchSize > 1` the handler registers with `perJobResults: true` and iterates jobs sequentially — one throw fails and retries only that job, siblings complete, per-job events unchanged. `burst: true` with `batchSize: 1` warns (bun-boss ignores it).
- **Standalone producers.** A descriptor with `storage` lazily connects a producer-only runtime on first `add()` — no port, no workers, ensure-only queue creation and **no option re-sync** (producers never rewrite consumer-owned options). One runtime per process (a second distinct storage throws). `Mochi.serve()` on the same storage adopts a connected standalone runtime; on a different storage it rejects during fail-fast validation, before the singleton pins or the port binds.
- **`Mochi.stop()`.** Public graceful teardown (`mochi:shutdown` hook → queue drain → server stop) without `process.exit`; the signal handlers now route through the same path. Works serverless (closes just the standalone queue runtime). Idempotent.
- **`expireInSeconds` re-sync fix.** Only sent when declared or overridden by the `queue:expireInSeconds` filter — a bare mount on shared durable storage no longer silently resets a custom expiry to 900. Fresh queues still get bun-boss's own 900 default.
- **`addBulk` log volume.** New `queue:addedBulk` event (one per call, `{queue, count, jobIds}`); per-job `queue:added` events keep firing (now flagged `bulk: true`) for programmatic subscribers, but the console logger prints only the one summary line — a 105k-job `addBulk` logs once.

## Migration

```ts
// before
Mochi.serve({ queues: { emails: Mochi.queue({ process }) } });
await Mochi.getQueue('emails').add({ to });

// after
export const emails = Mochi.queue('emails', { process });
Mochi.serve({ queues: [emails] });
await emails.add({ to });      // Mochi.getQueue('emails') still works
```

Deployments relying on the accidental expiry reset-to-900 will now keep stored values — declare `expireInSeconds` explicitly to change it.

## Consumers migrated

`packages/site` queue demo (now dogfoods the descriptor handle) and `packages/support`.

## Verification

- `bun run checks` green (lint, format, typecheck, tests across all workspaces; 163 mochi test files).
- New test files: `queueStandalone.test.ts`, `queueStandalonePglite.test.ts`, `serveStop.test.ts`, `serveAdoptsStandalone.test.ts`; new coverage in `queue.test.ts` (per-job batch settlement, worker-option precedence, burst warning, expiry re-sync trio, bulk events) and `serveQueues.test.ts` (duplicate names, declaration-time validation, storage-mismatch warning).
- Browser-validated the queue demo on the dev site (enqueue → process → SSE update, clean console) and all touched docs pages render.

Docs: `115-queues.md` rewritten (standalone producers, batch processing, worker tuning, `Mochi.stop()`); `147-events.md`, `160-serve-options.md`, `162-extensions.md`, `116-email.md` updated.
