### PR TITLE
feat(compiler): manual shared-chunk control via clientBundle.chunks

### DIFF
--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -68,6 +68,7 @@ In production (`development: false`), prebuilt JS/CSS bundles served from `asset
 - `svelteConfigPath` — path to a Svelte config file. Default: `./svelte.config.js`. See [Svelte config](/docs/svelte-config/).
 - `svelteCompiler` — which compiler emits component JS. Default: `'svelte'`. `'rsvelte'` needs `@mochi-framework/rsvelte`. See [rsvelte](/docs/rsvelte/).
 - `optimize` — run the whole-program svelte-shaker pass over `.svelte` source before compiling, so the compiler emits less code. **Production only**, and needs `@mochi-framework/svelte-shaker`. `true` shakes everything; `{ enabled, exclude }` gives finer control. Default: `false`. See [Svelte Shaker](/docs/svelte-shaker/).
+- `clientBundle` — assign modules in the island client bundle to named shared chunks with `chunks`, or turn Bun's code splitting off with `splitting`. **Production only**. Default: unset. See [Client bundle chunks](/docs/client-bundle/).
 - `csrf` — `MochiCsrfOptions` for the origin-header check. See below.
 - `proxy` — `MochiProxyOptions` for trusted reverse-proxy headers. See below.
 - `hooks` / `filters` — named lifecycle hooks and value filters. See [Extensions](/docs/extensions/).

--- a/packages/docs/179-client-bundle.md
+++ b/packages/docs/179-client-bundle.md
@@ -92,11 +92,25 @@ Some modules are left where Bun put them. Every one is named in the build report
   nothing to gain. Moving it loses: the runtime's modules are densely circular, and relocating them reorders their
   initialization, which builds cleanly and then throws during hydration in the browser.
 
+A group whose modules are all reached from a single island is not shared with anything, so Bun keeps them in that
+island's own bundle. The report says so rather than listing a chunk that does not exist:
+
+```
+  no shared chunk: admin — its modules are reached from one island entry, which already carries them.
+```
+
+### Initialization order
+
+Members of a chunk keep the order they ran in before you grouped them. What changes is where the group as a whole runs:
+it initializes at the point the **first** of its members is reached, so a member that used to run late now runs there
+too.
+
 <Callout type="warning">
 
-Mochi cannot detect this hazard in general. A package whose modules depend on each other's initialization order may
-behave the same way: the build succeeds and the failure appears only when the page hydrates. After changing `chunks`,
-load a page that uses the affected islands in a real browser and check the console — a passing build is not enough.
+That shift is not something Mochi can check for you. If a grouped module runs code at import time that something
+outside the chunk depends on having run first, the build succeeds and the failure appears only when the page hydrates.
+After changing `chunks`, load a page that uses the affected islands in a real browser and check the console — a passing
+build is not enough.
 
 </Callout>
 
@@ -110,3 +124,6 @@ clientBundle: {
 
 Every island entry becomes self-contained: no shared chunks, no extra requests, and any dependency used by two islands
 is duplicated into both. Worth measuring before adopting — it usually costs more bytes than it saves requests.
+
+Shared chunks are exactly what splitting emits, so `splitting: false` and `chunks` cannot be combined — Mochi rejects
+the pair at startup rather than running a classifier that has nothing to place.

--- a/packages/docs/179-client-bundle.md
+++ b/packages/docs/179-client-bundle.md
@@ -1,0 +1,112 @@
+---
+title: 'Client bundle chunks'
+slug: client-bundle
+description: 'Assign modules in the island client bundle to named shared chunks.'
+---
+
+<script>
+  import Callout from './_components/Callout.svelte';
+  import VersionNote from './_components/VersionNote.svelte';
+</script>
+
+## Client bundle chunks
+
+<VersionNote since="0.10.0" message="clientBundle ships in the next Mochi release (0.10.0). This page describes the upcoming API." />
+
+Mochi builds every hydratable island in one pass and lets Bun split shared code into chunks. `clientBundle.chunks`
+takes that decision back: map a module path to a chunk name and every module you give the same name ships as one file.
+
+```ts
+// file: src/index.ts
+await Mochi.serve({
+  clientBundle: {
+    chunks: (id, { packageName }) => {
+      if (packageName === 'chart.js' || packageName?.startsWith('d3-')) return 'charts';
+      if (id.includes('/src/admin/')) return 'admin';
+      return null; // leave placement to Bun
+    },
+  },
+  routes,
+});
+```
+
+Use it when you know something the bundler cannot: that two dependencies always load together, that a set of modules
+should be one long-lived cache entry, or that a page's islands should share one file instead of several.
+
+### The callback
+
+`chunks` runs once per module in the built client graph.
+
+- `id` — absolute path, always with forward slashes, so `id.includes('node_modules/chart.js/')` works on Windows too.
+- `ctx.packageName` — `chart.js`, `@lucide/svelte`, or `null` for your own source. Set for both `node_modules` layouts,
+  so it reads the same under either install linker.
+- `ctx.isNodeModules` — whether the module came from a dependency.
+- `ctx.relativeId` — `id` relative to the build directory.
+- `ctx.bytes` — parsed size, for a size-driven rule.
+
+Return a chunk name to place the module, or `null` to leave it to Bun. Names may contain letters, digits, `.`, `_` and
+`-`. An invalid name, or a callback that throws, fails the build and names the module responsible.
+
+### What ships
+
+A chunk is fetched by every island that reaches **any** of its members, and a module you assign is no longer
+tree-shaken against the islands importing it — the whole module ships. This is the same trade Vite's `manualChunks`
+makes: you are choosing cache granularity over minimum bytes.
+
+<Callout type="warning">
+
+Group modules that are genuinely used together. Putting a rarely-used dependency in the same chunk as a common one
+makes every island that needs the common one download both.
+
+</Callout>
+
+### Production only
+
+<Callout type="info">
+
+Chunking runs in **production only**. Assigning modules to chunks is a whole-graph decision that needs an extra
+discovery build pass, and per-file hot reloading cannot reuse its result — the same reason
+[`optimize`](/docs/svelte-shaker/) is production-only. In development the option is ignored and the bundle splits as it
+normally does. Run `mochi-framework build` to see the chunked output.
+
+</Callout>
+
+`mochi-framework build` reads `clientBundle` straight from your entry's `Mochi.serve()` call and prints the chunks it
+built, since a chunk is not visible anywhere else:
+
+```
+      Chunk       modules   size
+  ┌ ▤ charts           14   88 kB
+  └ ▤ admin             6   12 kB
+
+  2 chunks · 100 kB
+```
+
+### Modules that are skipped
+
+Some modules are left where Bun put them. Every one is named in the build report — nothing is skipped silently.
+
+- **CommonJS.** Its export names are worked out during bundling, after the point Mochi has to declare them, so moving
+  one would break any named import of it.
+- **Svelte itself.** Every island reaches the Svelte runtime, so Bun already emits it as one shared chunk — there is
+  nothing to gain. Moving it loses: the runtime's modules are densely circular, and relocating them reorders their
+  initialization, which builds cleanly and then throws during hydration in the browser.
+
+<Callout type="warning">
+
+Mochi cannot detect this hazard in general. A package whose modules depend on each other's initialization order may
+behave the same way: the build succeeds and the failure appears only when the page hydrates. After changing `chunks`,
+load a page that uses the affected islands in a real browser and check the console — a passing build is not enough.
+
+</Callout>
+
+### Turning splitting off
+
+```ts
+clientBundle: {
+  splitting: false;
+}
+```
+
+Every island entry becomes self-contained: no shared chunks, no extra requests, and any dependency used by two islands
+is duplicated into both. Worth measuring before adopting — it usually costs more bytes than it saves requests.

--- a/packages/docs/179-client-bundle.md
+++ b/packages/docs/179-client-bundle.md
@@ -13,6 +13,16 @@ description: 'Assign modules in the island client bundle to named shared chunks.
 
 <VersionNote since="0.10.0" message="clientBundle ships in the next Mochi release (0.10.0). This page describes the upcoming API." />
 
+<Callout type="danger">
+
+**Group only loosely-coupled packages, and check the result in a browser.** Packages whose modules import each other
+heavily — the d3 family, chart libraries with `.base` / `.svg` / `.canvas` component variants — can produce a bundle
+that builds cleanly and then throws `ReferenceError` or `Export 'x' is not defined` when an island hydrates. The build
+fails when it can detect the problem, but it cannot detect every case. Load an affected page and check the console
+before shipping a `chunks` change.
+
+</Callout>
+
 Mochi builds every hydratable island in one pass and lets Bun split shared code into chunks. `clientBundle.chunks`
 takes that decision back: map a module path to a chunk name and every module you give the same name ships as one file.
 
@@ -88,6 +98,9 @@ Some modules are left where Bun put them. Every one is named in the build report
 
 - **CommonJS.** Its export names are worked out during bundling, after the point Mochi has to declare them, so moving
   one would break any named import of it.
+- **Re-export barrels.** A module whose exports are `export * from` / `export { x } from` another module owns none of
+  those bindings. Moving one leaves the bundler emitting a chunk that references a name it never exports, which throws
+  when an island hydrates. Most package entry points are barrels, so expect to see a lot of these.
 - **Svelte itself.** Every island reaches the Svelte runtime, so Bun already emits it as one shared chunk — there is
   nothing to gain. Moving it loses: the runtime's modules are densely circular, and relocating them reorders their
   initialization, which builds cleanly and then throws during hydration in the browser.

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -476,6 +476,7 @@ export class Mochi {
         svelteCompiler: options.svelteCompiler,
         markdown: options.markdown,
         optimize: options.optimize,
+        clientBundle: options.clientBundle,
         barrelWarnings: options.barrelWarnings,
       });
       // No-op in dev or when the option is off; production-without-manifest

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/PageA.svelte
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/PageA.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import WidgetA from './WidgetA.svelte';
+</script>
+
+<main><WidgetA mochi:hydrate /></main>

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/PageB.svelte
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/PageB.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import WidgetB from './WidgetB.svelte';
+</script>
+
+<main><WidgetB mochi:hydrate /></main>

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/PageOrder.svelte
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/PageOrder.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+  import WidgetOrder from './WidgetOrder.svelte';
+</script>
+
+<main><WidgetOrder mochi:hydrate /></main>

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/WidgetA.svelte
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/WidgetA.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import VendorOne, { parse } from './vendorOne';
+  import { sharedLabel } from './shared';
+
+  let count = $state(0);
+  const tag = new VendorOne().tag;
+</script>
+
+<button onclick={() => count++}>{tag}:{parse(String(count))}:{sharedLabel(count)}</button>

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/WidgetB.svelte
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/WidgetB.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import VendorTwo, { parse } from './vendorTwo';
+  import { sharedLabel } from './shared';
+
+  let count = $state(1);
+  const tag = new VendorTwo().tag;
+</script>
+
+<button onclick={() => count--}>{tag}:{parse(String(count))}:{sharedLabel(count)}</button>

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/WidgetOrder.svelte
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/WidgetOrder.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { aFirst } from './aFirst';
+  import { zSecond } from './zSecond';
+  import { bOne } from './bOne';
+  import { aTwo } from './aTwo';
+  import { cThree } from './cThree';
+
+  let n = $state(0);
+</script>
+
+<button onclick={() => n++}>{aFirst + zSecond + bOne + aTwo + cThree + n}</button>

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/aFirst.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/aFirst.ts
@@ -1,0 +1,3 @@
+import { trace } from './orderTrace';
+trace.push('aFirst');
+export const aFirst = 1;

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/aTwo.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/aTwo.ts
@@ -1,0 +1,3 @@
+import { trace } from './orderTrace';
+trace.push('aTwo');
+export const aTwo = 1;

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/bOne.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/bOne.ts
@@ -1,0 +1,3 @@
+import { trace } from './orderTrace';
+trace.push('bOne');
+export const bOne = 1;

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/cThree.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/cThree.ts
@@ -1,0 +1,3 @@
+import { trace } from './orderTrace';
+trace.push('cThree');
+export const cThree = 1;

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/orderTrace.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/orderTrace.ts
@@ -1,0 +1,2 @@
+const g = globalThis as unknown as { __mochiChunkTrace?: string[] };
+export const trace = (g.__mochiChunkTrace ??= []);

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/shared.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/shared.ts
@@ -1,0 +1,1 @@
+export const sharedLabel = (n: number) => `shared:${n.toString(36)}`;

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/vendorOne.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/vendorOne.ts
@@ -1,0 +1,4 @@
+export const parse = (s: string) => `one:${s}`;
+export default class VendorOne {
+  readonly tag = 'VendorOne';
+}

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/vendorTwo.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/vendorTwo.ts
@@ -1,0 +1,4 @@
+export const parse = (s: string) => `two:${s}`;
+export default class VendorTwo {
+  readonly tag = 'VendorTwo';
+}

--- a/packages/mochi/src/__fixtures__/client-bundle-chunks/zSecond.ts
+++ b/packages/mochi/src/__fixtures__/client-bundle-chunks/zSecond.ts
@@ -1,0 +1,3 @@
+import { trace } from './orderTrace';
+trace.push('zSecond');
+export const zSecond = 2;

--- a/packages/mochi/src/cli/build.ts
+++ b/packages/mochi/src/cli/build.ts
@@ -4,7 +4,7 @@ import { buildInlineWebComponent } from '../compiler/buildInlineWebComponent';
 import { DEFAULT_ERROR_PAGE_PATH } from '../runtime/errors';
 import { CLIENT_STATS_COMPONENT } from '../dev/clientStatsRoutes';
 import { isMochiPage, isMochiApi, isMochiWs, isMochiSse } from '../types';
-import type { MarkdownConfig, MochiBarrelWarningOptions, MochiRouteValue, MochiSvelteShakerOptions } from '../types';
+import type { MarkdownConfig, MochiBarrelWarningOptions, MochiClientBundleOptions, MochiRouteValue, MochiSvelteShakerOptions } from '../types';
 import type { MochiSvelteCompiler } from '../compiler/svelteCompilerBackend';
 import { rmSync, mkdirSync } from 'node:fs';
 import path from 'node:path';
@@ -18,7 +18,7 @@ import { mochiEvents } from '../events';
 import type { MochiCompileCompleteEvent } from '../events';
 import { styleText } from 'node:util';
 import prettyBytes from '../vendor/pretty-bytes';
-import { collectImageResources, printResourceTree } from './resourceReport';
+import { collectImageResources, printChunkTree, printResourceTree } from './resourceReport';
 
 export interface MochiBuildOptions {
   routes: Record<string, MochiRouteValue>;
@@ -37,6 +37,8 @@ export interface MochiBuildOptions {
   markdown?: MarkdownConfig;
   /** Mirror the value passed to `Mochi.serve({ optimize })` so the prebuilt manifest and the runtime agree. Default: `false`. See `MochiServeOptions['optimize']`. */
   optimize?: boolean | MochiSvelteShakerOptions;
+  /** Mirror the value passed to `Mochi.serve({ clientBundle })`. Manual chunking runs in production builds only. See `MochiServeOptions['clientBundle']`. */
+  clientBundle?: MochiClientBundleOptions;
   /** Mirror the value passed to `Mochi.serve({ barrelWarnings })`; a build collapses offenders into one grouped summary line. Default: enabled. See `MochiServeOptions['barrelWarnings']`. */
   barrelWarnings?: boolean | MochiBarrelWarningOptions;
   /** Mirror the value passed to `Mochi.serve({ errorPage })` so it lands in the manifest and the runtime skips compiling it at startup. Default: Mochi's built-in error page. */
@@ -139,6 +141,7 @@ export async function build(options: MochiBuildOptions): Promise<void> {
       svelteCompiler: options.svelteCompiler,
       markdown: options.markdown,
       optimize: options.optimize,
+      clientBundle: options.clientBundle,
       barrelWarnings: options.barrelWarnings,
       // Group offenders into one summary for the one-shot production build; a
       // `--dev` build keeps the dev server's immediate per-package lines.
@@ -256,6 +259,11 @@ export async function build(options: MochiBuildOptions): Promise<void> {
     if (options.resources !== false) {
       printResourceTree(collectImageResources(imageAssets.values()));
     }
+
+    const chunkRows = (registry.getClientStats()?.outputs ?? [])
+      .filter((o): o is typeof o & { chunkName: string } => typeof o.chunkName === 'string')
+      .map((o) => ({ chunkName: o.chunkName, file: o.name, modules: o.inputs.length, bytes: o.size }));
+    printChunkTree(chunkRows, registry.getSkippedChunkModules());
 
     // Clean up intermediate .raw.css files
     const cssDir = path.join(outDir, 'svelte-css');

--- a/packages/mochi/src/cli/build.ts
+++ b/packages/mochi/src/cli/build.ts
@@ -19,6 +19,7 @@ import type { MochiCompileCompleteEvent } from '../events';
 import { styleText } from 'node:util';
 import prettyBytes from '../vendor/pretty-bytes';
 import { collectImageResources, printChunkTree, printResourceTree } from './resourceReport';
+import { isChunkModuleId } from '../compiler/clientBundleChunks';
 
 export interface MochiBuildOptions {
   routes: Record<string, MochiRouteValue>;
@@ -261,9 +262,11 @@ export async function build(options: MochiBuildOptions): Promise<void> {
     }
 
     const chunkRows = (registry.getClientStats()?.outputs ?? [])
-      .filter((o): o is typeof o & { chunkName: string } => typeof o.chunkName === 'string')
-      .map((o) => ({ chunkName: o.chunkName, file: o.name, modules: o.inputs.length, bytes: o.size }));
-    printChunkTree(chunkRows, registry.getSkippedChunkModules());
+      .filter((o): o is typeof o & { chunkNames: string[] } => Array.isArray(o.chunkNames))
+      // The generated view modules are an implementation detail of the grouping, so counting them would report a
+      // module count no one can reconcile against their own config.
+      .map((o) => ({ chunkNames: o.chunkNames, modules: o.inputs.filter((i) => !isChunkModuleId(i.path)).length, bytes: o.size }));
+    printChunkTree(chunkRows, registry.getSkippedChunkModules(), registry.getUnformedChunks());
 
     // Clean up intermediate .raw.css files
     const cssDir = path.join(outDir, 'svelte-css');

--- a/packages/mochi/src/cli/cli.ts
+++ b/packages/mochi/src/cli/cli.ts
@@ -177,6 +177,7 @@ async function main() {
     markdown: serveOptions?.markdown,
     svelteCompiler: serveOptions?.svelteCompiler,
     optimize: serveOptions && 'optimize' in serveOptions ? serveOptions.optimize : undefined,
+    clientBundle: serveOptions?.clientBundle,
     barrelWarnings: serveOptions?.barrelWarnings,
     errorPage: serveOptions?.errorPage,
     resources: serveOptions?.build?.resources,

--- a/packages/mochi/src/cli/resourceReport.test.ts
+++ b/packages/mochi/src/cli/resourceReport.test.ts
@@ -2,8 +2,21 @@ import { afterEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { collectImageResources } from './resourceReport';
+import { collectImageResources, printChunkTree } from './resourceReport';
 import type { LocalImageAsset } from '../image/types';
+
+/** Runs `fn` with console.log captured, returning everything it printed. */
+function captureLog(fn: () => void): string {
+  const lines: string[] = [];
+  const original = console.log;
+  console.log = (...args: unknown[]) => void lines.push(args.join(' '));
+  try {
+    fn();
+  } finally {
+    console.log = original;
+  }
+  return lines.join('\n');
+}
 
 const dirs: string[] = [];
 
@@ -49,5 +62,33 @@ describe('collectImageResources', () => {
 
   test('no assets yields no rows', () => {
     expect(collectImageResources([])).toEqual([]);
+  });
+});
+
+describe('printChunkTree', () => {
+  const row = (chunkNames: string[], bytes = 1000, modules = 3) => ({ chunkNames, modules, bytes });
+
+  test('prints a row per chunk with its total', () => {
+    const out = captureLog(() => printChunkTree([row(['vendor'], 2048)], []));
+    expect(out).toContain('Chunk');
+    expect(out).toContain('vendor');
+    expect(out).toContain('1 chunk');
+  });
+
+  test('names both groups when two of them land in one output', () => {
+    const out = captureLog(() => printChunkTree([row(['charts', 'vendor'])], []));
+    expect(out).toContain('charts + vendor');
+  });
+
+  // A column header with nothing under it reads as a broken report.
+  test('omits the table entirely when there are no chunks to list', () => {
+    const out = captureLog(() => printChunkTree([], [{ id: 'src/a.ts', reason: 'CommonJS' }], ['vendor']));
+    expect(out).not.toContain('Chunk');
+    expect(out).toContain('left in place: src/a.ts');
+    expect(out).toContain('no shared chunk: vendor');
+  });
+
+  test('prints nothing at all when there is nothing to report', () => {
+    expect(captureLog(() => printChunkTree([], []))).toBe('');
   });
 });

--- a/packages/mochi/src/cli/resourceReport.ts
+++ b/packages/mochi/src/cli/resourceReport.ts
@@ -59,3 +59,48 @@ export function printResourceTree(rows: ResourceRow[]): void {
   const total = rows.reduce((sum, r) => sum + r.bytes, 0);
   console.log(styleText('dim', `\n  ${n} asset${n === 1 ? '' : 's'} · ${prettyBytes(total)}`));
 }
+
+export interface ChunkRow {
+  /** User-assigned name from `clientBundle.chunks`. */
+  chunkName: string;
+  /** Emitted filename, which Bun always hashes as `chunk-<hash>.js`. */
+  file: string;
+  modules: number;
+  bytes: number;
+}
+
+/**
+ * The build console is the only place a manual chunk is ever visible: chunking is production-only, while the debug bar
+ * and the client-stats page are both gated on `development`.
+ */
+export function printChunkTree(rows: ChunkRow[], skipped: { id: string; reason: string }[]): void {
+  if (rows.length === 0 && skipped.length === 0) {
+    return;
+  }
+
+  const sorted = [...rows].sort((a, b) => b.bytes - a.bytes || a.chunkName.localeCompare(b.chunkName));
+  const sizes = sorted.map((r) => prettyBytes(r.bytes));
+  const nameWidth = Math.max('Chunk'.length, ...sorted.map((r) => r.chunkName.length));
+  const modWidth = Math.max('modules'.length, ...sorted.map((r) => String(r.modules).length));
+  const sizeWidth = Math.max('size'.length, ...sizes.map((s) => s.length), 4);
+
+  console.log('');
+  console.log(styleText('dim', `      ${'Chunk'.padEnd(nameWidth + 2)}  ${'modules'.padStart(modWidth)}  ${'size'.padStart(sizeWidth)}`));
+
+  const n = sorted.length;
+  for (let i = 0; i < n; i++) {
+    const { chunkName, modules } = sorted[i]!;
+    const char = styleText('dim', n === 1 ? '─' : i === 0 ? '┌' : i === n - 1 ? '└' : '├');
+    console.log(
+      `  ${char} ${styleText('cyan', '▤')} ${chunkName.padEnd(nameWidth + 2)}  ${styleText('dim', String(modules).padStart(modWidth))}  ${styleText('dim', sizes[i]!.padStart(sizeWidth))}`,
+    );
+  }
+
+  if (n > 0) {
+    const total = sorted.reduce((sum, r) => sum + r.bytes, 0);
+    console.log(styleText('dim', `\n  ${n} chunk${n === 1 ? '' : 's'} · ${prettyBytes(total)}`));
+  }
+  for (const s of skipped) {
+    console.log(styleText('yellow', `  left in place: ${s.id} — ${s.reason}.`));
+  }
+}

--- a/packages/mochi/src/cli/resourceReport.ts
+++ b/packages/mochi/src/cli/resourceReport.ts
@@ -72,7 +72,7 @@ export interface ChunkRow {
  * and the client-stats page are both gated on `development`.
  *
  * `notFormed` names groups whose modules never became a shared chunk — the one case where a user most needs telling,
- * since the config looks like it worked.
+ * since the config looks like it worked. A group that only partly moved never reaches here: that fails the build.
  */
 export function printChunkTree(rows: ChunkRow[], skipped: { id: string; reason: string }[], notFormed: string[] = []): void {
   if (rows.length === 0 && skipped.length === 0 && notFormed.length === 0) {
@@ -107,7 +107,19 @@ export function printChunkTree(rows: ChunkRow[], skipped: { id: string; reason: 
   for (const name of notFormed) {
     console.log(styleText('yellow', `  no shared chunk: ${name} — its modules are reached from one island entry, which already carries them.`));
   }
+  // One skipped-module line each buries the report when a dependency is mostly barrels — 111 of them on this site's own
+  // build — so identical reasons collapse to a count with a couple of examples.
+  const EXAMPLES = 2;
+  const byReason = new Map<string, string[]>();
   for (const s of skipped) {
-    console.log(styleText('yellow', `  left in place: ${s.id} — ${s.reason}.`));
+    byReason.set(s.reason, [...(byReason.get(s.reason) ?? []), s.id]);
+  }
+  for (const [reason, ids] of byReason) {
+    if (ids.length === 1) {
+      console.log(styleText('yellow', `  left in place: ${ids[0]} — ${reason}.`));
+      continue;
+    }
+    console.log(styleText('yellow', `  left in place: ${ids.length} modules — ${reason}.`));
+    console.log(styleText('dim', `    e.g. ${ids.slice(0, EXAMPLES).join(', ')}${ids.length > EXAMPLES ? `, …` : ''}`));
   }
 }

--- a/packages/mochi/src/cli/resourceReport.ts
+++ b/packages/mochi/src/cli/resourceReport.ts
@@ -61,10 +61,8 @@ export function printResourceTree(rows: ResourceRow[]): void {
 }
 
 export interface ChunkRow {
-  /** User-assigned name from `clientBundle.chunks`. */
-  chunkName: string;
-  /** Emitted filename, which Bun always hashes as `chunk-<hash>.js`. */
-  file: string;
+  /** User-assigned name(s) from `clientBundle.chunks`. More than one means two groups landed in the same output. */
+  chunkNames: string[];
   modules: number;
   bytes: number;
 }
@@ -72,33 +70,42 @@ export interface ChunkRow {
 /**
  * The build console is the only place a manual chunk is ever visible: chunking is production-only, while the debug bar
  * and the client-stats page are both gated on `development`.
+ *
+ * `notFormed` names groups whose modules never became a shared chunk — the one case where a user most needs telling,
+ * since the config looks like it worked.
  */
-export function printChunkTree(rows: ChunkRow[], skipped: { id: string; reason: string }[]): void {
-  if (rows.length === 0 && skipped.length === 0) {
+export function printChunkTree(rows: ChunkRow[], skipped: { id: string; reason: string }[], notFormed: string[] = []): void {
+  if (rows.length === 0 && skipped.length === 0 && notFormed.length === 0) {
     return;
   }
 
-  const sorted = [...rows].sort((a, b) => b.bytes - a.bytes || a.chunkName.localeCompare(b.chunkName));
-  const sizes = sorted.map((r) => prettyBytes(r.bytes));
-  const nameWidth = Math.max('Chunk'.length, ...sorted.map((r) => r.chunkName.length));
-  const modWidth = Math.max('modules'.length, ...sorted.map((r) => String(r.modules).length));
-  const sizeWidth = Math.max('size'.length, ...sizes.map((s) => s.length), 4);
+  const label = (r: ChunkRow) => r.chunkNames.join(' + ');
+  const sorted = [...rows].sort((a, b) => b.bytes - a.bytes || label(a).localeCompare(label(b)));
 
-  console.log('');
-  console.log(styleText('dim', `      ${'Chunk'.padEnd(nameWidth + 2)}  ${'modules'.padStart(modWidth)}  ${'size'.padStart(sizeWidth)}`));
+  if (sorted.length > 0) {
+    const sizes = sorted.map((r) => prettyBytes(r.bytes));
+    const nameWidth = Math.max('Chunk'.length, ...sorted.map((r) => label(r).length));
+    const modWidth = Math.max('modules'.length, ...sorted.map((r) => String(r.modules).length));
+    const sizeWidth = Math.max('size'.length, ...sizes.map((s) => s.length), 4);
 
-  const n = sorted.length;
-  for (let i = 0; i < n; i++) {
-    const { chunkName, modules } = sorted[i]!;
-    const char = styleText('dim', n === 1 ? '─' : i === 0 ? '┌' : i === n - 1 ? '└' : '├');
-    console.log(
-      `  ${char} ${styleText('cyan', '▤')} ${chunkName.padEnd(nameWidth + 2)}  ${styleText('dim', String(modules).padStart(modWidth))}  ${styleText('dim', sizes[i]!.padStart(sizeWidth))}`,
-    );
-  }
+    console.log('');
+    console.log(styleText('dim', `      ${'Chunk'.padEnd(nameWidth + 2)}  ${'modules'.padStart(modWidth)}  ${'size'.padStart(sizeWidth)}`));
 
-  if (n > 0) {
+    const n = sorted.length;
+    for (let i = 0; i < n; i++) {
+      const row = sorted[i]!;
+      const char = styleText('dim', n === 1 ? '─' : i === 0 ? '┌' : i === n - 1 ? '└' : '├');
+      console.log(
+        `  ${char} ${styleText('cyan', '▤')} ${label(row).padEnd(nameWidth + 2)}  ${styleText('dim', String(row.modules).padStart(modWidth))}  ${styleText('dim', sizes[i]!.padStart(sizeWidth))}`,
+      );
+    }
+
     const total = sorted.reduce((sum, r) => sum + r.bytes, 0);
     console.log(styleText('dim', `\n  ${n} chunk${n === 1 ? '' : 's'} · ${prettyBytes(total)}`));
+  }
+
+  for (const name of notFormed) {
+    console.log(styleText('yellow', `  no shared chunk: ${name} — its modules are reached from one island entry, which already carries them.`));
   }
   for (const s of skipped) {
     console.log(styleText('yellow', `  left in place: ${s.id} — ${s.reason}.`));

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -23,6 +23,7 @@ import type { MarkdownConfig, MochiBarrelWarningOptions, MochiClientBundleOption
 import {
   CHUNK_NAMESPACE,
   classifyModules,
+  attributeChunks,
   chunkResolveFilter,
   evaluationOrder,
   isChunkModuleId,
@@ -316,6 +317,32 @@ export interface ComponentRegistryOptions {
    * would never surface there. Default: `false`.
    */
   bufferBarrelWarnings?: boolean;
+}
+
+/** Names the modules a group could not take with it, so the classifier can exclude exactly those. */
+function formatPartialChunkError(
+  partial: { name: string; placed: number; total: number }[],
+  plan: ChunkPlan | null,
+  outputs: Record<string, { inputs: Record<string, unknown> }>,
+  namesByOutput: Map<string, string[]>,
+): string {
+  const LIST_LIMIT = 12;
+  const lines: string[] = [];
+  for (const { name, placed, total } of partial) {
+    const outPath = [...namesByOutput].find(([, names]) => names.includes(name))?.[0];
+    const landed = new Set(Object.keys(outputs[outPath ?? '']?.inputs ?? {}).map((i) => posixAbs(i)));
+    const strays = (plan?.members.get(name) ?? []).filter((m) => !landed.has(m)).map((m) => relForDisplay(m));
+    lines.push(`  "${name}": ${placed} of ${total} modules moved. Left behind:`);
+    lines.push(...strays.slice(0, LIST_LIMIT).map((s) => `    - ${s}`));
+    if (strays.length > LIST_LIMIT) {
+      lines.push(`    …and ${strays.length - LIST_LIMIT} more`);
+    }
+  }
+  return (
+    `[mochi] clientBundle.chunks could not move every module of ${partial.length === 1 ? 'a group' : 'some groups'}, ` +
+    `which produces a bundle that throws when an island hydrates:\n${lines.join('\n')}\n` +
+    `Return null for those modules from your \`chunks\` classifier, or drop the group.`
+  );
 }
 
 /** Deletes files a build left behind in its own output directory. Cleanup must never fail a build that succeeded. */
