### PR TITLE
fix(queues): floor the batch-deadline reserve at 250ms

### DIFF
--- a/packages/mochi/src/queue.test.ts
+++ b/packages/mochi/src/queue.test.ts
@@ -524,12 +524,13 @@ describe('Mochi queue', () => {
         process: async (job: MochiJob<{ n: number }>) => {
           runs.push(job.data.n);
           if (job.data.n === 2) {
-            await Bun.sleep(1_500);
+            await Bun.sleep(4_500);
           }
           return { n: job.data.n };
         },
-        // bun-boss times the whole batch out at max(expireInSeconds)=1s; job 2 alone outlives it.
-        options: { batchSize: 3, retryLimit: 0, expireInSeconds: 1, pollingIntervalSeconds: 0.5 },
+        // bun-boss times the whole batch out at max(expireInSeconds)=4s; job 2 alone outlives it. The budget is
+        // seconds-scale (not 1s) so the early settle beats bun-boss's wholesale timeout even on slow CI runners.
+        options: { batchSize: 3, retryLimit: 0, expireInSeconds: 4, pollingIntervalSeconds: 0.5 },
       },
     });
 

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -420,6 +420,8 @@ function batchDeadline(batch: JobWithMetadata<unknown>[]): number {
   return performance.now() + budgetMs - Math.min(1_000, Math.max(250, budgetMs * 0.1));
 }
 
+class BatchDeadlineExceeded extends Error {}
+
 async function withDeadline<R>(work: R | Promise<R>, deadlineAt: number, onTimeout: () => Error): Promise<R> {
   if (deadlineAt === Infinity) {
     return work;
@@ -441,6 +443,9 @@ function makeHandler<T, R>(name: string, process: MochiProcessor<T, R>, listener
   return async (batch: JobWithMetadata<T>[]): Promise<JobResult[]> => {
     const results: JobResult[] = [];
     const deadlineAt = batchDeadline(batch);
+    // Latched on the first deadline rejection rather than re-read from the clock: the timer can fire a fraction of a
+    // millisecond before `deadlineAt`, and a clock comparison would let the next job sneak in past an expired budget.
+    let expired = false;
     for (const raw of batch) {
       const job: MochiJob<T> = {
         id: raw.id,
@@ -451,7 +456,8 @@ function makeHandler<T, R>(name: string, process: MochiProcessor<T, R>, listener
         enqueuedAt: new Date(raw.createdOn).getTime(),
       };
       const start = performance.now();
-      if (start >= deadlineAt) {
+      if (expired || start >= deadlineAt) {
+        expired = true;
         const error = new Error(`the batch's shared expireInSeconds budget ran out before this job started; it is failed for retry`);
         notifySafely(name, () => mochiEvents.emit('queue:failed', { queue: name, jobId: job.id, attempt: job.attempt, duration: 0, error: error.message }));
         notifySafely(name, () => listeners?.failed?.(job, error));
@@ -464,13 +470,16 @@ function makeHandler<T, R>(name: string, process: MochiProcessor<T, R>, listener
         const result = await withDeadline(
           process(job),
           deadlineAt,
-          () => new Error(`the batch's shared expireInSeconds budget ran out mid-job; it is failed for retry (its processor may still be running)`),
+          () => new BatchDeadlineExceeded(`the batch's shared expireInSeconds budget ran out mid-job; it is failed for retry (its processor may still be running)`),
         );
         notifySafely(name, () => mochiEvents.emit('queue:completed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start }));
         notifySafely(name, () => listeners?.completed?.(job, result));
         results.push({ id: raw.id, status: 'completed', output: result });
       } catch (err) {
         const error = err instanceof Error ? err : new Error(String(err));
+        if (error instanceof BatchDeadlineExceeded) {
+          expired = true;
+        }
         notifySafely(name, () => mochiEvents.emit('queue:failed', { queue: name, jobId: job.id, attempt: job.attempt, duration: performance.now() - start, error: error.message }));
         notifySafely(name, () => listeners?.failed?.(job, error));
         // The raw Error, not a plucked message: bun-boss serializes an Error output with name/stack/cause intact, so

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -415,7 +415,9 @@ function batchDeadline(batch: JobWithMetadata<unknown>[]): number {
   if (budgetMs <= 0) {
     return Infinity;
   }
-  return performance.now() + budgetMs - Math.min(1_000, budgetMs * 0.1);
+  // The reserve is floored at 250ms: for second-scale budgets a pure 10% leaves the settle racing bun-boss's own
+  // timeout within OS timer jitter, and losing that race fails completed siblings wholesale.
+  return performance.now() + budgetMs - Math.min(1_000, Math.max(250, budgetMs * 0.1));
 }
 
 async function withDeadline<R>(work: R | Promise<R>, deadlineAt: number, onTimeout: () => Error): Promise<R> {


### PR DESCRIPTION
Follow-up to #282, which merged while this fix was in flight (it landed on the deleted branch's orphan recreation instead).

On second-scale expiry budgets, the batch handler's early-settle reserve was `min(1s, 10%)` — for the test's 1s budget that is a 100ms race against bun-boss's wholesale batch timeout, within OS timer jitter. On the slowest CI leg (**Windows + Bun canary**) the wholesale timeout won, failing already-completed siblings and hanging `queue.test.ts`'s 'batch outliving the shared expiry budget' test to its 15s timeout ([failing job](https://github.com/khromov/mochi/actions/runs/31329675158/job/93285784425)).

Fix: reserve is now `min(1s, max(250ms, 10%))`, and the test uses a 4s budget (400ms margin) instead of the knife-edge 1s.