### PR TITLE
chore(deps): bump bun-boss to 0.2.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
         "@joint-ops/hitlimit-bun": "1.5.0",
         "@noble/ciphers": "2.2.0",
         "@noble/hashes": "2.2.0",
-        "bun-boss": "^0.2.1",
+        "bun-boss": "^0.2.4",
         "chokidar": "^5.0.0",
         "deepmerge": "^4.3.1",
         "devalue": "^5.9.0",
@@ -683,7 +683,7 @@
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
-    "bun-boss": ["bun-boss@0.2.1", "", { "dependencies": { "@types/bun": "^1.3.14", "croner": "^10.0.1" } }, "sha512-n27NwlZ8WDe0i+zP3pCpQm0ufSeJaSW4aHNg3GkA64ofvpPawyno/gt0Orrck8Lf8pu7J/iXPwzMchJM6r4A6w=="],
+    "bun-boss": ["bun-boss@0.2.4", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-JZpAyGc4Wds9w7MBXRnPch4bWJlFZuX6nat4lDZfGHS2tvB0+JBzcLWzn27UGuyOrO8OeLJO62dXKGym/xzoNw=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -106,7 +106,7 @@
     "@joint-ops/hitlimit-bun": "1.5.0",
     "@noble/ciphers": "2.2.0",
     "@noble/hashes": "2.2.0",
-    "bun-boss": "^0.2.1",
+    "bun-boss": "^0.2.4",
     "chokidar": "^5.0.0",
     "deepmerge": "^4.3.1",
     "devalue": "^5.9.0",


### PR DESCRIPTION
Bumps `bun-boss` in `packages/mochi` from `^0.2.1` to `^0.2.4`.

Upstream: [khromov/bun-boss#44](https://github.com/khromov/bun-boss/pull/44) — the only substantive change since 0.2.1 in this range is moving `@types/bun` out of production dependencies into dev dependencies (bun-boss#43). It is now declared as an optional peer (`>=1.3.14`), which `packages/mochi`'s existing `@types/bun` devDependency (`1.3.14`) satisfies. Net effect for us is one fewer transitive prod dep.

No source changes were needed — `packages/mochi/src/queue.ts` (the sole `bun-boss` importer) is unaffected.

## Verification

- `bun run checks` (lint:fix + format + typecheck + test) — pass; 0 TS errors across all 9 workspaces, 155/155 mochi-framework test files green, including `queue.test.ts`, `queuePglite.test.ts`, `queuePostgres.test.ts`, and `serveQueues.test.ts`.
- `bun run syncpack` — no issues found.