@@ -1375,7 +1402,7 @@ export class ComponentRegistry {
           newComponentEntryUrls.set(compName, url);
         }
       }
-      const formedChunks = new Set<string>();
+      const { namesByOutput, unformed, partial } = attributeChunks(result.metafile.outputs, chunkPlan);
       const outputStats = Object.entries(result.metafile.outputs).map(([outPath, outMeta]) => {
         const inputs = Object.entries(outMeta.inputs).map(([inputPath, inputMeta]) => ({
           path: toPosixPath(inputPath).replace(toPosixPath(path.resolve('.')) + '/', ''),
@@ -1383,26 +1410,25 @@ export class ComponentRegistry {
         }));
         inputs.sort((a, b) => b.size - a.size);
         const imports = (outMeta.imports ?? []).filter((i) => i.kind === 'import-statement').map((i) => path.basename(i.path));
-        // Bun names every split chunk `chunk-<hash>.js` and its `[name]` template resolves to a reaching *entry's*
-        // name, so recording the user's name here is the only way it survives into the build's chunk report. Entry
-        // outputs are excluded: one reaching island inlines its group rather than sharing it, and reporting that as a
-        // chunk tells the user their config worked in the one case where it did nothing.
-        const outInputs = new Set(Object.keys(outMeta.inputs).map((i) => posixAbs(i)));
-        const chunkNames = chunkPlan && !outMeta.entryPoint ? [...chunkPlan.members].filter(([, members]) => members.every((m) => outInputs.has(m))).map(([name]) => name) : [];
-        for (const name of chunkNames) {
-          formedChunks.add(name);
-        }
+        const chunkNames = namesByOutput.get(outPath);
         return {
           name: path.basename(outPath),
           size: outMeta.bytes,
           inputs,
           imports,
-          ...(chunkNames.length > 0 ? { chunkNames } : {}),
+          ...(chunkNames ? { chunkNames } : {}),
         };
       });
       outputStats.sort((a, b) => b.size - a.size);
-      this.unformedChunks = chunkPlan ? [...chunkPlan.members.keys()].filter((name) => !formedChunks.has(name)).sort() : [];
+      this.unformedChunks = unformed;
       this.clientStats = { outputs: outputStats };
+      // A group that only half-moves leaves its members reachable both through their view and directly, and Bun then
+      // emits entry code referencing bindings it never exports — the island throws `ReferenceError` on hydration while
+      // the build looks clean. Nothing here can tell a survivable split from a fatal one, so a partial move fails the
+      // build: a named error beats a bundle that breaks only in a browser.
+      if (partial.length > 0) {
+        throw new Error(formatPartialChunkError(partial, chunkPlan, result.metafile.outputs, namesByOutput));
+      }
       this.warnOnRetainedComponentStubs(result.metafile);
       this.warnOnBarrelImports(result.metafile);
     }

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -19,7 +19,18 @@ import type { DebugBarData } from '../runtime/requestContext';
 import { logger } from '../utils/log';
 import { mochiEvents } from '../events';
 import { detectHeavyBarrels, formatBarrelLine, formatBarrelSummary, type BarrelMetafile, type HeavyBarrel } from './barrelDetect';
