### PR TITLE
test(runner): tolerate Bun's post-pass shutdown wedge on Windows

### DIFF
--- a/packages/mochi/src/cli/testing.test.ts
+++ b/packages/mochi/src/cli/testing.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { extractFailures, parseJunitSummary, toleratedWindowsWedge } from './testing';
 
 // Verbatim `bun test` reporter output (v1.3): the source snippet and `error:` block
@@ -153,5 +156,59 @@ describe('toleratedWindowsWedge', () => {
 
   test('false for a win32 timeout that never wrote a report', () => {
     expect(toleratedWindowsWedge(true, null, 'win32')).toBe(false);
+  });
+});
+
+// Spawns real `bun test` children to pin the Bun behavior the wedge tolerance relies on: the junit report is written
+// only at the end of a completed run, so it can never green-light a process that was killed or that recorded a failure.
+describe('junit report as a completion sentinel', () => {
+  async function junitAfterRun(source: string, { killAfterMs }: { killAfterMs?: number } = {}): Promise<string | null> {
+    const dir = mkdtempSync(join(tmpdir(), 'mochi-junit-probe-'));
+    try {
+      writeFileSync(join(dir, 'probe.test.ts'), source);
+      const reportPath = join(dir, 'report.xml');
+      const proc = Bun.spawn(['bun', 'test', '--reporter=junit', `--reporter-outfile=${reportPath}`, 'probe.test.ts'], {
+        cwd: dir,
+        stdin: 'ignore',
+        stdout: 'ignore',
+        stderr: 'ignore',
+      });
+      if (killAfterMs !== undefined) {
+        await Bun.sleep(killAfterMs);
+        proc.kill('SIGKILL');
+      }
+      await proc.exited;
+      const report = Bun.file(reportPath);
+      return (await report.exists()) ? await report.text() : null;
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  test('a green run writes a report the wedge tolerance accepts', async () => {
+    const xml = await junitAfterRun(`import { test, expect } from 'bun:test';\ntest('adds', () => { expect(1 + 1).toBe(2); });\n`);
+
+    expect(parseJunitSummary(xml)).toEqual({ tests: 1, failures: 0 });
+    expect(toleratedWindowsWedge(true, xml, 'win32')).toBe(true);
+  });
+
+  test('a failing run writes a report that records the failure', async () => {
+    const xml = await junitAfterRun(`import { test, expect } from 'bun:test';\ntest('adds', () => { expect(1 + 1).toBe(3); });\n`);
+
+    expect(parseJunitSummary(xml)?.failures).toBe(1);
+    expect(toleratedWindowsWedge(true, xml, 'win32')).toBe(false);
+  });
+
+  test('a run killed before finishing writes no report at all', async () => {
+    const xml = await junitAfterRun(`import { test } from 'bun:test';\ntest('hangs', async () => { await new Promise(() => {}); });\n`, { killAfterMs: 500 });
+
+    expect(xml).toBeNull();
+    expect(toleratedWindowsWedge(true, xml, 'win32')).toBe(false);
+  });
+
+  test('a module that throws at import time never yields a tolerable report', async () => {
+    const xml = await junitAfterRun(`throw new Error('boom at import time');\n`);
+
+    expect(toleratedWindowsWedge(true, xml, 'win32')).toBe(false);
   });
 });

--- a/packages/mochi/src/cli/testing.test.ts
+++ b/packages/mochi/src/cli/testing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { extractFailures } from './testing';
+import { bunReportedCleanPass, extractFailures, toleratedWindowsWedge } from './testing';
 
 // Verbatim `bun test` reporter output (v1.3): the source snippet and `error:` block
 // are printed *before* the `(fail)` line they belong to.
@@ -85,5 +85,58 @@ describe('extractFailures', () => {
     expect(failures[0]!.name).toBe('big one');
     expect(failures[0]!.detail).toHaveLength(26);
     expect(failures[0]!.detail.at(-1)).toBe('… (truncated, 16 more lines)');
+  });
+});
+
+const CLEAN_PASS_OUTPUT = `
+queuePglite.test.ts:
+(pass) Mochi queue on pglite storage > installs its schema and roundtrips a job in-process [3596.30ms]
+
+ 1 pass
+ 0 fail
+ 6 expect() calls
+Ran 1 test across 1 file. [3.74s]
+`;
+
+describe('bunReportedCleanPass', () => {
+  test('true for a completed all-pass run', () => {
+    expect(bunReportedCleanPass({ stderr: CLEAN_PASS_OUTPUT, stdout: '' })).toBe(true);
+  });
+
+  test('reads the footer from stdout when stderr is blank', () => {
+    expect(bunReportedCleanPass({ stderr: '  \n', stdout: CLEAN_PASS_OUTPUT })).toBe(true);
+  });
+
+  test('false when a test failed', () => {
+    expect(bunReportedCleanPass({ stderr: ASSERTION_OUTPUT, stdout: '' })).toBe(false);
+  });
+
+  test('false for an unattached import error', () => {
+    expect(bunReportedCleanPass({ stderr: IMPORT_ERROR_OUTPUT, stdout: '' })).toBe(false);
+  });
+
+  test('false when the process was killed before the footer printed', () => {
+    const stderr = Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n');
+    expect(bunReportedCleanPass({ stderr, stdout: '' })).toBe(false);
+  });
+});
+
+describe('toleratedWindowsWedge', () => {
+  const clean = { stderr: CLEAN_PASS_OUTPUT, stdout: '' };
+
+  test('true only for a timed-out clean pass on win32', () => {
+    expect(toleratedWindowsWedge(true, clean, 'win32')).toBe(true);
+  });
+
+  test('false on non-Windows even after a clean pass', () => {
+    expect(toleratedWindowsWedge(true, clean, 'linux')).toBe(false);
+  });
+
+  test('false when the file did not time out', () => {
+    expect(toleratedWindowsWedge(false, clean, 'win32')).toBe(false);
+  });
+
+  test('false for a win32 timeout that never reached a clean pass', () => {
+    expect(toleratedWindowsWedge(true, { stderr: ASSERTION_OUTPUT, stdout: '' }, 'win32')).toBe(false);
   });
 });

