### PR TITLE
Persist site image cache to a mountable volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,6 +70,13 @@ ENV WORKSPACE=${WORKSPACE}
 ENV PORT=${PORT}
 ENV MOCHI_LIVE_RELOAD=false
 ENV MOCHI_DOCKER=true
+
+# Dedicated, mountable image-transform cache — kept out of .mochi (whose dev
+# build cache is wiped on every boot). Pre-created + chowned so a mounted volume
+# inherits bun:bun; the site reads MOCHI_IMAGE_CACHE_DIR for image.cacheDir.
+ENV MOCHI_IMAGE_CACHE_DIR=/data/image-cache
+RUN mkdir -p /data/image-cache && chown -R bun:bun /data
+
 USER bun
 EXPOSE ${PORT}/tcp
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -99,6 +99,11 @@ RUN apk add --no-cache ncdu
 # named volume mounted here inherits bun:bun instead of root.
 RUN mkdir -p packages/${WORKSPACE}/.db && chown bun:bun packages/${WORKSPACE}/.db
 
+# Dedicated, mountable image-transform cache — pre-created + chowned so a mounted
+# volume inherits bun:bun; an app reads MOCHI_IMAGE_CACHE_DIR for image.cacheDir.
+ENV MOCHI_IMAGE_CACHE_DIR=/data/image-cache
+RUN mkdir -p /data/image-cache && chown -R bun:bun /data
+
 USER bun
 EXPOSE ${PORT}/tcp
 ENTRYPOINT [ "sh", "-c", "exec bun --cwd=packages/$WORKSPACE run start" ]

--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -52,6 +52,37 @@ The manifest records a schema version, and the runtime loads only the exact vers
 
 </Callout>
 
+## Persistent image cache
+
+Mochi's [image cache](/docs/images/) is written to disk under `cacheDir` (default `./.mochi/image-cache`). In a container that directory is recreated on every restart, so each redeploy starts with a cold cache and re-fetches and re-transforms every image. To keep the transformed bytes across restarts, point `cacheDir` at a dedicated path and mount a volume there:
+
+```ts
+Mochi.serve({
+  image: { cacheDir: process.env.MOCHI_IMAGE_CACHE_DIR /* , sizes: … */ },
+});
+```
+
+```yaml
+services:
+  site:
+    image: your-app
+    environment:
+      MOCHI_IMAGE_CACHE_DIR: /data/image-cache
+    volumes:
+      - image-cache:/data/image-cache
+
+volumes:
+  image-cache:
+```
+
+A plain `docker run -v image-cache:/data/image-cache your-app` mounts the same volume. Keep the mount off `./.mochi` — its build cache is rebuilt on every boot and must not persist. If the container runs as a non-root user, pre-create the directory owned by that user in your `Dockerfile` so the mounted volume is writable.
+
+<Callout type="info">
+
+Keep `MOCHI_KEY` stable across restarts. Image URLs are signed with a key derived from it, so a changed key invalidates already-minted links even though the cached bytes are still on disk.
+
+</Callout>
+
 ## PaaS
 
 Deploy code or containers. The platform manages infrastructure, scaling, and networking.

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -157,6 +157,9 @@ await Mochi.serve({
   // Named image sizes used by the /demos/image* pages (kept in sync with the
   // example shown in ./src/demoIndex.ts).
   image: {
+    // Persist transformed bytes to a mountable volume in containers; unset locally
+    // falls back to the framework default (./.mochi/image-cache).
+    cacheDir: process.env.MOCHI_IMAGE_CACHE_DIR,
     // The image-invalidation demo sources from our own loopback endpoint, which the
     // SSRF guard would otherwise reject as a private address. Safe here: every image
     // src on this site is hardcoded and server-minted (encrypted URLs), never taken

--- a/packages/site/src/lib/highlight.server.ts
+++ b/packages/site/src/lib/highlight.server.ts
@@ -15,7 +15,7 @@ export const highlightCode = pinGlobal('__mochi_site_highlight__', () => {
   const shiki = createShiki({
     ...(engine ? { engine } : {}),
     themes: [mochiTheme],
-    langs: ['bash', 'css', 'dockerfile', 'html', 'javascript', 'json', 'plaintext', 'svelte', 'toml', 'typescript', 'xml'],
+    langs: ['bash', 'css', 'dockerfile', 'html', 'javascript', 'json', 'plaintext', 'svelte', 'toml', 'typescript', 'xml', 'yaml'],
   });
   return createHighlighter((code, lang) =>
     shiki.then((s) =>


### PR DESCRIPTION
## What & why

The site's on-the-fly image cache is written to disk under `cacheDir` (default `./.mochi/image-cache`, so `packages/site/.mochi/image-cache` in the container). That directory is stripped from the build context by `.dockerignore` and recreated fresh on every boot, so **every container restart/redeploy starts with a cold image cache** — each image is re-fetched, re-decoded and re-transformed on the next request.

This makes the cache directory point at a dedicated, mountable path so the transformed bytes can survive restarts, kept separate from `.mochi` (whose dev build cache is wiped on every boot and must **not** persist).

## Changes

- **`packages/site/src/index.ts`** — image `cacheDir: process.env.MOCHI_IMAGE_CACHE_DIR`. Unset locally → falls back to the framework default (`resolveImageOptions` does `cacheDir ?? './.mochi/image-cache'`), so local dev is unchanged.
- **`Dockerfile`** (dev-mode; the image the site deploys from) — `ENV MOCHI_IMAGE_CACHE_DIR=/data/image-cache` + pre-create `/data/image-cache` owned by `bun` so a mounted volume inherits `bun:bun` (follows the existing `.db` precedent). No `VOLUME` instruction — it would create accumulating anonymous volumes on the CI smoke-test run; the mount is supplied at run time.
- **`Dockerfile.production`** — same two lines, to keep the pair in sync (harmless for `minimal`/`support`, which have no image config).
- **`packages/docs/184-deployment.md`** — a short "Persistent image cache" section with the `Mochi.serve()` config and a minimal `docker-compose.yml` example.
- **`packages/site/src/lib/highlight.server.ts`** — register the `yaml` grammar so the compose fence in the docs highlights (the SSR build otherwise fails with "Language `yaml` not found").

## How to enable a persistent mount

```yaml
services:
  site:
    image: your-app
    environment:
      MOCHI_IMAGE_CACHE_DIR: /data/image-cache
    volumes:
      - image-cache:/data/image-cache

volumes:
  image-cache:
```

Keep `MOCHI_KEY` stable across restarts so previously-minted signed image URLs keep resolving.

## Verification

- Local `bun run dev:site`: `/demos/image/` → 200, cache still writes to the default `packages/site/.mochi/image-cache` (env unset), `/docs/deployment-options/` renders the new section with YAML highlighting.
- `resolveImageOptions`: unset/`undefined` → `./.mochi/image-cache`; `/data/image-cache` → honored.
- Relying on GitHub CI for lint / format / typecheck / test.