-import type { MarkdownConfig, MochiBarrelWarningOptions, MochiManifest, MochiSvelteShakerOptions } from '../types';
+import type { MarkdownConfig, MochiBarrelWarningOptions, MochiClientBundleOptions, MochiManifest, MochiSvelteShakerOptions } from '../types';
+import {
+  CHUNK_NAMESPACE,
+  classifyModules,
+  chunkResolveFilter,
+  isChunkModuleId,
+  planChunks,
+  resolveChunkMember,
+  validateClientBundleOptions,
+  viewId,
+  type ChunkPlan,
+} from './clientBundleChunks';
 import { type HydratableComponent, type PreprocessIslandError, type ServerIslandComponent } from './svelteAstPreprocess';
 import { cachedPreprocessHydratable, createPreprocessCacheStats } from './preprocessCache';
 import { CompileCache, compileFingerprint, createCompileCacheStats, type CompileCacheStats } from './compileCache';
@@ -293,6 +304,8 @@ export interface ComponentRegistryOptions {
   markdown?: MarkdownConfig;
   /** Run the whole-program svelte-shaker pass before compiling. Production only — `prepareShake()` is a no-op in dev. */
   optimize?: boolean | MochiSvelteShakerOptions;
+  /** See `MochiServeOptions.clientBundle`. Production only — ignored when `development` is true. */
+  clientBundle?: MochiClientBundleOptions;
   /** See `MochiServeOptions.barrelWarnings`. */
   barrelWarnings?: boolean | MochiBarrelWarningOptions;
   /**
@@ -384,6 +397,8 @@ export class ComponentRegistry {
       size: number;
       inputs: { path: string; size: number }[];
       imports: string[];
+      /** User-assigned name from `clientBundle.chunks`, when this output is a manual chunk. */
+      chunkName?: string;
     }[];
   } | null = null;
   /** Stats for side-effect CSS bundles, merged into clientStats at read time. */
@@ -392,6 +407,7 @@ export class ComponentRegistry {
     size: number;
     inputs: { path: string; size: number }[];
     imports: string[];
+    chunkName?: string;
   }[] = [];
   /** Maps server island component name → resolved file path */
   private serverIslandPaths: Map<string, string> = new Map();
@@ -411,6 +427,9 @@ export class ComponentRegistry {
   private readonly svelteCompiler: MochiSvelteCompiler | undefined;
   readonly markdown: MarkdownConfig | undefined;
   readonly optimize: boolean | MochiSvelteShakerOptions;
+  private readonly clientBundle: MochiClientBundleOptions | undefined;
+  /** Modules the chunk classifier picked but which were skipped, surfaced by the build's chunk report. */
+  private skippedChunkModules: { id: string; reason: string }[] = [];
   private readonly barrelWarningsEnabled: boolean;
   private readonly barrelIgnore: Set<string>;
   private readonly barrelMinBytes: number;
@@ -440,6 +459,12 @@ export class ComponentRegistry {
     this.svelteCompiler = opts.svelteCompiler;
     this.markdown = opts.markdown;
     this.optimize = opts.optimize ?? false;
+    // Validate at construction so a malformed option fails at `Mochi.serve()` / the top of `build()`, naming the
+    // offending key, rather than surfacing deep inside a bundle.
+    this.clientBundle = validateClientBundleOptions(opts.clientBundle);
+    if (this.development && this.clientBundle) {
+      logger.info('[mochi] clientBundle is ignored in development — manual chunking runs in production builds only. Run `mochi-framework build` to see the chunked output.');
+    }
     const bw = opts.barrelWarnings;
     this.barrelWarningsEnabled = bw !== false;
     this.barrelIgnore = new Set(typeof bw === 'object' ? (bw.ignore ?? []) : []);
@@ -1088,6 +1113,8 @@ export class ComponentRegistry {
     const newClientFiles = new Map<string, string>();
     const newComponentEntryUrls = new Map<string, string>();
     let newIslandBootstrapUrl: string | null = null;
+    /** Set by the discovery pass when the user's classifier assigned at least one module. */
+    let chunkPlan: ChunkPlan | null = null;
 
     // The debug bar builds standalone (production-mode Svelte, own runtime) and only once per process — framework
     // sources don't change under a running user app, so watcher rebuilds skip it entirely.
@@ -1127,9 +1154,49 @@ export class ComponentRegistry {
       rejectUnknown: this.loadedFromManifest && !this.development,
     });
 
-    const clientPlugin: BunPlugin = {
+    // Built once per pass: pass 1 discovers the graph with no plan, pass 2 rebuilds it with one.
+    const makeClientPlugin = (plan: ChunkPlan | null): BunPlugin => ({
       name: 'svelte-client',
       setup(build) {
+        if (plan) {
+          // Assigned modules resolve to a generated view, which re-exports the real module and links it into its
+          // group's ring. Specifiers are resolved here rather than matched against pass 1's metafile edges, because
+          // Bun reports `imports[].original` only on an edge's first occurrence and leaves `path` unresolved on the rest.
+          //
+          // One handler covers both directions. A namespace-scoped registration does not fire for the generated
+          // modules' own imports, and a catch-all filter stops Bun resolving the `files:` entrypoints altogether.
+          build.onResolve(
+            {
+              filter: chunkResolveFilter(
+                plan.chunkOf,
+                Object.keys(filesMap).map((f) => path.basename(f)),
+              ),
+            },
+            (args) => {
+              if (plan.sources.has(args.path)) {
+                return { path: args.path, namespace: CHUNK_NAMESPACE };
+              }
+              // A view imports its real module and the next view in the ring; redirecting those would loop them back.
+              if (isChunkModuleId(args.importer)) {
+                return { path: args.path, namespace: 'file' };
+              }
+              // An empty importer means Bun is resolving an entrypoint; an entrypoint is never a chunk member.
+              if (!args.importer) {
+                return undefined;
+              }
+              const abs = resolveChunkMember(args);
+              if (!abs) {
+                return undefined;
+              }
+              const target = plan.chunkOf.get(abs);
+              // Only edges crossing into the group are redirected. Rewriting one member's import of another would route
+              // it through that member's view and around the group's ring, putting the real modules in a cycle and
+              // reordering their initialization — which breaks packages with circular internals.
+              return target && plan.chunkOf.get(toPosixPath(args.importer)) !== target ? { path: viewId(abs), namespace: CHUNK_NAMESPACE } : undefined;
+            },
+          );
+          build.onLoad({ filter: /.*/, namespace: CHUNK_NAMESPACE }, (args) => ({ contents: plan.sources.get(args.path)!, loader: 'js' }));
+        }
         build.onLoad({ filter: applyFilter('image:fileFilter', IMAGE_FILE_FILTER, { target: 'client' }) }, imageAssetLoader);
         // Mirrors the SSR side-effect-CSS strip, since the SSR-rendered `<head>` already links the bundle via
         // entryImportedCss → importedCssUrls. Bun's default CSS handling would otherwise inline JS-injected styles or
@@ -1204,33 +1271,55 @@ export class ComponentRegistry {
           );
         }
       },
-    };
-
-    const result = await Bun.build({
-      entrypoints,
-      files: filesMap,
-      // The guard goes first so its `onResolve` sees a server-only specifier
-      // before any of the client plugin's own handlers can claim it.
-      plugins: [serverOnlyModuleGuard, clientPlugin],
-      target: 'browser',
-      conditions: ['svelte', ...(development ? ['development'] : ['production'])],
-      define: {
-        DEV: String(development),
-        BROWSER: 'true',
-        NODE: 'false',
-        ...CLIENT_BUILD_DEFINE,
-      },
-      minify: true,
-      splitting: true,
-      naming: '[name]-[hash].[ext]',
-      publicPath: `${this.assetPrefix}/client/`,
-      outdir: path.resolve(`${this.outDir}/svelte-client`),
-      metafile: true,
-      throw: false,
     });
 
+    const runBuild = (plan: ChunkPlan | null) =>
+      Bun.build({
+        entrypoints,
+        files: filesMap,
+        // The guard goes first so its `onResolve` sees a server-only specifier
+        // before any of the client plugin's own handlers can claim it.
+        plugins: [serverOnlyModuleGuard, makeClientPlugin(plan)],
+        target: 'browser',
+        conditions: ['svelte', ...(development ? ['development'] : ['production'])],
+        define: {
+          DEV: String(development),
+          BROWSER: 'true',
+          NODE: 'false',
+          ...CLIENT_BUILD_DEFINE,
+        },
+        minify: true,
+        splitting: this.clientBundle?.splitting ?? true,
+        naming: '[name]-[hash].[ext]',
+        publicPath: `${this.assetPrefix}/client/`,
+        outdir: path.resolve(`${this.outDir}/svelte-client`),
+        metafile: true,
+        throw: false,
+      });
+
+    let result = await runBuild(null);
     if (!result.success) {
       throw new Error(`Svelte client build failed:\n${formatBuildMessages(result.logs)}`);
+    }
+
+    // A classifier over module ids needs the module graph, and Bun resolves entrypoints before anything else — so a
+    // group's members can't be computed lazily during the first build. Hence the discovery pass. Production only:
+    // per-file HMR can't reuse a whole-graph chunk layout, same reasoning as `optimize`.
+    const chunkClassifier = this.development ? undefined : this.clientBundle?.chunks;
+    this.skippedChunkModules = [];
+    if (chunkClassifier && result.metafile) {
+      const { chunkOf, skipped, defaultOf } = classifyModules(result.metafile, chunkClassifier, {
+        entrypoints: new Set(entrypoints.map((e) => toPosixPath(path.resolve(e)))),
+      });
+      this.skippedChunkModules = skipped;
+      if (chunkOf.size > 0) {
+        const plan = planChunks(chunkOf, (abs) => defaultOf.get(abs) ?? false);
+        result = await runBuild(plan);
+        if (!result.success) {
+          throw new Error(`Svelte client build failed (manual chunks):\n${formatBuildMessages(result.logs)}`);
+        }
+        chunkPlan = plan;
+      }
     }
 
     for (const output of result.outputs) {
@@ -1271,11 +1360,16 @@ export class ComponentRegistry {
         }));
         inputs.sort((a, b) => b.size - a.size);
         const imports = (outMeta.imports ?? []).filter((i) => i.kind === 'import-statement').map((i) => path.basename(i.path));
+        // Bun names every split chunk `chunk-<hash>.js` and its `[name]` template resolves to a reaching *entry's*
+        // name, so recording the user's name here is the only way it survives into the build's chunk report.
+        const outInputs = new Set(Object.keys(outMeta.inputs).map((i) => toPosixPath(path.resolve(i))));
+        const chunkName = chunkPlan ? [...chunkPlan.members].find(([, members]) => members.every((m) => outInputs.has(m)))?.[0] : undefined;
         return {
           name: path.basename(outPath),
           size: outMeta.bytes,
           inputs,
           imports,
+          ...(chunkName ? { chunkName } : {}),
         };
       });
       outputStats.sort((a, b) => b.size - a.size);
@@ -1837,6 +1931,11 @@ export class ComponentRegistry {
       return this.importedCssStats.length > 0 ? { outputs: [...this.importedCssStats] } : null;
     }
     return { outputs: [...this.clientStats.outputs, ...this.importedCssStats] };