--- a/packages/mochi/src/cli/testing.test.ts
+++ b/packages/mochi/src/cli/testing.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { bunReportedCleanPass, extractFailures, toleratedWindowsWedge } from './testing';
+import { extractFailures, parseJunitSummary, toleratedWindowsWedge } from './testing';
 
 // Verbatim `bun test` reporter output (v1.3): the source snippet and `error:` block
 // are printed *before* the `(fail)` line they belong to.
@@ -88,55 +88,70 @@ describe('extractFailures', () => {
   });
 });
 
-const CLEAN_PASS_OUTPUT = `
-queuePglite.test.ts:
-(pass) Mochi queue on pglite storage > installs its schema and roundtrips a job in-process [3596.30ms]
-
- 1 pass
- 0 fail
- 6 expect() calls
-Ran 1 test across 1 file. [3.74s]
+// Verbatim `bun test --reporter=junit` reports (v1.3), written only at the end of a completed run.
+const PASS_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="1" assertions="6" failures="0" skipped="0" time="3.741">
+  <testsuite name="queuePglite.test.ts" file="queuePglite.test.ts" tests="1" assertions="6" failures="0" skipped="0" time="3.6" hostname="ci">
+    <testcase name="Mochi queue on pglite storage &gt; installs its schema and roundtrips a job in-process" classname="" time="3.596" file="queuePglite.test.ts" line="12" assertions="6" />
+  </testsuite>
+</testsuites>
 `;
 