+  }
+
+  /** Modules `clientBundle.chunks` selected but that were left where Bun put them, with the reason. */
+  getSkippedChunkModules(): { id: string; reason: string }[] {
+    return [...this.skippedChunkModules];
   }
 
   getDebugBarUrl(): string | null {

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -27,6 +27,7 @@ import {
   evaluationOrder,
   isChunkModuleId,
   planChunks,
+  posixAbs,
   resolveChunkMember,
   validateClientBundleOptions,
   viewId,
@@ -1208,7 +1209,7 @@ export class ComponentRegistry {
               // Only edges crossing into the group are redirected. Rewriting one member's import of another would route
               // it through that member's view and around the group's ring, putting the real modules in a cycle and
               // reordering their initialization — which breaks packages with circular internals.
-              return target && plan.chunkOf.get(toPosixPath(args.importer)) !== target ? { path: viewId(abs), namespace: CHUNK_NAMESPACE } : undefined;
+              return target && plan.chunkOf.get(posixAbs(args.importer)) !== target ? { path: viewId(abs), namespace: CHUNK_NAMESPACE } : undefined;
             },
           );
           build.onLoad({ filter: /.*/, namespace: CHUNK_NAMESPACE }, (args) => ({ contents: plan.sources.get(args.path)!, loader: 'js' }));
@@ -1326,7 +1327,7 @@ export class ComponentRegistry {
     this.unformedChunks = [];
     if (chunkClassifier && result.metafile) {
       const { chunkOf, skipped, defaultOf } = classifyModules(result.metafile, chunkClassifier, {
-        entrypoints: new Set(entrypoints.map((e) => toPosixPath(path.resolve(e)))),
+        entrypoints: new Set(entrypoints.map((e) => posixAbs(e))),
       });
       this.skippedChunkModules = skipped;
       if (chunkOf.size > 0) {
@@ -1386,7 +1387,7 @@ export class ComponentRegistry {
         // name, so recording the user's name here is the only way it survives into the build's chunk report. Entry
         // outputs are excluded: one reaching island inlines its group rather than sharing it, and reporting that as a
         // chunk tells the user their config worked in the one case where it did nothing.
-        const outInputs = new Set(Object.keys(outMeta.inputs).map((i) => toPosixPath(path.resolve(i))));
+        const outInputs = new Set(Object.keys(outMeta.inputs).map((i) => posixAbs(i)));
         const chunkNames = chunkPlan && !outMeta.entryPoint ? [...chunkPlan.members].filter(([, members]) => members.every((m) => outInputs.has(m))).map(([name]) => name) : [];
         for (const name of chunkNames) {
           formedChunks.add(name);

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -24,6 +24,7 @@ import {
   CHUNK_NAMESPACE,
   classifyModules,
   chunkResolveFilter,
+  evaluationOrder,
   isChunkModuleId,
   planChunks,
   resolveChunkMember,
@@ -316,6 +317,19 @@ export interface ComponentRegistryOptions {
   bufferBarrelWarnings?: boolean;
 }
 
+/** Deletes files a build left behind in its own output directory. Cleanup must never fail a build that succeeded. */
+function pruneStaleOutputs(dir: string, keep: Set<string>): void {
+  try {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      if (entry.isFile() && !keep.has(entry.name)) {
+        fs.rmSync(path.join(dir, entry.name), { force: true });
+      }
+    }
+  } catch {
+    // Nothing on disk to prune (an in-memory or never-written outDir), which is fine.
+  }
+}
+
 // Runs once per compiled-component entry (compileAll / fromManifest) so renderComponent reads these lookups instead of
 // rebuilding three collections on every render.
 function indexHydratables(hydratables: HydratableComponent[]): {
@@ -397,8 +411,8 @@ export class ComponentRegistry {
       size: number;
       inputs: { path: string; size: number }[];
       imports: string[];
-      /** User-assigned name from `clientBundle.chunks`, when this output is a manual chunk. */
-      chunkName?: string;
+      /** User-assigned name(s) from `clientBundle.chunks`, when this output really is a shared chunk they produced. */
+      chunkNames?: string[];
     }[];
   } | null = null;
   /** Stats for side-effect CSS bundles, merged into clientStats at read time. */
@@ -407,7 +421,7 @@ export class ComponentRegistry {
     size: number;
     inputs: { path: string; size: number }[];
     imports: string[];
-    chunkName?: string;
+    chunkNames?: string[];
   }[] = [];
   /** Maps server island component name → resolved file path */
   private serverIslandPaths: Map<string, string> = new Map();
@@ -430,6 +444,8 @@ export class ComponentRegistry {
   private readonly clientBundle: MochiClientBundleOptions | undefined;
   /** Modules the chunk classifier picked but which were skipped, surfaced by the build's chunk report. */
   private skippedChunkModules: { id: string; reason: string }[] = [];
+  /** Chunk names whose modules never landed in a shared chunk, surfaced by the build's chunk report. */
+  private unformedChunks: string[] = [];
   private readonly barrelWarningsEnabled: boolean;
   private readonly barrelIgnore: Set<string>;
   private readonly barrelMinBytes: number;
@@ -1307,13 +1323,14 @@ export class ComponentRegistry {
     // per-file HMR can't reuse a whole-graph chunk layout, same reasoning as `optimize`.
     const chunkClassifier = this.development ? undefined : this.clientBundle?.chunks;
     this.skippedChunkModules = [];
+    this.unformedChunks = [];
     if (chunkClassifier && result.metafile) {
       const { chunkOf, skipped, defaultOf } = classifyModules(result.metafile, chunkClassifier, {
         entrypoints: new Set(entrypoints.map((e) => toPosixPath(path.resolve(e)))),
       });
       this.skippedChunkModules = skipped;
       if (chunkOf.size > 0) {
-        const plan = planChunks(chunkOf, (abs) => defaultOf.get(abs) ?? false);
+        const plan = planChunks(chunkOf, (abs) => defaultOf.get(abs) ?? false, evaluationOrder(result.metafile));
         result = await runBuild(plan);
         if (!result.success) {
           throw new Error(`Svelte client build failed (manual chunks):\n${formatBuildMessages(result.logs)}`);
@@ -1326,6 +1343,10 @@ export class ComponentRegistry {
       const filename = path.basename(output.path);
       newClientFiles.set(`${this.assetPrefix}/client/${filename}`, await output.text());
     }
+    // Every pass writes a full set of hashed files to the same directory and `Bun.build` never empties it, so the
+    // discovery pass's outputs — and any earlier rebuild's — would otherwise be shipped alongside the real ones. Only
+    // client JS lives here; CSS goes to sibling directories.
+    pruneStaleOutputs(path.resolve(`${this.outDir}/svelte-client`), new Set(result.outputs.map((o) => path.basename(o.path))));
 
     // Map entry-point outputs back to components using metafile.entryPoint
     // This avoids fragile filename matching.
@@ -1353,6 +1374,7 @@ export class ComponentRegistry {
           newComponentEntryUrls.set(compName, url);
         }
       }
+      const formedChunks = new Set<string>();
       const outputStats = Object.entries(result.metafile.outputs).map(([outPath, outMeta]) => {
         const inputs = Object.entries(outMeta.inputs).map(([inputPath, inputMeta]) => ({
           path: toPosixPath(inputPath).replace(toPosixPath(path.resolve('.')) + '/', ''),
@@ -1361,18 +1383,24 @@ export class ComponentRegistry {
         inputs.sort((a, b) => b.size - a.size);
         const imports = (outMeta.imports ?? []).filter((i) => i.kind === 'import-statement').map((i) => path.basename(i.path));
         // Bun names every split chunk `chunk-<hash>.js` and its `[name]` template resolves to a reaching *entry's*
-        // name, so recording the user's name here is the only way it survives into the build's chunk report.
+        // name, so recording the user's name here is the only way it survives into the build's chunk report. Entry
+        // outputs are excluded: one reaching island inlines its group rather than sharing it, and reporting that as a
+        // chunk tells the user their config worked in the one case where it did nothing.
         const outInputs = new Set(Object.keys(outMeta.inputs).map((i) => toPosixPath(path.resolve(i))));
-        const chunkName = chunkPlan ? [...chunkPlan.members].find(([, members]) => members.every((m) => outInputs.has(m)))?.[0] : undefined;
+        const chunkNames = chunkPlan && !outMeta.entryPoint ? [...chunkPlan.members].filter(([, members]) => members.every((m) => outInputs.has(m))).map(([name]) => name) : [];
+        for (const name of chunkNames) {
+          formedChunks.add(name);
+        }
         return {
           name: path.basename(outPath),
           size: outMeta.bytes,
           inputs,
           imports,
-          ...(chunkName ? { chunkName } : {}),
+          ...(chunkNames.length > 0 ? { chunkNames } : {}),
         };
       });
       outputStats.sort((a, b) => b.size - a.size);
+      this.unformedChunks = chunkPlan ? [...chunkPlan.members.keys()].filter((name) => !formedChunks.has(name)).sort() : [];
       this.clientStats = { outputs: outputStats };
       this.warnOnRetainedComponentStubs(result.metafile);
       this.warnOnBarrelImports(result.metafile);
@@ -1936,6 +1964,11 @@ export class ComponentRegistry {
   /** Modules `clientBundle.chunks` selected but that were left where Bun put them, with the reason. */
   getSkippedChunkModules(): { id: string; reason: string }[] {
     return [...this.skippedChunkModules];
+  }
+
+  /** Chunk names `clientBundle.chunks` produced that never became a shared chunk, so the report can say so. */
+  getUnformedChunks(): string[] {
+    return [...this.unformedChunks];
   }
 
   getDebugBarUrl(): string | null {

--- a/packages/mochi/src/compiler/clientBundleChunkBundle.test.ts
+++ b/packages/mochi/src/compiler/clientBundleChunkBundle.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { ComponentRegistry } from './ComponentRegistry';
+import { mochiEvents } from '../events';
+
+const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'client-bundle-chunks');
+const PAGE_A = path.join(FIXTURE_DIR, 'PageA.svelte');
+const PAGE_B = path.join(FIXTURE_DIR, 'PageB.svelte');
+
+// Both vendor modules export a colliding `parse`, so a formulation that merged the group's exports into one surface
+// would resolve the wrong one — the failure this fixture exists to catch.
+const intoVendor = (id: string) => (id.includes('client-bundle-chunks/vendor') ? 'vendor' : null);
+
+let outDir: string;
+let bundleEvents: number;
+const onBundle = () => {
+  bundleEvents += 1;
+};
+
+beforeEach(() => {
+  // src/compiler/ is two levels below the package root, and a Mochi outDir must stay inside the project tree.
+  outDir = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-chunk-bundle-'));
+  bundleEvents = 0;
+  mochiEvents.on('client-bundle:complete', onBundle);
+});
+
+afterEach(() => {
+  mochiEvents.off('client-bundle:complete', onBundle);
+  rmSync(outDir, { recursive: true, force: true });
+});
+
+const outputs = (registry: ComponentRegistry) => registry.getClientStats()?.outputs ?? [];
+const inputPaths = (o: { inputs: { path: string }[] }) => o.inputs.map((i) => i.path);
+/** Inputs that are real source files, dropping the generated view modules the mechanism inserts. */
+const realInputs = (o: { inputs: { path: string }[] }) => inputPaths(o).filter((p) => !p.includes('mochi-chunk:'));
+
+describe('clientBundle.chunks', () => {
+  test('collapses the named modules into one shared chunk, out of the island entries', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoVendor } });
+    await registry.compileAll([PAGE_A, PAGE_B]);
+
+    const named = outputs(registry).filter((o) => o.chunkName === 'vendor');
+    expect(named).toHaveLength(1);
+
+    const chunkInputs = realInputs(named[0]!).join('\n');
+    expect(chunkInputs).toContain('vendorOne.ts');
+    expect(chunkInputs).toContain('vendorTwo.ts');
+
+    // The point of the feature: the real vendor modules left the per-island entries. Each entry keeps a generated
+    // view module named after its source, which is a re-export shim and not the module itself.
+    for (const o of outputs(registry)) {
+      if (o.chunkName === 'vendor') {
+        continue;
+      }
+      expect(realInputs(o).join('\n')).not.toContain('vendorOne.ts');
+      expect(realInputs(o).join('\n')).not.toContain('vendorTwo.ts');
+    }
+  });
+
+  test('every emitted output is actually served', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoVendor } });
+    await registry.compileAll([PAGE_A, PAGE_B]);
+
+    const files = registry.getClientFiles();
+    for (const o of outputs(registry)) {
+      expect(files.has(`${registry.assetPrefix}/client/${o.name}`)).toBe(true);
+    }
+  });
+
+  test('islands still resolve to their own entry bundles', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoVendor } });
+    await registry.compileAll([PAGE_A, PAGE_B]);
+
+    expect(registry.getIslandBootstrapUrl()).not.toBeNull();
+    const urls = outputs(registry)
+      .filter((o) => o.chunkName === undefined)
+      .map((o) => o.name);
+    expect(urls.length).toBeGreaterThan(0);
+  });
+
+  // The colliding `parse` must not be flattened: each island keeps its own binding.
+  test('a chunk carrying two modules with the same export name still builds', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoVendor } });
+    await expect(registry.compileAll([PAGE_A, PAGE_B])).resolves.toBeUndefined();
+    expect(registry.getErrors()).toHaveLength(0);
+  });
+
+  test('a classifier that matches nothing leaves the bundle exactly as it was', async () => {
+    const plain = new ComponentRegistry({ development: false, outDir });
+    await plain.compileAll([PAGE_A, PAGE_B]);
+    const before = outputs(plain)
+      .map((o) => `${o.name}:${o.size}`)
+      .sort();
+
+    const other = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-chunk-bundle-'));
+    try {
+      const withOpt = new ComponentRegistry({ development: false, outDir: other, clientBundle: { chunks: () => null } });
+      await withOpt.compileAll([PAGE_A, PAGE_B]);
+      const after = outputs(withOpt)
+        .map((o) => `${o.name}:${o.size}`)
+        .sort();
+      expect(after).toEqual(before);
+    } finally {
+      rmSync(other, { recursive: true, force: true });
+    }
+  });
+
+  test('an invalid chunk name fails the build and names the offender', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: (id) => (id.includes('vendorOne') ? '../escape' : null) } });
+    await expect(registry.compileAll([PAGE_A])).rejects.toThrow(/Invalid chunk name .*vendorOne/s);
+  });
+
+  test('a malformed option is rejected at construction, before any build runs', () => {
+    expect(() => new ComponentRegistry({ development: false, outDir, clientBundle: { nope: true } as never })).toThrow(/Unknown clientBundle option "nope"/);
+  });
+});
+
+describe('clientBundle in development', () => {
+  // Production-only is the guarantee the whole design rests on: dev must pay nothing and behave identically.
+  test('ignores chunks entirely — no discovery pass, no named chunk', async () => {
+    const registry = new ComponentRegistry({ development: true, outDir, debugBar: false, clientBundle: { chunks: intoVendor } });
+    await registry.compileAll([PAGE_A, PAGE_B]);
+
+    expect(bundleEvents).toBe(1);
+    expect(outputs(registry).some((o) => o.chunkName !== undefined)).toBe(false);
+    expect(registry.getSkippedChunkModules()).toHaveLength(0);
+  });
+});

--- a/packages/mochi/src/compiler/clientBundleChunkBundle.test.ts
+++ b/packages/mochi/src/compiler/clientBundleChunkBundle.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import { ComponentRegistry } from './ComponentRegistry';
 import { mochiEvents } from '../events';
@@ -40,7 +40,7 @@ describe('clientBundle.chunks', () => {
     const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoVendor } });
     await registry.compileAll([PAGE_A, PAGE_B]);
 
-    const named = outputs(registry).filter((o) => o.chunkName === 'vendor');
+    const named = outputs(registry).filter((o) => o.chunkNames?.includes('vendor'));
     expect(named).toHaveLength(1);
 
     const chunkInputs = realInputs(named[0]!).join('\n');
@@ -50,7 +50,7 @@ describe('clientBundle.chunks', () => {
     // The point of the feature: the real vendor modules left the per-island entries. Each entry keeps a generated
     // view module named after its source, which is a re-export shim and not the module itself.
     for (const o of outputs(registry)) {
-      if (o.chunkName === 'vendor') {
+      if (o.chunkNames?.includes('vendor')) {
         continue;
       }
       expect(realInputs(o).join('\n')).not.toContain('vendorOne.ts');
@@ -74,7 +74,7 @@ describe('clientBundle.chunks', () => {
 
     expect(registry.getIslandBootstrapUrl()).not.toBeNull();
     const urls = outputs(registry)
-      .filter((o) => o.chunkName === undefined)
+      .filter((o) => o.chunkNames === undefined)
       .map((o) => o.name);
     expect(urls.length).toBeGreaterThan(0);
   });
@@ -114,6 +114,63 @@ describe('clientBundle.chunks', () => {
   test('a malformed option is rejected at construction, before any build runs', () => {
     expect(() => new ComponentRegistry({ development: false, outDir, clientBundle: { nope: true } as never })).toThrow(/Unknown clientBundle option "nope"/);
   });
+
+  // The discovery pass writes a full set of hashed outputs to the same directory as the real one and `Bun.build` never
+  // empties it, so without a prune the build ships two copies of the client bundle.
+  test('leaves nothing on disk that the build did not emit', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoVendor } });
+    await registry.compileAll([PAGE_A, PAGE_B]);
+
+    const onDisk = readdirSync(path.join(outDir, 'svelte-client')).sort();
+    expect(onDisk).toEqual(
+      outputs(registry)
+        .map((o) => o.name)
+        .sort(),
+    );
+  });
+
+  // A group reached from a single island is inlined into that entry rather than shared, and naming the entry as if it
+  // were a chunk reports success in exactly the case where the config did nothing.
+  test('a group that never becomes a shared chunk is reported as such, not as a chunk', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: (id) => (id.includes('vendorOne') ? 'solo' : null) } });
+    await registry.compileAll([PAGE_A]);
+
+    expect(outputs(registry).some((o) => o.chunkNames !== undefined)).toBe(false);
+    expect(registry.getUnformedChunks()).toEqual(['solo']);
+  });
+
+  test('a group that does become a shared chunk is not reported as unformed', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoVendor } });
+    await registry.compileAll([PAGE_A, PAGE_B]);
+
+    expect(registry.getUnformedChunks()).toEqual([]);
+  });
+});
+
+// Grouping hoists a group to wherever its first member was reached, so the one thing it must preserve is the members'
+// order relative to each other. Both fixtures' modules are independent — no import edge orders them — so the only
+// thing that can carry the sequence is the plan itself.
+describe('clientBundle.chunks module order', () => {
+  const ORDER_PAGE = path.join(FIXTURE_DIR, 'PageOrder.svelte');
+  const SOURCE_ORDER = ['aFirst', 'zSecond', 'bOne', 'aTwo', 'cThree'];
+  const intoOrderGroups = (id: string) => {
+    if (id.includes('/aFirst.ts') || id.includes('/zSecond.ts')) {
+      return 'alpha';
+    }
+    return ['/bOne.ts', '/aTwo.ts', '/cThree.ts'].some((m) => id.includes(m)) ? 'beta' : null;
+  };
+
+  test('members keep the order they ran in before they were grouped', async () => {
+    const registry = new ComponentRegistry({ development: false, outDir, clientBundle: { chunks: intoOrderGroups } });
+    await registry.compileAll([ORDER_PAGE]);
+
+    // Each fixture module pushes its own name, so the surviving string literals read out the initialization order.
+    const bundle = [...registry.getClientFiles().values()].find((text) => text.includes('"aFirst"'))!;
+    const emitted = SOURCE_ORDER.map((name) => [name, bundle.indexOf(`"${name}"`)] as const)
+      .sort((a, b) => a[1] - b[1])
+      .map(([name]) => name);
+    expect(emitted).toEqual(SOURCE_ORDER);
+  });
 });
 
 describe('clientBundle in development', () => {
@@ -123,7 +180,7 @@ describe('clientBundle in development', () => {
     await registry.compileAll([PAGE_A, PAGE_B]);
 
     expect(bundleEvents).toBe(1);
-    expect(outputs(registry).some((o) => o.chunkName !== undefined)).toBe(false);
+    expect(outputs(registry).some((o) => o.chunkNames !== undefined)).toBe(false);
     expect(registry.getSkippedChunkModules()).toHaveLength(0);
   });
 });

--- a/packages/mochi/src/compiler/clientBundleChunks.test.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { classifyModules, evaluationOrder, hasDefaultExport, packageNameOf, planChunks, validateClientBundleOptions, viewId, type ChunkMetafile } from './clientBundleChunks';
-import { toPosixPath } from '../utils/index';
+import {
+  classifyModules,
+  evaluationOrder,
+  hasDefaultExport,
+  packageNameOf,
+  planChunks,
+  posixAbs,
+  validateClientBundleOptions,
+  viewId,
+  type ChunkMetafile,
+} from './clientBundleChunks';
 
-const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'client-bundle-chunks');
-const VENDOR_ONE = path.join(FIXTURE_DIR, 'vendorOne.ts');
-const VENDOR_TWO = path.join(FIXTURE_DIR, 'vendorTwo.ts');
+const FIXTURE_DIR = posixAbs(path.join(import.meta.dir, '..', '__fixtures__', 'client-bundle-chunks'));
+const VENDOR_ONE = posixAbs('vendorOne.ts', FIXTURE_DIR);
+const VENDOR_TWO = posixAbs('vendorTwo.ts', FIXTURE_DIR);
 
 const metafile = (inputs: Record<string, { bytes: number; format?: string }>): ChunkMetafile => ({ inputs });
 
@@ -61,7 +70,7 @@ describe('validateClientBundleOptions', () => {
 describe('evaluationOrder', () => {
   // Keys come back resolved against the given cwd, which on Windows qualifies the drive — so the expectations are built
   // the same way rather than written as literal POSIX paths.
-  const keyFor = (p: string) => toPosixPath(path.resolve('/app', p));
+  const keyFor = (p: string) => posixAbs(p, '/app');
 
   // Bun lists an output's inputs in the order it concatenated them; the input map is in parse order, which is why the
   // outputs are the ones read.
@@ -106,7 +115,7 @@ describe('classifyModules', () => {
 
   test('never moves an entrypoint', () => {
     const { chunkOf } = classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 'vendor', {
-      entrypoints: new Set([VENDOR_ONE.replace(/\\/g, '/')]),
+      entrypoints: new Set([VENDOR_ONE]),
     });
     expect(chunkOf.size).toBe(0);
   });
@@ -226,7 +235,7 @@ describe('planChunks', () => {
 
   // The ring is what keeps this linear rather than every-view-imports-every-other.
   test('emits one sibling import per member, not one per pair', () => {
-    const members = new Map([...Array(6)].map((_, i) => [`${FIXTURE_DIR}/m${i}.ts`, 'big'] as const));
+    const members = new Map([...Array(6)].map((_, i) => [posixAbs(`m${i}.ts`, FIXTURE_DIR), 'big'] as const));
     const plan = planChunks(new Map(members), always);
     const total = [...plan.sources.values()].reduce((n, s) => n + (s.match(/^import "view:/gm) ?? []).length, 0);
     expect(total).toBe(6);

--- a/packages/mochi/src/compiler/clientBundleChunks.test.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
 import {
+  attributeChunks,
   classifyModules,
   evaluationOrder,
   hasDefaultExport,
   packageNameOf,
   planChunks,
   posixAbs,
+  reExportsAnotherModule,
   validateClientBundleOptions,
   viewId,
   type ChunkMetafile,
@@ -316,8 +318,124 @@ describe('protected packages', () => {
   });
 
   test('leaves other packages alone', () => {
-    const other = Bun.resolveSync('devalue', path.join(import.meta.dir, '..', '..'));
+    // A leaf module, not the package entry — devalue's entry is a re-export barrel, which is skipped on its own merits.
+    const other = path.join(path.dirname(Bun.resolveSync('devalue', path.join(import.meta.dir, '..', '..'))), 'src/parse.js');
     const { chunkOf } = classifyModules(metafile({ [other]: { bytes: 10, format: 'esm' } }), () => 'vendor');
     expect(chunkOf.size).toBe(1);
+  });
+
+  // The barrel skip is worth pinning against a real package: a published entry point is very often a re-export barrel,
+  // which is exactly the shape that broke island hydration on a large graph.
+  test("skips a real package's re-export entry point", () => {
+    const entry = Bun.resolveSync('devalue', path.join(import.meta.dir, '..', '..'));
+    const { chunkOf, skipped } = classifyModules(metafile({ [entry]: { bytes: 10, format: 'esm' } }), () => 'vendor');
+    expect(chunkOf.size).toBe(0);
+    expect(skipped[0]!.reason).toContain('re-exports another module');
+  });
+});
+
+describe('attributeChunks', () => {
+  const plan = (members: Record<string, string[]>) => ({
+    members: new Map(Object.entries(members).map(([k, v]) => [k, v.map((p) => posixAbs(p))])),
+    chunkOf: new Map(),
+    sources: new Map(),
+  });
+  const out = (inputs: string[], entryPoint?: string) => ({ ...(entryPoint ? { entryPoint } : {}), inputs: Object.fromEntries(inputs.map((i) => [i, {}])) });
+
+  test('credits the shared output holding the group', () => {
+    const r = attributeChunks({ 'chunk-a.js': out(['a.ts', 'b.ts']) }, plan({ vendor: ['a.ts', 'b.ts'] }));
+    expect(r.namesByOutput.get('chunk-a.js')).toEqual(['vendor']);
+    expect(r.unformed).toEqual([]);
+    expect(r.partial).toEqual([]);
+  });
+
+  // A member whose specifier the resolver could not match keeps Bun's placement, so a real group routinely collapses
+  // most — not all — of the way. Demanding every member reported a large working chunk as a total failure.
+  test('credits the output with the plurality and reports the shortfall', () => {
+    const r = attributeChunks({ 'chunk-a.js': out(['a.ts', 'b.ts', 'c.ts']), 'chunk-b.js': out(['d.ts']) }, plan({ vendor: ['a.ts', 'b.ts', 'c.ts', 'd.ts'] }));
+    expect(r.namesByOutput.get('chunk-a.js')).toEqual(['vendor']);
+    expect(r.unformed).toEqual([]);
+    expect(r.partial).toEqual([{ name: 'vendor', placed: 3, total: 4 }]);
+  });
+
+  test('an entry output is never credited', () => {
+    const r = attributeChunks({ '_hydrate-W.js': out(['a.ts', 'b.ts'], '_hydrate-W.js') }, plan({ vendor: ['a.ts', 'b.ts'] }));
+    expect(r.namesByOutput.size).toBe(0);
+    expect(r.unformed).toEqual(['vendor']);
+  });
+
+  test('a lone member scattered across outputs is not a formed chunk', () => {
+    const r = attributeChunks({ 'chunk-a.js': out(['a.ts']), 'chunk-b.js': out(['b.ts']) }, plan({ vendor: ['a.ts', 'b.ts'] }));
+    expect(r.unformed).toEqual(['vendor']);
+  });
+
+  test('a single-member group counts when it lands in a shared chunk', () => {
+    const r = attributeChunks({ 'chunk-a.js': out(['a.ts']) }, plan({ solo: ['a.ts'] }));
+    expect(r.namesByOutput.get('chunk-a.js')).toEqual(['solo']);
+    expect(r.unformed).toEqual([]);
+  });
+
+  test('two groups landing in one output are both named', () => {
+    const r = attributeChunks({ 'chunk-a.js': out(['a.ts', 'b.ts', 'c.ts', 'd.ts']) }, plan({ one: ['a.ts', 'b.ts'], two: ['c.ts', 'd.ts'] }));
+    expect(r.namesByOutput.get('chunk-a.js')).toEqual(['one', 'two']);
+  });
+
+  test('no plan means nothing to attribute', () => {
+    const r = attributeChunks({ 'chunk-a.js': out(['a.ts']) }, null);
+    expect(r.namesByOutput.size).toBe(0);
+    expect(r.unformed).toEqual([]);
+  });
+});
+
+describe('reExportsAnotherModule', () => {
+  const cases: [string, string, boolean][] = [
+    ['star re-export', "export * from './x';", true],
+    ['namespaced star re-export', "export * as ns from './x';", true],
+    ['named re-export', "export { a, b } from './x';", true],
+    ['renamed re-export', "export { a as b } from './x';", true],
+    ['indented re-export', "  export * from './x';", true],
+    ['re-export after other code', "const a = 1;\nexport * from './x';", true],
+    ['plain named export', 'export const a = 1;', false],
+    ['default export', 'export default class {}', false],
+    ['import then separate export', "import { a } from './x';\nexport const b = a;", false],
+    ['export list with no source', 'const a = 1;\nexport { a };', false],
+  ];
+  for (const [name, source, expected] of cases) {
+    test(name, () => {
+      expect(reExportsAnotherModule('/x/a.ts', () => source)).toBe(expected);
+    });
+  }
+
+  // A .svelte file cannot forward another module's bindings, and its source is not scannable here anyway.
+  test('ignores extensions it cannot scan', () => {
+    expect(reExportsAnotherModule('/x/A.svelte', () => "export * from './x';")).toBe(false);
+    expect(reExportsAnotherModule('/x/a.css', () => "export * from './x';")).toBe(false);
+  });
+
+  test('an unreadable file is not treated as a barrel', () => {
+    expect(
+      reExportsAnotherModule('/x/a.ts', () => {
+        throw new Error('gone');
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('classifyModules barrel skip', () => {
+  test('refuses to group a re-export barrel and says why', () => {
+    const { chunkOf, skipped } = classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 'vendor', {
+      readFile: () => "export * from './other';",
+    });
+    expect(chunkOf.size).toBe(0);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]!.reason).toContain('re-exports another module');
+  });
+
+  test('still groups a module that only has its own exports', () => {
+    const { chunkOf, skipped } = classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 'vendor', {
+      readFile: () => 'export const a = 1;',
+    });
+    expect(chunkOf.size).toBe(1);
+    expect(skipped).toHaveLength(0);
   });
 });

--- a/packages/mochi/src/compiler/clientBundleChunks.test.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
+import { classifyModules, hasDefaultExport, packageNameOf, planChunks, validateClientBundleOptions, type ChunkMetafile } from './clientBundleChunks';
+
+const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'client-bundle-chunks');
+const VENDOR_ONE = path.join(FIXTURE_DIR, 'vendorOne.ts');
+const VENDOR_TWO = path.join(FIXTURE_DIR, 'vendorTwo.ts');
+
+const metafile = (inputs: Record<string, { bytes: number; format?: string }>): ChunkMetafile => ({ inputs });
+
+describe('packageNameOf', () => {
+  test('reads the package out of a hoisted node_modules path', () => {
+    expect(packageNameOf('/app/node_modules/chart.js/dist/chart.js')).toBe('chart.js');
+  });
+
+  test('keeps both segments of a scoped package', () => {
+    expect(packageNameOf('/app/node_modules/@lucide/svelte/icons/sun.js')).toBe('@lucide/svelte');
+  });
+
+  test("sees through Bun's isolated-linker store layout", () => {
+    expect(packageNameOf('/app/node_modules/.bun/chart.js@4.4.0/node_modules/chart.js/dist/chart.js')).toBe('chart.js');
+    expect(packageNameOf('/app/node_modules/.bun/@lucide+svelte@1.0.0/node_modules/@lucide/svelte/i.js')).toBe('@lucide/svelte');
+  });
+
+  test('returns null for first-party source', () => {
+    expect(packageNameOf('/app/src/components/Chart.svelte')).toBeNull();
+  });
+});
+
+describe('validateClientBundleOptions', () => {
+  test('passes through undefined', () => {
+    expect(validateClientBundleOptions(undefined)).toBeUndefined();
+  });
+
+  test('rejects a non-object', () => {
+    expect(() => validateClientBundleOptions('nope')).toThrow(/must be an object/);
+    expect(() => validateClientBundleOptions([])).toThrow(/received array/);
+  });
+
+  test('names an unknown key', () => {
+    expect(() => validateClientBundleOptions({ chunkNaming: 'x' })).toThrow(/Unknown clientBundle option "chunkNaming"/);
+  });
+
+  test('rejects a non-function chunks', () => {
+    expect(() => validateClientBundleOptions({ chunks: 'vendor' })).toThrow(/clientBundle\.chunks must be a function/);
+  });
+
+  test('rejects a non-boolean splitting', () => {
+    expect(() => validateClientBundleOptions({ splitting: 'yes' })).toThrow(/clientBundle\.splitting must be a boolean/);
+  });
+});
+
+describe('classifyModules', () => {
+  test('assigns real files the classifier names', () => {
+    const { chunkOf } = classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 'vendor');
+    expect([...chunkOf.values()]).toEqual(['vendor']);
+  });
+
+  test('leaves modules the classifier passes on', () => {
+    const { chunkOf } = classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => null);
+    expect(chunkOf.size).toBe(0);
+  });
+
+  // Virtual modules are excluded by an existence check, so the framework's own `mochi-env:` / `mochi-server-only:`
+  // namespaces and the synthetic `_hydrate-*.js` entries drop out without this module knowing any of their names.
+  test('skips virtual modules that have no file on disk', () => {
+    const { chunkOf } = classifyModules(metafile({ 'mochi-env:mochi-framework': { bytes: 10 }, '_hydrate-Widget_ab.js': { bytes: 10 } }), () => 'vendor');
+    expect(chunkOf.size).toBe(0);
+  });
+
+  test('never moves an entrypoint', () => {
+    const { chunkOf } = classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 'vendor', {
+      entrypoints: new Set([VENDOR_ONE.replace(/\\/g, '/')]),
+    });
+    expect(chunkOf.size).toBe(0);
+  });
+
+  // A CJS module's named exports are synthesized by the bundler, after the point a view module must declare them, so
+  // relocating one fails the build on any named import of it.
+  test('skips CommonJS and reports why', () => {
+    const { chunkOf, skipped } = classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'cjs' } }), () => 'vendor');
+    expect(chunkOf.size).toBe(0);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]!.reason).toContain('CommonJS');
+  });
+
+  test('hands the classifier a POSIX id and package context', () => {
+    const seen: { id: string; pkg: string | null; rel: string }[] = [];
+    classifyModules(metafile({ [VENDOR_ONE]: { bytes: 42, format: 'esm' } }), (id, ctx) => {
+      seen.push({ id, pkg: ctx.packageName, rel: ctx.relativeId });
+      return null;
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.id).not.toContain('\\');
+    expect(seen[0]!.rel).not.toContain('\\');
+    expect(seen[0]!.id.endsWith('/vendorOne.ts')).toBe(true);
+    expect(seen[0]!.pkg).toBeNull();
+  });
+
+  test('rejects a non-string, non-nullish return', () => {
+    expect(() => classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 42 as unknown as string)).toThrow(/returned 42 .*vendorOne\.ts/);
+  });
+
+  test('rejects an empty chunk name', () => {
+    expect(() => classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => '  ')).toThrow(/empty chunk name/);
+  });
+
+  test('rejects a name that is not filename-safe', () => {
+    expect(() => classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => '../escape')).toThrow(/Invalid chunk name/);
+    expect(() => classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 'a/b')).toThrow(/Invalid chunk name/);
+  });
+
+  test('rejects a name Mochi reserves', () => {
+    expect(() => classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => 'chunk')).toThrow(/is reserved by Mochi/);
+  });
+
+  test('surfaces a throwing classifier with the module it was called on', () => {
+    expect(() =>
+      classifyModules(metafile({ [VENDOR_ONE]: { bytes: 10, format: 'esm' } }), () => {
+        throw new Error('boom');
+      }),
+    ).toThrow(/threw while classifying "[^"]*vendorOne\.ts": boom/);
+  });
+});
+
+describe('planChunks', () => {
+  const always = () => true;
+
+  test('emits one view per member', () => {
+    const plan = planChunks(
+      new Map([
+        [VENDOR_ONE, 'vendor'],
+        [VENDOR_TWO, 'vendor'],
+      ]),
+      always,
+    );
+    expect(plan.members.get('vendor')).toHaveLength(2);
+    expect(plan.sources.size).toBe(2);
+  });
+
+  // Reaching any member has to reach all of them, or their entrypoint-reachability sets differ and Bun splits them up.
+  test('views form a ring and each re-exports its real module', () => {
+    const plan = planChunks(
+      new Map([
+        [VENDOR_ONE, 'vendor'],
+        [VENDOR_TWO, 'vendor'],
+      ]),
+      always,
+    );
+    const [first, second] = plan.members.get('vendor')!;
+    expect(plan.sources.get(`view:${first}`)).toContain(`import "view:${second}";`);
+    expect(plan.sources.get(`view:${second}`)).toContain(`import "view:${first}";`);
+    expect(plan.sources.get(`view:${first}`)).toContain(`export * from ${JSON.stringify(first)};`);
+  });
+
+  // The ring is what keeps this linear rather than every-view-imports-every-other.
+  test('emits one sibling import per member, not one per pair', () => {
+    const members = new Map([...Array(6)].map((_, i) => [`${FIXTURE_DIR}/m${i}.ts`, 'big'] as const));
+    const plan = planChunks(new Map(members), always);
+    const total = [...plan.sources.values()].reduce((n, s) => n + (s.match(/^import "view:/gm) ?? []).length, 0);
+    expect(total).toBe(6);
+  });
+
+  test('a lone member has no sibling import to make', () => {
+    const plan = planChunks(new Map([[VENDOR_ONE, 'solo']]), always);
+    expect(plan.sources.get(`view:${VENDOR_ONE}`)).not.toContain('import "view:');
+  });
+
+  // `export *` carries every named export, including re-exported ones, but never `default`.
+  test('re-exports default only when the module has one', () => {
+    const withDefault = planChunks(new Map([[VENDOR_ONE, 'vendor']]), () => true).sources.get(`view:${VENDOR_ONE}`)!;
+    expect(withDefault).toContain('export { default } from');
+
+    const without = planChunks(new Map([[VENDOR_ONE, 'vendor']]), () => false).sources.get(`view:${VENDOR_ONE}`)!;
+    expect(without).not.toContain('export { default }');
+  });
+
+  test('members are sorted so two runs of one config plan identically', () => {
+    const a = planChunks(
+      new Map([
+        [VENDOR_TWO, 'v'],
+        [VENDOR_ONE, 'v'],
+      ]),
+      always,
+    );
+    const b = planChunks(
+      new Map([
+        [VENDOR_ONE, 'v'],
+        [VENDOR_TWO, 'v'],
+      ]),
+      always,
+    );
+    expect(a.members.get('v')).toEqual(b.members.get('v')!);
+    expect(a.sources.get(`view:${VENDOR_ONE}`)).toBe(b.sources.get(`view:${VENDOR_ONE}`)!);
+  });
+
+  // Two names must not cross-import, or both groups collapse into one chunk.
+  test('separate names stay separate groups', () => {
+    const plan = planChunks(
+      new Map([
+        [VENDOR_ONE, 'one'],
+        [VENDOR_TWO, 'two'],
+      ]),
+      always,
+    );
+    expect([...plan.members.keys()].sort()).toEqual(['one', 'two']);
+    expect(plan.sources.get(`view:${VENDOR_ONE}`)).not.toContain(VENDOR_TWO);
+  });
+});
+
+describe('hasDefaultExport', () => {
+  test('detects a declared default', () => {
+    expect(hasDefaultExport('/x/a.ts', () => 'export default class {}')).toBe(true);
+    expect(hasDefaultExport('/x/a.ts', () => 'export const only = 1;')).toBe(false);
+  });
+
+  test('assumes a default for sources compiled later in the build', () => {
+    expect(hasDefaultExport('/x/Widget.svelte', () => 'unparseable as TS')).toBe(true);
+  });
+
+  test('returns null for an extension it cannot read', () => {
+    expect(hasDefaultExport('/x/style.css', () => 'body{}')).toBeNull();
+  });
+});
+
+describe('protected packages', () => {
+  // Chunking Svelte builds cleanly and then throws on hydration in the browser, so it is refused up front rather than
+  // left to fail at runtime. Uses the real installed path, since membership is derived from the module path.
+  test("refuses to move Svelte's runtime and says why", () => {
+    // Deep internal paths are not exported by svelte's package.json, so anchor on the package root instead.
+    const sveltePath = path.join(path.dirname(Bun.resolveSync('svelte/package.json', path.join(import.meta.dir, '..', '..'))), 'src/internal/client/index.js');
+    const { chunkOf, skipped } = classifyModules(metafile({ [sveltePath]: { bytes: 10, format: 'esm' } }), () => 'vendor');
+    expect(chunkOf.size).toBe(0);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0]!.reason).toContain('svelte runtime');
+  });
+
+  test('leaves other packages alone', () => {
+    const other = Bun.resolveSync('devalue', path.join(import.meta.dir, '..', '..'));
+    const { chunkOf } = classifyModules(metafile({ [other]: { bytes: 10, format: 'esm' } }), () => 'vendor');
+    expect(chunkOf.size).toBe(1);
+  });
+});

--- a/packages/mochi/src/compiler/clientBundleChunks.test.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
 import { classifyModules, evaluationOrder, hasDefaultExport, packageNameOf, planChunks, validateClientBundleOptions, viewId, type ChunkMetafile } from './clientBundleChunks';
+import { toPosixPath } from '../utils/index';
 
 const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'client-bundle-chunks');
 const VENDOR_ONE = path.join(FIXTURE_DIR, 'vendorOne.ts');