-describe('bunReportedCleanPass', () => {
-  test('true for a completed all-pass run', () => {
-    expect(bunReportedCleanPass({ stderr: CLEAN_PASS_OUTPUT, stdout: '' })).toBe(true);
+const FAIL_XML = `<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="bun test" tests="1" assertions="1" failures="1" skipped="0" time="0.020">
+  <testsuite name="fail.test.ts" file="fail.test.ts" tests="1" assertions="1" failures="1" skipped="0" time="0" hostname="ci">
+    <testcase name="adds" classname="" time="0.000519" file="fail.test.ts" line="2" assertions="1">
+      <failure type="AssertionError" />
+    </testcase>
+  </testsuite>
+</testsuites>
+`;
+
+describe('parseJunitSummary', () => {
+  test('reads the run totals from a passing report', () => {
+    expect(parseJunitSummary(PASS_XML)).toEqual({ tests: 1, failures: 0 });
   });
 
-  test('reads the footer from stdout when stderr is blank', () => {
-    expect(bunReportedCleanPass({ stderr: '  \n', stdout: CLEAN_PASS_OUTPUT })).toBe(true);
+  test('reads the failure count from a failing report', () => {
+    expect(parseJunitSummary(FAIL_XML)).toEqual({ tests: 1, failures: 1 });
   });
 
-  test('false when a test failed', () => {
-    expect(bunReportedCleanPass({ stderr: ASSERTION_OUTPUT, stdout: '' })).toBe(false);
+  test('counts a per-test timeout as a failure', () => {
+    expect(parseJunitSummary(FAIL_XML.replace('AssertionError', 'TimeoutError'))).toEqual({ tests: 1, failures: 1 });
   });
 
-  test('false for an unattached import error', () => {
-    expect(bunReportedCleanPass({ stderr: IMPORT_ERROR_OUTPUT, stdout: '' })).toBe(false);
+  test('null for a missing or empty report', () => {
+    expect(parseJunitSummary(null)).toBeNull();
+    expect(parseJunitSummary('')).toBeNull();
   });
 
-  test('false when the process was killed before the footer printed', () => {
-    const stderr = Array.from({ length: 30 }, (_, i) => `line ${i}`).join('\n');
-    expect(bunReportedCleanPass({ stderr, stdout: '' })).toBe(false);
+  test('null for a report truncated mid-write', () => {
+    expect(parseJunitSummary(PASS_XML.slice(0, PASS_XML.indexOf('failures=') + 11))).toBeNull();
+  });
+
+  test('null for console output that is not a report at all', () => {
+    expect(parseJunitSummary('bun test v1.3.14\n\n 1 pass\n 0 fail\nRan 1 test across 1 file. [3.74s]')).toBeNull();
   });
 });
 
 describe('toleratedWindowsWedge', () => {
-  const clean = { stderr: CLEAN_PASS_OUTPUT, stdout: '' };
-
-  test('true only for a timed-out clean pass on win32', () => {
-    expect(toleratedWindowsWedge(true, clean, 'win32')).toBe(true);
+  test('true only for a timed-out green report on win32', () => {
+    expect(toleratedWindowsWedge(true, PASS_XML, 'win32')).toBe(true);
   });
 
-  test('false on non-Windows even after a clean pass', () => {
-    expect(toleratedWindowsWedge(true, clean, 'linux')).toBe(false);
+  test('false on non-Windows even after a green report', () => {
+    expect(toleratedWindowsWedge(true, PASS_XML, 'linux')).toBe(false);
   });
 
   test('false when the file did not time out', () => {
-    expect(toleratedWindowsWedge(false, clean, 'win32')).toBe(false);
+    expect(toleratedWindowsWedge(false, PASS_XML, 'win32')).toBe(false);
   });
 
-  test('false for a win32 timeout that never reached a clean pass', () => {
-    expect(toleratedWindowsWedge(true, { stderr: ASSERTION_OUTPUT, stdout: '' }, 'win32')).toBe(false);
+  test('false for a win32 timeout whose report records a failure', () => {
+    expect(toleratedWindowsWedge(true, FAIL_XML, 'win32')).toBe(false);
+  });
+
+  test('false for a win32 timeout that never wrote a report', () => {
+    expect(toleratedWindowsWedge(true, null, 'win32')).toBe(false);
   });
 });

--- a/packages/mochi/src/cli/testing.test.ts
+++ b/packages/mochi/src/cli/testing.test.ts
@@ -159,31 +159,36 @@ describe('toleratedWindowsWedge', () => {
   });
 });
 
+/** Runs `source` as a test file in a real `bun test` child, returning its captured output and junit report (if written). */
+async function runProbeFile(source: string, { killAfterMs }: { killAfterMs?: number } = {}): Promise<{ stdout: string; stderr: string; junitXml: string | null }> {
+  const dir = mkdtempSync(join(tmpdir(), 'mochi-junit-probe-'));
+  try {
+    writeFileSync(join(dir, 'probe.test.ts'), source);
+    const reportPath = join(dir, 'report.xml');
+    const proc = Bun.spawn(['bun', 'test', '--reporter=junit', `--reporter-outfile=${reportPath}`, 'probe.test.ts'], {
+      cwd: dir,
+      stdin: 'ignore',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const stdoutP = new Response(proc.stdout).text();
+    const stderrP = new Response(proc.stderr).text();
+    if (killAfterMs !== undefined) {
+      await Bun.sleep(killAfterMs);
+      proc.kill('SIGKILL');
+    }
+    const [stdout, stderr] = await Promise.all([stdoutP, stderrP, proc.exited]);
+    const report = Bun.file(reportPath);
+    return { stdout, stderr, junitXml: (await report.exists()) ? await report.text() : null };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 // Spawns real `bun test` children to pin the Bun behavior the wedge tolerance relies on: the junit report is written
 // only at the end of a completed run, so it can never green-light a process that was killed or that recorded a failure.
 describe('junit report as a completion sentinel', () => {
-  async function junitAfterRun(source: string, { killAfterMs }: { killAfterMs?: number } = {}): Promise<string | null> {
-    const dir = mkdtempSync(join(tmpdir(), 'mochi-junit-probe-'));
-    try {
-      writeFileSync(join(dir, 'probe.test.ts'), source);
-      const reportPath = join(dir, 'report.xml');
-      const proc = Bun.spawn(['bun', 'test', '--reporter=junit', `--reporter-outfile=${reportPath}`, 'probe.test.ts'], {
-        cwd: dir,
-        stdin: 'ignore',
-        stdout: 'ignore',
-        stderr: 'ignore',
-      });
-      if (killAfterMs !== undefined) {
-        await Bun.sleep(killAfterMs);
-        proc.kill('SIGKILL');
-      }
-      await proc.exited;
-      const report = Bun.file(reportPath);
-      return (await report.exists()) ? await report.text() : null;
-    } finally {
-      rmSync(dir, { recursive: true, force: true });
-    }
-  }
+  const junitAfterRun = async (source: string, opts?: { killAfterMs?: number }): Promise<string | null> => (await runProbeFile(source, opts)).junitXml;
 
   test('a green run writes a report the wedge tolerance accepts', async () => {
     const xml = await junitAfterRun(`import { test, expect } from 'bun:test';\ntest('adds', () => { expect(1 + 1).toBe(2); });\n`);
@@ -210,5 +215,36 @@ describe('junit report as a completion sentinel', () => {
     const xml = await junitAfterRun(`throw new Error('boom at import time');\n`);
 
     expect(toleratedWindowsWedge(true, xml, 'win32')).toBe(false);
+  });
+});
+
+// Guards the verbatim fixtures at the top of this file against reporter drift: a Bun upgrade that reshapes the console
+// output should fail here, not silently degrade the end-of-run failure excerpts to the raw-tail fallback.
+describe('extractFailures against live bun output', () => {
+  test('parses failure names and error text from a real failing run', async () => {
+    const { stderr } = await runProbeFile(`import { describe, expect, test } from 'bun:test';
+describe('outer group', () => {
+  test('passes', () => { expect(1).toBe(1); });
+  test('fails an assertion', () => { expect(400).toBe(200); });
+  test('throws', () => { throw new Error('boom from thrown test'); });
+});
+`);
+
+    const { failures, fallback } = extractFailures({ stdout: '', stderr });
+
+    expect(fallback).toBeUndefined();
+    expect(failures.map((f) => f.name)).toEqual(['outer group > fails an assertion', 'outer group > throws']);
+    expect(failures[0]!.detail.join('\n')).toContain('Expected: 200');
+    expect(failures[1]!.detail.join('\n')).toContain('boom from thrown test');
+  });
+
+  test('parses a real import error as an unattached failure', async () => {
+    const { stderr } = await runProbeFile(`import './does-not-exist';\n`);
+
+    const { failures } = extractFailures({ stdout: '', stderr });
+
+    expect(failures).toHaveLength(1);
+    expect(failures[0]!.name).toBeNull();
+    expect(failures[0]!.detail.join('\n')).toContain("Cannot find module './does-not-exist'");
   });
 });

--- a/packages/mochi/src/cli/testing.ts
+++ b/packages/mochi/src/cli/testing.ts
@@ -1,4 +1,7 @@
 import { Glob } from 'bun';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 
 export interface RunTestsOptions {
   /** Package root to glob `src/**\/*.test.ts` from and run each file in. Defaults to the cwd. */
@@ -13,9 +16,9 @@ export interface RunTestsOptions {
    */
   windowsSkip?: Iterable<string>;
   /**
-   * Hard per-file deadline (ms). A `bun test` child still running past it is killed; if it had already printed a clean
-   * pass (a Windows shutdown wedge) the file still counts as passed, otherwise it is recorded as failed with "TIMED
-   * OUT". Either way one wedged process can't hang the run — a backstop for Bun's per-*test* `--timeout`, which fails a
+   * Hard per-file deadline (ms). A `bun test` child still running past it is killed; if its junit report shows a
+   * finished green run (a Windows shutdown wedge) the file still counts as passed, otherwise it is recorded as failed
+   * with "TIMED OUT". Either way one wedged process can't hang the run — a backstop for Bun's per-*test* `--timeout`, which fails a
    * test while leaving the process alive. Default 60_000: far above any healthy file and well under CI's job cap.
    */
   fileTimeoutMs?: number;
@@ -25,7 +28,7 @@ interface FileResult {
   file: string;
   ok: boolean;
   timedOut: boolean;
-  /** The file blew the deadline but had already printed a clean pass — a Bun-on-Windows shutdown wedge, tolerated. */
+  /** The file blew the deadline but its junit report shows a finished green run — a Bun-on-Windows shutdown wedge, tolerated. */
   wedgedTolerated: boolean;
   exitCode: number | null;
   stdout: string;
@@ -116,31 +119,50 @@ function dropEdgeBlanks(block: string[]): string[] {
   return block.slice(start, end);
 }
 
-const CLEAN_FOOTER_RE = /^\s*Ran \d+ tests? across \d+ files?\./m;
-const ZERO_FAIL_RE = /^\s*0 fail\b/m;
-const FAIL_MARKER_RE = /^\(fail\)/m;
-
-/**
- * True only when `bun test`'s output proves the file finished cleanly: the "Ran N tests" completion footer, a `0 fail`
- * line, no `(fail)` markers, and no unattached error block. Requiring the footer is the safety catch — a process killed
- * mid-run (a real hang, an import that never resolves) never emits it, and an `afterAll` that throws makes Bun report a
- * failure — so the only thing this forgives is a wedge that happens *after* a green run.
- */
-export function bunReportedCleanPass(result: Pick<FileResult, 'stdout' | 'stderr'>): boolean {
-  const text = result.stderr.trim() ? result.stderr : result.stdout;
-  if (!CLEAN_FOOTER_RE.test(text) || !ZERO_FAIL_RE.test(text) || FAIL_MARKER_RE.test(text)) {
-    return false;
-  }
-  return extractFailures(result).failures.length === 0;
+export interface JunitSummary {
+  tests: number;
+  failures: number;
 }
 
 /**
- * A file that blew the per-file deadline is tolerated only on Windows and only if it had already printed a clean pass —
- * Bun's native post-test shutdown wedges there with some in-process resources (e.g. PGlite's WASM instance) still loaded,
- * a runtime bug with no JS-level recovery. `platform` is a parameter so tests can exercise both branches.
+ * Pulls the run totals out of a `bun test --reporter=junit` report's root `<testsuites>` element, or null when the
+ * input is missing, truncated, or not a report. Bun writes the report only at the end of a completed run, so a missing
+ * or partial file is proof the process was killed mid-run rather than after finishing.
  */
-export function toleratedWindowsWedge(timedOut: boolean, result: Pick<FileResult, 'stdout' | 'stderr'>, platform: NodeJS.Platform = process.platform): boolean {
-  return timedOut && platform === 'win32' && bunReportedCleanPass(result);
+export function parseJunitSummary(xml: string | null): JunitSummary | null {
+  if (!xml) {
+    return null;
+  }
+  let summary: JunitSummary | null = null;
+  new HTMLRewriter()
+    .on('testsuites', {
+      element(el) {
+        if (summary) {
+          return;
+        }
+        const tests = Number(el.getAttribute('tests'));
+        const failures = Number(el.getAttribute('failures'));
+        if (Number.isInteger(tests) && Number.isInteger(failures)) {
+          summary = { tests, failures };
+        }
+      },
+    })
+    .transform(xml);
+  return summary;
+}
+
+/**
+ * A file that blew the per-file deadline is tolerated only on Windows and only if its junit report proves the run had
+ * already finished green — Bun's native post-test shutdown wedges there with some in-process resources (e.g. PGlite's
+ * WASM instance) still loaded, a runtime bug with no JS-level recovery. `platform` is a parameter so tests can exercise
+ * both branches.
+ */
+export function toleratedWindowsWedge(timedOut: boolean, junitXml: string | null, platform: NodeJS.Platform = process.platform): boolean {
+  if (!timedOut || platform !== 'win32') {
+    return false;
+  }
+  const summary = parseJunitSummary(junitXml);
+  return summary !== null && summary.failures === 0;
 }
 
 /**
@@ -158,6 +180,9 @@ export async function runTests(options: RunTestsOptions = {}): Promise<void> {
   const dir = options.dir ?? '.';
   const sequential = new Set(options.sequential ?? []);
   const fileTimeoutMs = options.fileTimeoutMs ?? 60_000;
+
+  // Each child writes a junit report here; it doubles as the completion sentinel for the Windows wedge tolerance.
+  const junitDir = mkdtempSync(join(tmpdir(), 'mochi-junit-'));
 
   const windowsSkip = new Set(process.platform === 'win32' ? (options.windowsSkip ?? []) : []);
 
@@ -183,7 +208,8 @@ export async function runTests(options: RunTestsOptions = {}): Promise<void> {
   // handle, or the Bun-on-Windows shutdown quirk — would block the worker on `proc.exited` until CI's job cap. The hard
   // deadline turns that into a fast outcome: a named failure, or (Windows-only, after a clean pass) a tolerated wedge.
   async function runFile(file: string): Promise<FileResult> {
-    const proc = Bun.spawn(['bun', 'test', '--timeout', '30000', file], {
+    const junitPath = join(junitDir, `${file.replaceAll('/', '_')}.xml`);
+    const proc = Bun.spawn(['bun', 'test', '--timeout', '30000', '--reporter=junit', `--reporter-outfile=${junitPath}`, file], {
       cwd: dir,
       stdin: 'ignore',
       stdout: 'pipe',
@@ -219,7 +245,9 @@ export async function runTests(options: RunTestsOptions = {}): Promise<void> {
     }
 
     const [exitCode, stdout, stderr] = await Promise.all([proc.exited, stdoutP, stderrP]);
-    const wedgedTolerated = toleratedWindowsWedge(timedOut, { stdout, stderr });
+    const junitFile = Bun.file(junitPath);
+    const junitXml = timedOut && (await junitFile.exists()) ? await junitFile.text() : null;
+    const wedgedTolerated = toleratedWindowsWedge(timedOut, junitXml);
     return { file, ok: (!timedOut && exitCode === 0) || wedgedTolerated, timedOut, wedgedTolerated, exitCode, stdout, stderr };
   }
 
@@ -256,6 +284,8 @@ export async function runTests(options: RunTestsOptions = {}): Promise<void> {
     results.push(result);
     report(result, '→ ');
   }
+
+  rmSync(junitDir, { recursive: true, force: true });
 
   const failed = results.filter((r) => !r.ok);
   console.log(`\n${'='.repeat(60)}`);

--- a/packages/mochi/src/cli/testing.ts
+++ b/packages/mochi/src/cli/testing.ts
@@ -6,14 +6,16 @@ export interface RunTestsOptions {
   /** Test files (paths relative to `dir`) that must run sequentially, after the parallel batch. */
   sequential?: Iterable<string>;
   /**
-   * Test files (paths relative to `dir`) to skip on Windows only, for suites that pass every test but then wedge in
-   * Bun's native post-test shutdown there — a runtime bug with no JS-level recovery, since bun stops running the loop
-   * before it hangs. Skipped files are logged, and their logic still runs on Linux and macOS.
+   * Test files (paths relative to `dir`) to skip on Windows only. A file that wedges in Bun's native post-test shutdown
+   * *after* a clean pass is already tolerated automatically (see `toleratedWindowsWedge`), so this list is reserved for
+   * files that wedge *before* printing a clean pass, or that genuinely cannot run on Windows (e.g. POSIX-signal tests).
+   * Skipped files are logged, and their logic still runs on Linux and macOS.
    */
   windowsSkip?: Iterable<string>;
   /**
-   * Hard per-file deadline (ms). A `bun test` child still running past it is killed and recorded as failed with
-   * "TIMED OUT", so one wedged process can't hang the run — a backstop for Bun's per-*test* `--timeout`, which fails a
+   * Hard per-file deadline (ms). A `bun test` child still running past it is killed; if it had already printed a clean
+   * pass (a Windows shutdown wedge) the file still counts as passed, otherwise it is recorded as failed with "TIMED
+   * OUT". Either way one wedged process can't hang the run — a backstop for Bun's per-*test* `--timeout`, which fails a
    * test while leaving the process alive. Default 60_000: far above any healthy file and well under CI's job cap.
    */
   fileTimeoutMs?: number;
@@ -23,6 +25,8 @@ interface FileResult {
   file: string;
   ok: boolean;
   timedOut: boolean;
+  /** The file blew the deadline but had already printed a clean pass — a Bun-on-Windows shutdown wedge, tolerated. */
+  wedgedTolerated: boolean;
   exitCode: number | null;
   stdout: string;
   stderr: string;
@@ -112,6 +116,33 @@ function dropEdgeBlanks(block: string[]): string[] {
   return block.slice(start, end);
 }
 
+const CLEAN_FOOTER_RE = /^\s*Ran \d+ tests? across \d+ files?\./m;
+const ZERO_FAIL_RE = /^\s*0 fail\b/m;
+const FAIL_MARKER_RE = /^\(fail\)/m;
+
+/**
+ * True only when `bun test`'s output proves the file finished cleanly: the "Ran N tests" completion footer, a `0 fail`
+ * line, no `(fail)` markers, and no unattached error block. Requiring the footer is the safety catch — a process killed
+ * mid-run (a real hang, an import that never resolves) never emits it, and an `afterAll` that throws makes Bun report a
+ * failure — so the only thing this forgives is a wedge that happens *after* a green run.
+ */
+export function bunReportedCleanPass(result: Pick<FileResult, 'stdout' | 'stderr'>): boolean {
+  const text = result.stderr.trim() ? result.stderr : result.stdout;
+  if (!CLEAN_FOOTER_RE.test(text) || !ZERO_FAIL_RE.test(text) || FAIL_MARKER_RE.test(text)) {
+    return false;
+  }
+  return extractFailures(result).failures.length === 0;
+}
+
+/**
+ * A file that blew the per-file deadline is tolerated only on Windows and only if it had already printed a clean pass —
+ * Bun's native post-test shutdown wedges there with some in-process resources (e.g. PGlite's WASM instance) still loaded,
+ * a runtime bug with no JS-level recovery. `platform` is a parameter so tests can exercise both branches.
+ */
+export function toleratedWindowsWedge(timedOut: boolean, result: Pick<FileResult, 'stdout' | 'stderr'>, platform: NodeJS.Platform = process.platform): boolean {
+  return timedOut && platform === 'win32' && bunReportedCleanPass(result);
+}
+
 /**
  * Runs each `src/**\/*.test.ts` file in its own `bun test` process, up to `navigator.hardwareConcurrency` in parallel,
  * exiting with code 1 if any file fails.
@@ -150,7 +181,7 @@ export async function runTests(options: RunTestsOptions = {}): Promise<void> {
 
   // Bun's `--timeout` fails an individual test but leaves the process alive, so one wedged after its tests — a leaked
   // handle, or the Bun-on-Windows shutdown quirk — would block the worker on `proc.exited` until CI's job cap. The hard
-  // deadline turns that into a fast, named failure.
+  // deadline turns that into a fast outcome: a named failure, or (Windows-only, after a clean pass) a tolerated wedge.
   async function runFile(file: string): Promise<FileResult> {
     const proc = Bun.spawn(['bun', 'test', '--timeout', '30000', file], {
       cwd: dir,
@@ -188,11 +219,14 @@ export async function runTests(options: RunTestsOptions = {}): Promise<void> {
     }
 
     const [exitCode, stdout, stderr] = await Promise.all([proc.exited, stdoutP, stderrP]);
-    return { file, ok: !timedOut && exitCode === 0, timedOut, exitCode, stdout, stderr };
+    const wedgedTolerated = toleratedWindowsWedge(timedOut, { stdout, stderr });
+    return { file, ok: (!timedOut && exitCode === 0) || wedgedTolerated, timedOut, wedgedTolerated, exitCode, stdout, stderr };
   }
 
   function report(result: FileResult, prefix = ''): void {
-    if (result.timedOut) {
+    if (result.wedgedTolerated) {
+      console.log(`\n${prefix}⚠ ${result.file} — passed, but Bun wedged in post-test shutdown on Windows (tolerated after ${Math.round(fileTimeoutMs / 1000)}s)`);
+    } else if (result.timedOut) {
       console.log(`\n${prefix}✗ ${result.file} — TIMED OUT after ${Math.round(fileTimeoutMs / 1000)}s (killed)`);
     } else {
       console.log(`\n${prefix}${result.ok ? '✓' : '✗'} ${result.file}`);


### PR DESCRIPTION
## Problem

The `test-matrix (windows-latest)` job flakes with a spurious timeout, e.g. [run 31449607960](https://github.com/khromov/mochi/actions/runs/31449607960/job/93651050282):

```
✗ src/queuePglite.test.ts (timed out)
    (pass) Mochi queue on pglite storage > installs its schema and roundtrips a job in-process [3596.30ms]
     1 pass
     0 fail
    Ran 1 test across 1 file. [3.74s]
```

The test **passes** — including its `afterAll`, which closes the PGlite instance. The file is only marked "timed out" because the `bun test` **process never exits**: Bun wedges in its native post-test shutdown on Windows with the in-memory PGlite (WASM) instance still loaded, so `runTests()`'s hard per-file deadline (`fileTimeoutMs`, 60s) kills it. This is the same class already documented in `windowsSkip` for `cache.test.ts` — "passes every test but deterministically wedges in Bun's native post-test shutdown … a runtime bug with no JS-level recovery."

It's flaky and **roams the whole PGlite class** — a per-file skip is whack-a-mole:
- Run 31449607960 (main) wedged on `queuePglite.test.ts`.
- Run 31343982765 (drop-queue-batching) wedged on `queueStandalonePglite.test.ts — TIMED OUT after 60s (killed)`, while the same run's Bun-canary Windows job passed all 159 files.

Four files boot an in-process PGlite and can each trip it: `queuePglite`, `queueStandalonePglite`, `queuePostgres`, `runtime/rateLimit.postgres.integration`.

## Fix

Rather than skip the files (dropping Windows coverage for a subsystem that actually passes), teach the runner to **tolerate a deadline kill that happens strictly after a clean pass**, in `packages/mochi/src/cli/testing.ts`:

- `bunReportedCleanPass(result)` — true only when bun's output proves a green finish: the `Ran N tests across N files` footer, a `0 fail` line, no `(fail)` markers, and no unattached error block.
- `toleratedWindowsWedge(timedOut, result, platform)` — `timedOut && platform === 'win32' && bunReportedCleanPass(result)`.
- `runFile()` folds that into `ok`; `report()` logs a `⚠ … (tolerated)` line instead of a red `✗ TIMED OUT`.

Requiring the completion footer is the safety catch: a genuine hang (a test that never resolves, an import that throws) never prints it, and an `afterAll` that throws makes bun report a failure — so the only thing forgiven is a wedge **after** an already-green run. The `windowsSkip` list is unchanged; the four PGlite files aren't in it and are now tolerated automatically.

## Tests

`packages/mochi/src/cli/testing.test.ts` gains coverage for both helpers: clean-pass detection (true), and false for a failing run, an unattached import error, and a killed-before-footer process; plus the platform/`timedOut` gating of `toleratedWindowsWedge`.

## Verification

- `bun test packages/mochi/src/cli/testing.test.ts` — 14 pass.
- `bun test` on `queuePglite` + `queueStandalonePglite` still green on Linux (tolerance is win32-only, so Linux behavior is unchanged).
- Real signal: this PR's `test-matrix (windows-latest)` job should go green; when a PGlite file wedges, the log shows the tolerated `⚠` warning instead of a failure.