@@ -58,6 +59,10 @@ describe('validateClientBundleOptions', () => {
 });
 
 describe('evaluationOrder', () => {
+  // Keys come back resolved against the given cwd, which on Windows qualifies the drive — so the expectations are built
+  // the same way rather than written as literal POSIX paths.
+  const keyFor = (p: string) => toPosixPath(path.resolve('/app', p));
+
   // Bun lists an output's inputs in the order it concatenated them; the input map is in parse order, which is why the
   // outputs are the ones read.
   test('reads the order modules were concatenated into each output', () => {
@@ -68,12 +73,12 @@ describe('evaluationOrder', () => {
       },
       '/app',
     );
-    expect([...order.keys()]).toEqual(['/app/src/first.ts', '/app/src/second.ts', '/app/src/third.ts']);
+    expect([...order.keys()]).toEqual([keyFor('src/first.ts'), keyFor('src/second.ts'), keyFor('src/third.ts')]);
   });
 
   test('a module in two outputs keeps its first position', () => {
     const order = evaluationOrder({ inputs: {}, outputs: { 'a.js': { inputs: { 'x.ts': {}, 'y.ts': {} } }, 'b.js': { inputs: { 'y.ts': {} } } } }, '/app');
-    expect(order.get('/app/y.ts')).toBe(1);
+    expect(order.get(keyFor('y.ts'))).toBe(1);
   });
 
   test('a metafile with no outputs yields no order', () => {

--- a/packages/mochi/src/compiler/clientBundleChunks.test.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { classifyModules, hasDefaultExport, packageNameOf, planChunks, validateClientBundleOptions, type ChunkMetafile } from './clientBundleChunks';
+import { classifyModules, evaluationOrder, hasDefaultExport, packageNameOf, planChunks, validateClientBundleOptions, viewId, type ChunkMetafile } from './clientBundleChunks';
 
 const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'client-bundle-chunks');
 const VENDOR_ONE = path.join(FIXTURE_DIR, 'vendorOne.ts');
@@ -47,6 +47,37 @@ describe('validateClientBundleOptions', () => {
 
   test('rejects a non-boolean splitting', () => {
     expect(() => validateClientBundleOptions({ splitting: 'yes' })).toThrow(/clientBundle\.splitting must be a boolean/);
+  });
+
+  // With splitting off Bun emits no shared chunks at all, so the pair would run the classifier and a second build pass
+  // to produce nothing.
+  test('rejects chunks together with splitting: false', () => {
+    expect(() => validateClientBundleOptions({ chunks: () => null, splitting: false })).toThrow(/chunks needs clientBundle\.splitting/);
+    expect(() => validateClientBundleOptions({ chunks: () => null, splitting: true })).not.toThrow();
+  });
+});
+
+describe('evaluationOrder', () => {
+  // Bun lists an output's inputs in the order it concatenated them; the input map is in parse order, which is why the
+  // outputs are the ones read.
+  test('reads the order modules were concatenated into each output', () => {
+    const order = evaluationOrder(
+      {
+        inputs: {},
+        outputs: { 'b.js': { inputs: { 'src/second.ts': {}, 'src/third.ts': {} } }, 'a.js': { inputs: { 'src/first.ts': {} } } },
+      },
+      '/app',
+    );
+    expect([...order.keys()]).toEqual(['/app/src/first.ts', '/app/src/second.ts', '/app/src/third.ts']);
+  });
+
+  test('a module in two outputs keeps its first position', () => {
+    const order = evaluationOrder({ inputs: {}, outputs: { 'a.js': { inputs: { 'x.ts': {}, 'y.ts': {} } }, 'b.js': { inputs: { 'y.ts': {} } } } }, '/app');
+    expect(order.get('/app/y.ts')).toBe(1);
+  });
+
+  test('a metafile with no outputs yields no order', () => {
+    expect(evaluationOrder({ inputs: {} }, '/app').size).toBe(0);
   });
 });
 
@@ -148,9 +179,44 @@ describe('planChunks', () => {
       always,
     );
     const [first, second] = plan.members.get('vendor')!;
-    expect(plan.sources.get(`view:${first}`)).toContain(`import "view:${second}";`);
-    expect(plan.sources.get(`view:${second}`)).toContain(`import "view:${first}";`);
-    expect(plan.sources.get(`view:${first}`)).toContain(`export * from ${JSON.stringify(first)};`);
+    // Paths are JSON-quoted into generated source, which on Windows escapes every separator — so the expectation has
+    // to be built the same way rather than interpolated raw.
+    expect(plan.sources.get(viewId(first!))).toContain(`import ${JSON.stringify(viewId(second!))};`);
+    expect(plan.sources.get(viewId(second!))).toContain(`import ${JSON.stringify(viewId(first!))};`);
+    expect(plan.sources.get(viewId(first!))).toContain(`export * from ${JSON.stringify(first)};`);
+  });
+
+  // Grouping relocates a module's initialization; emitting the ring import first would run the group back to front, so
+  // a member's own re-export has to come before it walks on to the next view.
+  test('a view runs its own module before the rest of the ring', () => {
+    const plan = planChunks(
+      new Map([
+        [VENDOR_ONE, 'vendor'],
+        [VENDOR_TWO, 'vendor'],
+      ]),
+      always,
+    );
+    const [first] = plan.members.get('vendor')!;
+    const source = plan.sources.get(viewId(first!))!;
+    expect(source.indexOf('export * from')).toBeLessThan(source.indexOf('import "view:'));
+  });
+
+  // Ring order is evaluation order, so whichever member is reached first walks the others in the sequence they already
+  // ran in. Alphabetical order is only the tie-break for modules pass 1 never placed together.
+  test('members are laid out in the evaluation order the build reported', () => {
+    const order = new Map([
+      [VENDOR_TWO, 0],
+      [VENDOR_ONE, 1],
+    ]);
+    const plan = planChunks(
+      new Map([
+        [VENDOR_ONE, 'vendor'],
+        [VENDOR_TWO, 'vendor'],
+      ]),
+      always,
+      order,
+    );
+    expect(plan.members.get('vendor')).toEqual([VENDOR_TWO, VENDOR_ONE]);
   });
 
   // The ring is what keeps this linear rather than every-view-imports-every-other.

--- a/packages/mochi/src/compiler/clientBundleChunks.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.ts
@@ -37,6 +37,28 @@ export const viewId = (absPath: string): string => `${VIEW_PREFIX}${absPath}`;
 /** Minimal shape this module reads out of `Bun.build`'s metafile, so tests can build literals instead of running a build. */
 export interface ChunkMetafile {
   inputs: Record<string, { bytes: number; format?: string }>;
+  outputs?: Record<string, { inputs: Record<string, unknown> }>;
+}
+
+/**
+ * Pass 1's module evaluation order, keyed by absolute POSIX path.
+ *
+ * Bun lists an output's inputs in the order it concatenated them, which is the order the browser would have run them —
+ * the only record of the ungrouped initialization sequence, since the input map is in parse order instead. Outputs are
+ * walked in sorted path order so two members that pass 1 put in different chunks still rank deterministically; their
+ * relative order was never observable anyway, whereas co-located members keep exactly the order they had.
+ */
+export function evaluationOrder(metafile: ChunkMetafile, cwd: string = process.cwd()): Map<string, number> {
+  const order = new Map<string, number>();
+  for (const outPath of Object.keys(metafile.outputs ?? {}).sort()) {
+    for (const input of Object.keys(metafile.outputs![outPath]!.inputs)) {
+      const id = toPosixPath(path.resolve(cwd, input));
+      if (!order.has(id)) {
+        order.set(id, order.size);
+      }
+    }
+  }
+  return order;
 }
 
 const SCANNABLE_LOADERS: Record<string, 'js' | 'jsx' | 'ts' | 'tsx'> = {
@@ -119,6 +141,11 @@ export function validateClientBundleOptions(opts: unknown): MochiClientBundleOpt
   }
   if (o.splitting !== undefined && typeof o.splitting !== 'boolean') {
     throw new Error(`[mochi] clientBundle.splitting must be a boolean, received ${typeof o.splitting}.`);
+  }
+  // Shared chunks are what splitting emits, so the pair is self-contradictory: the classifier would run, cost a second
+  // full build pass, and produce nothing — while the build report named island entries as if they were chunks.
+  if (o.chunks !== undefined && o.splitting === false) {
+    throw new Error('[mochi] clientBundle.chunks needs clientBundle.splitting — with splitting disabled Bun emits no shared chunks for it to fill. Drop one of the two.');
   }
   return opts as MochiClientBundleOptions;
 }
@@ -212,10 +239,16 @@ export function classifyModules(
  * entrypoint reachability and is what collapses the group into a single chunk. A ring rather than every-imports-every
  * keeps this linear: a 250-module group emits 250 extra imports instead of ~62,000.
  *
+ * Grouping hoists the whole group to wherever its first member was reached, so the members' order relative to each
+ * other is all that can be preserved — and it is, by two things together. The re-export is emitted *before* the ring
+ * import, so a view runs its own module before walking on; a ring import first would evaluate the group backwards.
+ * And `order` (pass 1's evaluation order, via `evaluationOrder`) lays the ring out in the sequence the modules already
+ * ran in, so whichever member is reached first walks the rest in their original order.
+ *
  * `export *` carries every named export the module has, including ones it re-exports from elsewhere, so no export list
  * has to be computed ahead of the build. It never carries `default`, which is why that one name is passed in.
  */
-export function planChunks(chunkOf: Map<string, string>, hasDefault: (absPath: string) => boolean): ChunkPlan {
+export function planChunks(chunkOf: Map<string, string>, hasDefault: (absPath: string) => boolean, order?: ReadonlyMap<string, number>): ChunkPlan {
   const members = new Map<string, string[]>();
   for (const [id, chunk] of chunkOf) {
     const list = members.get(chunk);
@@ -225,23 +258,24 @@ export function planChunks(chunkOf: Map<string, string>, hasDefault: (absPath: s
       members.set(chunk, [id]);
     }
   }
-  // Sorted so one config plans identically across runs, keeping output hashes stable.
+  // Evaluation order first, path as the tie-break, so one config plans identically across runs and output hashes stay
+  // stable even for members pass 1 never placed together.
+  const rank = (id: string) => order?.get(id) ?? Number.MAX_SAFE_INTEGER;
   for (const list of members.values()) {
-    list.sort();
+    list.sort((a, b) => rank(a) - rank(b) || (a < b ? -1 : a > b ? 1 : 0));
   }
 
   const sources = new Map<string, string>();
   for (const list of members.values()) {
     list.forEach((m, i) => {
       const quoted = JSON.stringify(m);
-      const lines: string[] = [];
+      const lines: string[] = [`export * from ${quoted};`];
+      if (hasDefault(m)) {
+        lines.push(`export { default } from ${quoted};`);
+      }
       const next = list[(i + 1) % list.length]!;
       if (next !== m) {
         lines.push(`import ${JSON.stringify(viewId(next))};`);
-      }
-      lines.push(`export * from ${quoted};`);
-      if (hasDefault(m)) {
-        lines.push(`export { default } from ${quoted};`);
       }
       sources.set(viewId(m), lines.join('\n'));
     });

--- a/packages/mochi/src/compiler/clientBundleChunks.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.ts
@@ -113,6 +113,30 @@ export function hasDefaultExport(absPath: string, readFile: (p: string) => strin
   }
 }
 
+/** `export * from`, `export * as ns from`, `export { a } from` — a module that forwards another module's bindings. */
+const RE_EXPORT = /^[ \t]*export\s*(?:\*(?:\s+as\s+[A-Za-z_$][\w$]*)?|\{[^}]*\})\s*from\s*['"]/m;
+
+/**
+ * Whether a module forwards another module's bindings, which disqualifies it from being grouped.
+ *
+ * A barrel's exports are bindings that live in *other* modules, and the view wrapping it adds a second layer of the
+ * same. Moving one leaves Bun emitting a chunk that references a binding it never exports — the entry reads a name that
+ * is defined in another chunk and not imported, which throws `ReferenceError` on hydration while the build reports
+ * success. Rather than reason about when that is safe, barrels stay where Bun put them.
+ *
+ * Erring toward `true` is the safe direction: a false positive only means one module keeps its original placement.
+ */
+export function reExportsAnotherModule(absPath: string, readFile: (p: string) => string): boolean {
+  if (!SCANNABLE_LOADERS[path.extname(absPath).toLowerCase()]) {
+    return false;
+  }
+  try {
+    return RE_EXPORT.test(readFile(absPath));
+  } catch {
+    return false;
+  }
+}
+
 export interface ChunkPlan {
   /** Chunk name → absolute POSIX paths of every module assigned to it. */
   members: Map<string, PosixAbsPath[]>;
@@ -196,7 +220,17 @@ export function classifyModules(
   opts: { entrypoints?: Set<PosixAbsPath>; cwd?: string; readFile?: (p: string) => string } = {},
 ): { chunkOf: Map<PosixAbsPath, string>; skipped: { id: string; reason: string }[]; defaultOf: Map<PosixAbsPath, boolean> } {
   const cwd = opts.cwd ?? process.cwd();
-  const readFile = opts.readFile ?? ((p: string) => fs.readFileSync(p, 'utf8'));
+  const readRaw = opts.readFile ?? ((p: string) => fs.readFileSync(p, 'utf8'));
+  // Two checks below read the same source, and a large graph runs this over hundreds of files.
+  const sources = new Map<string, string>();
+  const readFile = (p: string) => {
+    let src = sources.get(p);
+    if (src === undefined) {
+      src = readRaw(p);
+      sources.set(p, src);
+    }
+    return src;
+  };
   const defaultOf = new Map<PosixAbsPath, boolean>();
   const entrypoints = opts.entrypoints ?? new Set<PosixAbsPath>();
   const chunkOf = new Map<PosixAbsPath, string>();
@@ -233,6 +267,12 @@ export function classifyModules(
     // the runtime, so Bun already emits it as a single shared chunk.
     if (packageName !== null && PROTECTED_PACKAGES.has(packageName)) {
       skipped.push({ id: relativeId, reason: `the ${packageName} runtime, already one shared chunk and unsafe to reorder` });
+      continue;
+    }
+    // A barrel's exports are bindings owned by other modules; relocating one leaves the bundler emitting a chunk that
+    // references a name it never exports, which throws on hydration while the build reports success.
+    if (reExportsAnotherModule(id, readFile)) {
+      skipped.push({ id: relativeId, reason: 're-exports another module, and the forwarded bindings do not survive the move' });
       continue;
     }
     const hasDefault = hasDefaultExport(id, readFile);
@@ -357,4 +397,67 @@ export function resolveChunkMember(args: { path: string; importer?: string; reso
 /** True for a generated view id, i.e. a module this planner authored. */
 export function isChunkModuleId(id: string | undefined): boolean {
   return !!id && (id.startsWith(VIEW_PREFIX) || id.startsWith(`${CHUNK_NAMESPACE}:`));
+}
+
+export interface ChunkAttribution {
+  /** Output path → the user chunk name(s) it carries. */
+  namesByOutput: Map<string, string[]>;
+  /** Groups that produced no shared chunk at all. */
+  unformed: string[];
+  /** Groups that collapsed into a shared chunk, but left some members behind. */
+  partial: { name: string; placed: number; total: number }[];
+}
+
+/**
+ * Decide which output each chunk group ended up in.
+ *
+ * A group is credited to the output holding the *most* of its members rather than one holding all of them: a member
+ * whose import specifier `chunkResolveFilter` could not match keeps Bun's own placement (documented graceful
+ * degradation), so on a large real graph a group routinely collapses ~90% of the way. Demanding every member reported a
+ * 323-module chunk as a total failure. Entry outputs are never credited — a group reached from one island is inlined
+ * there rather than shared, which is the case a user most needs told about.
+ */
+export function attributeChunks(outputs: Record<string, { entryPoint?: string; inputs: Record<string, unknown> }>, plan: ChunkPlan | null): ChunkAttribution {
+  const namesByOutput = new Map<string, string[]>();
+  const unformed: string[] = [];
+  const partial: { name: string; placed: number; total: number }[] = [];
+  if (!plan) {
+    return { namesByOutput, unformed, partial };
+  }
+
+  const placed = new Map<string, Map<string, number>>();
+  for (const [outPath, outMeta] of Object.entries(outputs)) {
+    if (outMeta.entryPoint) {
+      continue;
+    }
+    const outInputs = new Set(Object.keys(outMeta.inputs).map((i) => posixAbs(i)));
+    for (const [name, members] of plan.members) {
+      const n = members.filter((m) => outInputs.has(m)).length;
+      if (n > 0) {
+        const perOut = placed.get(name) ?? new Map<string, number>();
+        perOut.set(outPath, n);
+        placed.set(name, perOut);
+      }
+    }
+  }
+
+  for (const [name, members] of [...plan.members].sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))) {
+    let best: { outPath: string; n: number } | null = null;
+    for (const [outPath, n] of placed.get(name) ?? []) {
+      // Output path breaks ties so a rebuild of one config reports identically.
+      if (!best || n > best.n || (n === best.n && outPath < best.outPath)) {
+        best = { outPath, n };
+      }
+    }
+    // One member alone in a shared chunk is a real placement only when that is the whole group.
+    if (!best || best.n < Math.min(2, members.length)) {
+      unformed.push(name);
+      continue;
+    }
+    namesByOutput.set(best.outPath, [...(namesByOutput.get(best.outPath) ?? []), name]);
+    if (best.n < members.length) {
+      partial.push({ name, placed: best.n, total: members.length });
+    }
+  }
+  return { namesByOutput, unformed, partial };
 }

--- a/packages/mochi/src/compiler/clientBundleChunks.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.ts
@@ -1,0 +1,311 @@
+/**
+ * Manual chunk control for the island client bundle: `Mochi.serve({ clientBundle: { chunks } })`.
+ *
+ * Bun's bundler has no `manualChunks` equivalent — it assigns a module to a chunk purely by the set of entrypoints
+ * that reach it, and two modules share a chunk only when those sets match exactly. So the grouping is induced rather
+ * than configured: each assigned module is replaced, at its import sites, by a generated *view* that re-exports it and
+ * links into a ring through the group's other views. Reaching any member therefore reaches all of them, which equalizes
+ * their reachability sets and collapses the group into one output.
+ *
+ * These views are deliberately not entrypoints. Bun pins an entrypoint file into its own entry chunk while bucketing
+ * its dependencies by reachability, so an entrypoint here emits a near-empty named file plus a separate fat chunk.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { toPosixPath } from '../utils/index';
+import type { MochiChunkClassifier, MochiClientBundleOptions } from '../types';
+
+/** Plugin namespace holding the generated view modules. */
+export const CHUNK_NAMESPACE = 'mochi-chunk';
+
+const VIEW_PREFIX = 'view:';
+
+/** Chunk names become part of build output and reporting, so keep them to filename-safe characters. */
+const VALID_CHUNK_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Names Mochi already uses for its own entries and outputs. */
+const RESERVED_CHUNK_NAMES = new Set(['chunk', 'stats']);
+
+/** Packages whose module initialization order cannot survive being relocated. See the skip in `classifyModules`. */
+const PROTECTED_PACKAGES = new Set(['svelte']);
+
+const STORE_PATH = /^(?:\.\.\/)*node_modules\/\.bun\/[^/]+\/node_modules\/(.+)$/;
+const LEADING_NODE_MODULES = /^(?:\.\.\/)*node_modules\//;
+
+export const viewId = (absPath: string): string => `${VIEW_PREFIX}${absPath}`;
+
+/** Minimal shape this module reads out of `Bun.build`'s metafile, so tests can build literals instead of running a build. */
+export interface ChunkMetafile {
+  inputs: Record<string, { bytes: number; format?: string }>;
+}
+
+const SCANNABLE_LOADERS: Record<string, 'js' | 'jsx' | 'ts' | 'tsx'> = {
+  '.js': 'js',
+  '.mjs': 'js',
+  '.cjs': 'js',
+  '.jsx': 'jsx',
+  '.ts': 'ts',
+  '.mts': 'ts',
+  '.cts': 'ts',
+  '.tsx': 'tsx',
+};
+
+/** Compiled by a loader later in the build; every one of them has a default export and no other statically known name. */
+const ALWAYS_DEFAULT_EXTENSIONS = new Set(['.svelte', '.md', '.svx']);
+
+/**
+ * Whether a view needs an explicit `export { default } from`, or `null` when that can't be determined ahead of the
+ * build and the module must be left alone.
+ *
+ * A view re-exports its module with `export *`, which carries every named export — including ones the module itself
+ * re-exports from elsewhere — but never `default`. So the default is the only name that has to be decided up front.
+ */
+export function hasDefaultExport(absPath: string, readFile: (p: string) => string): boolean | null {
+  const ext = path.extname(absPath).toLowerCase();
+  if (ALWAYS_DEFAULT_EXTENSIONS.has(ext)) {
+    return true;
+  }
+  const loader = SCANNABLE_LOADERS[ext];
+  if (!loader) {
+    return null;
+  }
+  try {
+    return new Bun.Transpiler({ loader }).scan(readFile(absPath)).exports.includes('default');
+  } catch {
+    return null;
+  }
+}
+
+export interface ChunkPlan {
+  /** Chunk name → absolute POSIX paths of every module assigned to it. */
+  members: Map<string, string[]>;
+  /** Absolute POSIX path → the chunk it belongs to. */
+  chunkOf: Map<string, string>;
+  /** Virtual module id → generated source. */
+  sources: Map<string, string>;
+}
+
+/**
+ * Strip Bun's `node_modules/` and isolated-store `node_modules/.bun/<pkg>@<ver>/node_modules/` prefixes so an id reads
+ * the same under either linker. Mirrors `bundleInputPaths.cleanInputPath`, but that one is display-oriented and lossy,
+ * so it must not be reused as an identity.
+ */
+export function packageNameOf(posixId: string): string | null {
+  const rel = posixId.replace(/^.*?(?=(?:\.\.\/)*node_modules\/)/, '');
+  const store = rel.match(STORE_PATH);
+  const stripped = store ? store[1]! : LEADING_NODE_MODULES.test(rel) ? rel.replace(LEADING_NODE_MODULES, '') : null;
+  if (stripped === null) {
+    return null;
+  }
+  const seg = stripped.split('/');
+  return stripped.startsWith('@') ? seg.slice(0, 2).join('/') : (seg[0] ?? null);
+}
+
+export function validateClientBundleOptions(opts: unknown): MochiClientBundleOptions | undefined {
+  if (opts === undefined || opts === null) {
+    return undefined;
+  }
+  if (typeof opts !== 'object' || Array.isArray(opts)) {
+    throw new Error(`[mochi] clientBundle must be an object with optional "chunks" / "splitting", received ${Array.isArray(opts) ? 'array' : typeof opts}.`);
+  }
+  const o = opts as Record<string, unknown>;
+  for (const key of Object.keys(o)) {
+    if (key !== 'chunks' && key !== 'splitting') {
+      throw new Error(`[mochi] Unknown clientBundle option "${key}". Supported: chunks, splitting.`);
+    }
+  }
+  if (o.chunks !== undefined && typeof o.chunks !== 'function') {
+    throw new Error(`[mochi] clientBundle.chunks must be a function (id, ctx) => string | null, received ${typeof o.chunks}.`);
+  }
+  if (o.splitting !== undefined && typeof o.splitting !== 'boolean') {
+    throw new Error(`[mochi] clientBundle.splitting must be a boolean, received ${typeof o.splitting}.`);
+  }
+  return opts as MochiClientBundleOptions;
+}
+
+function assertValidChunkName(name: string, relId: string): void {
+  if (name.trim() === '') {
+    throw new Error(`[mochi] clientBundle.chunks returned an empty chunk name for "${relId}" — return a non-empty name or null.`);
+  }
+  if (!VALID_CHUNK_NAME.test(name)) {
+    throw new Error(
+      `[mochi] Invalid chunk name ${JSON.stringify(name)} from clientBundle.chunks for "${relId}" — ` +
+        `chunk names may contain letters, digits, ".", "_" and "-", and must start with a letter or digit.`,
+    );
+  }
+  if (RESERVED_CHUNK_NAMES.has(name)) {
+    throw new Error(`[mochi] Chunk name ${JSON.stringify(name)} is reserved by Mochi (from clientBundle.chunks for "${relId}") — pick another name.`);
+  }
+}
+
+/**
+ * Run the user classifier over every real source file in the client graph.
+ *
+ * Virtual modules are filtered out by an existence check rather than a name list, so the framework's own
+ * `mochi-env:` / `mochi-server-only:` namespaces and the synthetic `_hydrate-*.js` entries are all excluded without
+ * this module needing to know about any of them.
+ *
+ * Anything the classifier picks but that cannot be moved safely is collected in `skipped` for the build report rather
+ * than dropped quietly, since a silent skip reads as "it worked".
+ */
+export function classifyModules(
+  metafile: ChunkMetafile,
+  classify: MochiChunkClassifier,
+  opts: { entrypoints?: Set<string>; cwd?: string; readFile?: (p: string) => string } = {},
+): { chunkOf: Map<string, string>; skipped: { id: string; reason: string }[]; defaultOf: Map<string, boolean> } {
+  const cwd = opts.cwd ?? process.cwd();
+  const readFile = opts.readFile ?? ((p: string) => fs.readFileSync(p, 'utf8'));
+  const defaultOf = new Map<string, boolean>();
+  const entrypoints = opts.entrypoints ?? new Set<string>();
+  const chunkOf = new Map<string, string>();
+  const skipped: { id: string; reason: string }[] = [];
+
+  for (const [rawId, meta] of Object.entries(metafile.inputs)) {
+    const id = toPosixPath(path.resolve(cwd, rawId));
+    if (entrypoints.has(id) || !fs.existsSync(id)) {
+      continue;
+    }
+    const relativeId = toPosixPath(path.relative(cwd, id));
+    const packageName = packageNameOf(id);
+    let picked: string | null | undefined;
+    try {
+      picked = classify(id, { isNodeModules: packageName !== null, packageName, relativeId, bytes: meta.bytes });
+    } catch (err) {
+      throw new Error(`[mochi] clientBundle.chunks threw while classifying "${relativeId}": ${err instanceof Error ? err.message : String(err)}`, { cause: err });
+    }
+    if (picked === null || picked === undefined) {
+      continue;
+    }
+    if (typeof picked !== 'string') {
+      throw new Error(`[mochi] clientBundle.chunks returned ${JSON.stringify(picked)} for "${relativeId}" — ` + `return a chunk name string, or null to leave placement to Bun.`);
+    }
+    assertValidChunkName(picked, relativeId);
+    // A CJS module's exports are synthesized during bundling, so neither `export *` nor an up-front default check sees
+    // them; a view would silently re-export nothing.
+    if (meta.format === 'cjs') {
+      skipped.push({ id: relativeId, reason: 'CommonJS, whose exports are synthesized during bundling' });
+      continue;
+    }
+    // Svelte's runtime is densely circular, and moving its modules reorders their initialization: the build still
+    // succeeds while the browser throws on hydration. There is nothing to win either way — every island entry reaches
+    // the runtime, so Bun already emits it as a single shared chunk.
+    if (packageName !== null && PROTECTED_PACKAGES.has(packageName)) {
+      skipped.push({ id: relativeId, reason: `the ${packageName} runtime, already one shared chunk and unsafe to reorder` });
+      continue;
+    }
+    const hasDefault = hasDefaultExport(id, readFile);
+    if (hasDefault === null) {
+      skipped.push({ id: relativeId, reason: `unreadable ${path.extname(id) || 'source'}` });
+      continue;
+    }
+    defaultOf.set(id, hasDefault);
+    chunkOf.set(id, picked);
+  }
+  return { chunkOf, skipped, defaultOf };
+}
+
+/**
+ * Build the view sources for an assignment.
+ *
+ * Each member gets a view that star-re-exports the real module and side-effect-imports the *next* view in the group,
+ * closing into a ring. Reaching any one view therefore walks the ring and reaches every member, which equalizes their
+ * entrypoint reachability and is what collapses the group into a single chunk. A ring rather than every-imports-every
+ * keeps this linear: a 250-module group emits 250 extra imports instead of ~62,000.
+ *
+ * `export *` carries every named export the module has, including ones it re-exports from elsewhere, so no export list
+ * has to be computed ahead of the build. It never carries `default`, which is why that one name is passed in.
+ */
+export function planChunks(chunkOf: Map<string, string>, hasDefault: (absPath: string) => boolean): ChunkPlan {
+  const members = new Map<string, string[]>();
+  for (const [id, chunk] of chunkOf) {
+    const list = members.get(chunk);
+    if (list) {
+      list.push(id);
+    } else {
+      members.set(chunk, [id]);
+    }
+  }
+  // Sorted so one config plans identically across runs, keeping output hashes stable.
+  for (const list of members.values()) {
+    list.sort();
+  }
+
+  const sources = new Map<string, string>();
+  for (const list of members.values()) {
+    list.forEach((m, i) => {
+      const quoted = JSON.stringify(m);
+      const lines: string[] = [];
+      const next = list[(i + 1) % list.length]!;
+      if (next !== m) {
+        lines.push(`import ${JSON.stringify(viewId(next))};`);
+      }
+      lines.push(`export * from ${quoted};`);
+      if (hasDefault(m)) {
+        lines.push(`export { default } from ${quoted};`);
+      }
+      sources.set(viewId(m), lines.join('\n'));
+    });
+  }
+  return { members, chunkOf, sources };
+}
+
+/**
+ * A filter matching any specifier that *might* resolve to an assigned module.
+ *
+ * An `onResolve` whose filter matches one of the in-memory `files:` entrypoints the island bundle is built from makes
+ * Bun stop resolving it entirely, failing the build with `ModuleNotFound … (entry point)` — even when the handler
+ * returns `undefined` for everything. Hence both halves here: a cheap superset (file stem plus containing directory
+ * name, so `./lib` resolving to `lib/index.ts` is covered) and an explicit exclusion of the entry names.
+ *
+ * A specifier that slips past degrades gracefully: the module keeps Bun's own placement instead of being mis-assigned.
+ */
+export function chunkResolveFilter(chunkOf: Map<string, string>, virtualEntryNames: Iterable<string> = []): RegExp {
+  // The generated view specifiers have to match too, since one handler serves both directions.
+  const stems = new Set<string>([VIEW_PREFIX]);
+  for (const abs of chunkOf.keys()) {
+    stems.add(path.basename(abs, path.extname(abs)));
+    stems.add(path.basename(abs));
+    stems.add(path.basename(path.dirname(abs)));
+  }
+  const alternation = [...stems]
+    .filter((s) => s.length > 0)
+    .sort()
+    .map(escapeRegex)
+    .join('|');
+  // No members means the caller shouldn't have asked; match nothing rather than everything.
+  if (alternation === '') {
+    return /(?!)/;
+  }
+  // A directory stem like `src` (from `svelte/src/utils.js`) otherwise matches the island entry paths, and an
+  // `onResolve` whose filter matches an in-memory `files:` entry stops Bun resolving it at all — even when the handler
+  // returns undefined. So entry names are excluded up front rather than inside the handler.
+  const guard = [...virtualEntryNames].map(escapeRegex).join('|');
+  return new RegExp(`^${guard === '' ? '' : `(?!.*(?:${guard}))`}.*(?:${alternation})`);
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Absolute POSIX path a plugin specifier points at, or `null` when it can't be resolved.
+ *
+ * Chunk membership is keyed on the resolved paths Bun's metafile reports, while `onResolve` sees the raw specifier —
+ * usually extensionless (`./vendorOne`), so a bare `path.resolve` would never match `…/vendorOne.ts`. Mirrors the
+ * resolve-with-fallback in `serverOnlyComponents.ts`.
+ */
+export function resolveChunkMember(args: { path: string; importer?: string; resolveDir?: string }): string | null {
+  try {
+    return toPosixPath(Bun.resolveSync(args.path, args.resolveDir || (args.importer ? path.dirname(args.importer) : process.cwd())));
+  } catch {
+    if (args.resolveDir) {
+      return toPosixPath(path.resolve(args.resolveDir, args.path));
+    }
+    return null;
+  }
+}
+
+/** True for a generated view id, i.e. a module this planner authored. */
+export function isChunkModuleId(id: string | undefined): boolean {
+  return !!id && (id.startsWith(VIEW_PREFIX) || id.startsWith(`${CHUNK_NAMESPACE}:`));
+}

--- a/packages/mochi/src/compiler/clientBundleChunks.ts
+++ b/packages/mochi/src/compiler/clientBundleChunks.ts
@@ -32,7 +32,22 @@ const PROTECTED_PACKAGES = new Set(['svelte']);
 const STORE_PATH = /^(?:\.\.\/)*node_modules\/\.bun\/[^/]+\/node_modules\/(.+)$/;
 const LEADING_NODE_MODULES = /^(?:\.\.\/)*node_modules\//;
 
-export const viewId = (absPath: string): string => `${VIEW_PREFIX}${absPath}`;
+/**
+ * An absolute path that has been resolved against a base and normalized to forward slashes — the form every map in this
+ * module is keyed by.
+ *
+ * The brand exists because the resolved form is platform-dependent at the root (`/app/x.ts` on POSIX,
+ * `C:/app/x.ts` on Windows) while looking like any other string. Writing a key as a literal type-checks, matches
+ * locally, and then misses on Windows only. Requiring `posixAbs()` to mint one makes that mistake a compile error.
+ */
+export type PosixAbsPath = string & { readonly __posixAbs: unique symbol };
+
+/** The only way to mint a {@link PosixAbsPath}. */
+export function posixAbs(p: string, cwd: string = process.cwd()): PosixAbsPath {
+  return toPosixPath(path.resolve(cwd, p)) as PosixAbsPath;
+}
+
+export const viewId = (absPath: PosixAbsPath): string => `${VIEW_PREFIX}${absPath}`;
 
 /** Minimal shape this module reads out of `Bun.build`'s metafile, so tests can build literals instead of running a build. */
 export interface ChunkMetafile {
@@ -48,11 +63,11 @@ export interface ChunkMetafile {
  * walked in sorted path order so two members that pass 1 put in different chunks still rank deterministically; their
  * relative order was never observable anyway, whereas co-located members keep exactly the order they had.
  */
-export function evaluationOrder(metafile: ChunkMetafile, cwd: string = process.cwd()): Map<string, number> {
-  const order = new Map<string, number>();
+export function evaluationOrder(metafile: ChunkMetafile, cwd: string = process.cwd()): Map<PosixAbsPath, number> {
+  const order = new Map<PosixAbsPath, number>();
   for (const outPath of Object.keys(metafile.outputs ?? {}).sort()) {
     for (const input of Object.keys(metafile.outputs![outPath]!.inputs)) {
-      const id = toPosixPath(path.resolve(cwd, input));
+      const id = posixAbs(input, cwd);
       if (!order.has(id)) {
         order.set(id, order.size);
       }
@@ -100,9 +115,9 @@ export function hasDefaultExport(absPath: string, readFile: (p: string) => strin
 
 export interface ChunkPlan {
   /** Chunk name → absolute POSIX paths of every module assigned to it. */
-  members: Map<string, string[]>;
+  members: Map<string, PosixAbsPath[]>;
   /** Absolute POSIX path → the chunk it belongs to. */
-  chunkOf: Map<string, string>;
+  chunkOf: Map<PosixAbsPath, string>;
   /** Virtual module id → generated source. */
   sources: Map<string, string>;
 }
@@ -178,17 +193,17 @@ function assertValidChunkName(name: string, relId: string): void {
 export function classifyModules(
   metafile: ChunkMetafile,
   classify: MochiChunkClassifier,
-  opts: { entrypoints?: Set<string>; cwd?: string; readFile?: (p: string) => string } = {},
-): { chunkOf: Map<string, string>; skipped: { id: string; reason: string }[]; defaultOf: Map<string, boolean> } {
+  opts: { entrypoints?: Set<PosixAbsPath>; cwd?: string; readFile?: (p: string) => string } = {},
+): { chunkOf: Map<PosixAbsPath, string>; skipped: { id: string; reason: string }[]; defaultOf: Map<PosixAbsPath, boolean> } {
   const cwd = opts.cwd ?? process.cwd();
   const readFile = opts.readFile ?? ((p: string) => fs.readFileSync(p, 'utf8'));
-  const defaultOf = new Map<string, boolean>();
-  const entrypoints = opts.entrypoints ?? new Set<string>();
-  const chunkOf = new Map<string, string>();
+  const defaultOf = new Map<PosixAbsPath, boolean>();
+  const entrypoints = opts.entrypoints ?? new Set<PosixAbsPath>();
+  const chunkOf = new Map<PosixAbsPath, string>();
   const skipped: { id: string; reason: string }[] = [];
 
   for (const [rawId, meta] of Object.entries(metafile.inputs)) {
-    const id = toPosixPath(path.resolve(cwd, rawId));
+    const id = posixAbs(rawId, cwd);
     if (entrypoints.has(id) || !fs.existsSync(id)) {
       continue;
     }
@@ -248,8 +263,8 @@ export function classifyModules(
  * `export *` carries every named export the module has, including ones it re-exports from elsewhere, so no export list
  * has to be computed ahead of the build. It never carries `default`, which is why that one name is passed in.
  */
-export function planChunks(chunkOf: Map<string, string>, hasDefault: (absPath: string) => boolean, order?: ReadonlyMap<string, number>): ChunkPlan {
-  const members = new Map<string, string[]>();
+export function planChunks(chunkOf: Map<PosixAbsPath, string>, hasDefault: (absPath: PosixAbsPath) => boolean, order?: ReadonlyMap<PosixAbsPath, number>): ChunkPlan {
+  const members = new Map<string, PosixAbsPath[]>();
   for (const [id, chunk] of chunkOf) {
     const list = members.get(chunk);
     if (list) {
@@ -260,7 +275,7 @@ export function planChunks(chunkOf: Map<string, string>, hasDefault: (absPath: s
   }
   // Evaluation order first, path as the tie-break, so one config plans identically across runs and output hashes stay
   // stable even for members pass 1 never placed together.
-  const rank = (id: string) => order?.get(id) ?? Number.MAX_SAFE_INTEGER;
+  const rank = (id: PosixAbsPath) => order?.get(id) ?? Number.MAX_SAFE_INTEGER;
   for (const list of members.values()) {
     list.sort((a, b) => rank(a) - rank(b) || (a < b ? -1 : a > b ? 1 : 0));
   }
@@ -293,7 +308,7 @@ export function planChunks(chunkOf: Map<string, string>, hasDefault: (absPath: s
  *
  * A specifier that slips past degrades gracefully: the module keeps Bun's own placement instead of being mis-assigned.
  */
-export function chunkResolveFilter(chunkOf: Map<string, string>, virtualEntryNames: Iterable<string> = []): RegExp {
+export function chunkResolveFilter(chunkOf: Map<PosixAbsPath, string>, virtualEntryNames: Iterable<string> = []): RegExp {
   // The generated view specifiers have to match too, since one handler serves both directions.
   const stems = new Set<string>([VIEW_PREFIX]);
   for (const abs of chunkOf.keys()) {
@@ -328,12 +343,12 @@ function escapeRegex(s: string): string {
  * usually extensionless (`./vendorOne`), so a bare `path.resolve` would never match `…/vendorOne.ts`. Mirrors the
  * resolve-with-fallback in `serverOnlyComponents.ts`.
  */
-export function resolveChunkMember(args: { path: string; importer?: string; resolveDir?: string }): string | null {
+export function resolveChunkMember(args: { path: string; importer?: string; resolveDir?: string }): PosixAbsPath | null {
   try {
-    return toPosixPath(Bun.resolveSync(args.path, args.resolveDir || (args.importer ? path.dirname(args.importer) : process.cwd())));
+    return toPosixPath(Bun.resolveSync(args.path, args.resolveDir || (args.importer ? path.dirname(args.importer) : process.cwd()))) as PosixAbsPath;
   } catch {
     if (args.resolveDir) {
-      return toPosixPath(path.resolve(args.resolveDir, args.path));
+      return posixAbs(args.path, args.resolveDir);
     }
     return null;
   }

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -212,6 +212,9 @@ export type {
   MochiSvelteShakerOptions,
   MochiBarrelWarningOptions,
   MochiBuildReportOptions,
+  MochiClientBundleOptions,
+  MochiChunkClassifier,
+  MochiChunkContext,
 } from './types';
 
 import type { Snippet } from 'svelte';

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -331,6 +331,8 @@ export interface MochiManifest {
       size: number;
       inputs: { path: string; size: number }[];
       imports: string[];
+      /** Name assigned by `clientBundle.chunks`, when this output is a manual chunk. Diagnostic only. */
+      chunkName?: string;
     }[];
   } | null;
   /** Maps server island component name → its encoded source path (see `version`). */
@@ -614,6 +616,15 @@ export interface MochiServeOptions {
    */
   barrelWarnings?: boolean | MochiBarrelWarningOptions;
   /**
+   * Manual control over how the island client bundle splits: map module paths to named shared chunks with `chunks`
+   * (Vite/Rollup `manualChunks(id)` semantics), and toggle Bun's splitting with `splitting`.
+   *
+   * **Production only**, like `optimize`: assigning modules to chunks is a whole-graph decision needing a discovery
+   * build pass, which per-file HMR can't safely reuse. In development the option is ignored and the bundle splits
+   * exactly as it does today. `mochi-framework build` reads this straight from your entry's `Mochi.serve()` call.
+   */
+  clientBundle?: MochiClientBundleOptions;
+  /**
    * Output controls for `mochi-framework build`, read from your entry alongside `optimize` and `barrelWarnings`.
    * The runtime itself ignores this field.
    */
@@ -625,6 +636,41 @@ export interface MochiServeOptions {
 export interface MochiBuildReportOptions {
   /** Print the emitted-resources list, one row per local image import with dimensions and size on disk. The summary line keeps its asset count either way. Default: enabled. */
   resources?: boolean;
+}
+
+/**
+ * `id` is an absolute POSIX path (forward slashes on every platform), so `id.includes('node_modules/chart.js/')`
+ * behaves the same on Windows. Return a chunk name, or `null`/`undefined` to leave placement to Bun.
+ */
+export type MochiChunkClassifier = (id: string, ctx: MochiChunkContext) => string | null | undefined;
+
+/** Second argument to `MochiChunkClassifier`, so the common cases need no string surgery on `id`. */
+export interface MochiChunkContext {
+  /** `true` when the module resolves under a `node_modules/` directory. */
+  isNodeModules: boolean;
+  /** Package name for a `node_modules` module (`chart.js`, `@lucide/svelte`), otherwise `null`. */
+  packageName: string | null;
+  /** POSIX path relative to the build cwd, matching what `stats.outputs[].inputs[].path` reports. */
+  relativeId: string;
+  /** Parsed size in bytes, from Bun's metafile. */
+  bytes: number;
+}
+
+/** Object form of `MochiServeOptions['clientBundle']`. See that field for semantics. */
+export interface MochiClientBundleOptions {
+  /**
+   * Rollup/Vite `manualChunks(id)` semantics for the island client bundle: map module paths to named shared chunks.
+   * Called once per module in the built client graph; modules given the same name land in one output file.
+   *
+   * CommonJS modules are skipped — their exports cannot be enumerated ahead of bundling, so moving one breaks any
+   * named import of it. The build report lists what was skipped.
+   */
+  chunks?: MochiChunkClassifier;
+  /**
+   * Bun's code splitting. `false` makes every island entry self-contained, duplicating shared dependencies across
+   * them instead of emitting shared chunks. Default: `true`.
+   */
+  splitting?: boolean;
 }
 
 /** Object form of `MochiServeOptions['barrelWarnings']`. See that field for semantics. */

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -331,8 +331,8 @@ export interface MochiManifest {
       size: number;
       inputs: { path: string; size: number }[];
       imports: string[];
-      /** Name assigned by `clientBundle.chunks`, when this output is a manual chunk. Diagnostic only. */
-      chunkName?: string;
+      /** Name(s) assigned by `clientBundle.chunks`, when this output really is a shared chunk they produced. Diagnostic only. */
+      chunkNames?: string[];
     }[];
   } | null;
   /** Maps server island component name → its encoded source path (see `version`). */
@@ -668,7 +668,8 @@ export interface MochiClientBundleOptions {
   chunks?: MochiChunkClassifier;
   /**
    * Bun's code splitting. `false` makes every island entry self-contained, duplicating shared dependencies across
-   * them instead of emitting shared chunks. Default: `true`.
+   * them instead of emitting shared chunks. Cannot be combined with `chunks`, which has no chunks to fill without it.
+   * Default: `true`.
    */
   splitting?: boolean;
 }

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -189,6 +189,19 @@ await Mochi.serve({
     },
   },
   markdown: markdownConfig,
+  // The charting stack and the reactive-utility packages are each pulled in whole by the islands that use them, so
+  // grouping them trades a spread of tiny per-island chunks for a couple of cache entries that survive content changes.
+  clientBundle: {
+    chunks: (_id, { packageName }) => {
+      // The charting stack is deliberately not grouped: layerchart's multi-renderer `.svelte` families cannot all be
+      // moved, and the d3 packages under it break island hydration even when the group does form — they import each
+      // other heavily, which the grouping does not survive.
+      if (packageName && ['runed', 'mode-watcher', 'svelte-toolbelt', 'tailwind-merge'].includes(packageName)) {
+        return 'ui';
+      }
+      return null;
+    },
+  },
   eventHooks: {
     'mochi:init': ({ options }) => {
       logger.info(`init: starting on port ${options.port}`);


### PR DESCRIPTION
> [!WARNING]
> **Draft — not ready to merge.** Browser-testing this against `packages/site` found that grouping can produce a bundle
> which builds cleanly and then throws when an island hydrates (`ReferenceError: x is not defined`,
> `Export 'x' is not defined in module`).
>
> Later commits narrow the failure modes — re-export barrels are refused, and a group that only partly moves now fails
> the build — but they do **not** close them: a group of packages that import each other heavily (the d3 family) still
> breaks hydration even when the group collapses completely, and no classifier-level check catches that.
>
> Groups of loosely-coupled packages do work and are verified in a browser. Treat the callback API as unproven until
> the underlying wiring is fixed or the scope is narrowed.

---

Adds `Mochi.serve({ clientBundle: { chunks, splitting } })` — a Rollup/Vite-style `manualChunks(id)` classifier over **module paths**, so an app can group shared code the bundler has no way to group on its own.

```ts
clientBundle: {
  chunks: (id, { packageName }) => {
    if (packageName === 'chart.js' || packageName?.startsWith('d3-')) return 'charts';
    if (id.includes('/src/admin/')) return 'admin';
    return null; // leave placement to Bun
  },
}
```

Production only, matching the [`optimize`](https://github.com/khromov/mochi/blob/main/packages/docs/177-svelte-shaker.md) precedent: the assignment is a whole-graph decision that per-file HMR cannot reuse. Dev behaves exactly as before and pays nothing.

## Why it works this way

Bun's bundler has **no `manualChunks`** — only `splitting: boolean` and `naming.chunk`. It assigns a module to a chunk purely by the set of entrypoints that reach it, and two modules share a chunk iff those sets match exactly. So the grouping has to be *induced*: each assigned module is replaced, at its import sites, by a generated **view** that re-exports it and links into a **ring** with the group's other views. Reaching any member walks the ring and reaches all of them, equalizing their reachability so Bun emits the group as one chunk.

A ring rather than every-view-imports-every-other keeps it linear — a 250-module group costs 250 extra imports instead of ~62,000 (worth ~10s of client-bundle time on `packages/site`).

**Only edges crossing into a group are redirected.** Rewriting one member's import of another routes it around the ring, putting the real modules in a cycle and reordering their initialization.

## Modules that are skipped

Reported in the build's chunk report, never silently:

- **CommonJS** — its exports are synthesized during bundling, so a moved copy would re-export nothing.
- **Svelte itself** — already one shared chunk (every island reaches it), and reordering its densely circular internals breaks hydration.

## Please read before merging

**A passing build does not prove this works.** Chunking Svelte built cleanly and then threw `Cannot read properties of null` on hydration — visible only in a browser. That specific case is now refused, but the class of failure can't be detected in general, so the docs tell readers to load a real page after changing `chunks`.

Two judgment calls worth a second opinion:

- The Svelte denylist is a hard refusal rather than an overridable warning (`PROTECTED_PACKAGES` in `clientBundleChunks.ts`). Chosen because the failure is invisible until hydration and there is no upside.
- `chunkNaming` is deliberately **not** in the API: Bun's `[name]` for a chunk resolves to a reaching *entry's* name, never the configured one, so it would be a knob that does not do what it says. The chosen name surfaces in the build report instead.

`VersionNote` says `since="0.10.0"` — needs checking against the release this actually ships in.

## Verification

- `bun run checks` passes (typecheck clean, all suites green, nothing reformatted).
- 40 new tests: `compiler/clientBundleChunks.test.ts` (32, pure) and `compiler/clientBundleChunkBundle.test.ts` (8, end-to-end).
- Verified in a real browser on `packages/site`: an 84-module `@lucide/svelte` → `icons` chunk builds, is fetched, hydrates, and stays interactive (island click toggles state), clean console on both the hydration and charts demos. Temporary site config reverted.

## Out of scope

Found while working here, deliberately not fixed: **`filters` and `eventHooks` never reach `mochi-framework build`** (`cli.ts` forwards a whitelist; `initExtensions()` only runs inside `Mochi.serve()`). So `compile:preprocessors`, the `image:*` filters, `barrel:warn` and `publicDir:scan` all silently no-op in production builds today — despite the docs saying `image:localAssetEmitted` fires "at build time". Worth its own issue.

