### PR TITLE
fix(debug-bar): match svelte inputs under the isolated linker in "Hide Svelte"

### DIFF
--- a/packages/mochi/src/debug-bar/BundlesPanel.svelte
+++ b/packages/mochi/src/debug-bar/BundlesPanel.svelte
@@ -5,7 +5,7 @@
   import ArrowUpRight from '../icons/arrow-up-right.svelte';
   import DebugPanel from './DebugPanel.svelte';
   import { debugBarState } from './state.svelte';
-  import { formatSize } from './utils';
+  import { formatSize, isSvelteInput } from './utils';
 
   let { open, onclose }: { open: boolean; onclose: () => void } = $props();
 
@@ -15,7 +15,7 @@
   let filterSvelte = $state(localStorage.getItem(HIDE_SVELTE_KEY) === '1');
 
   function svelteSizeOf(b: BundleInfo): number {
-    return b.inputs.filter((i) => i.path.startsWith('svelte/')).reduce((s, i) => s + i.size, 0);
+    return b.inputs.filter((i) => isSvelteInput(i.path)).reduce((s, i) => s + i.size, 0);
   }
 
   let totalSize = $derived(bundles.reduce((sum, b) => sum + b.sizeBytes, 0));
@@ -68,7 +68,7 @@
 </script>
 
 {#snippet bundleRow(bundle: BundleInfo)}
-  {@const displayInputs = filterSvelte ? bundle.inputs.filter((i) => !i.path.startsWith('svelte/')) : bundle.inputs}
+  {@const displayInputs = filterSvelte ? bundle.inputs.filter((i) => !isSvelteInput(i.path)) : bundle.inputs}
   {@const displaySize = bundle.sizeBytes - (filterSvelte ? svelteSizeOf(bundle) : 0)}
   {@const empty = displayInputs.length === 0 && bundle.kind !== 'bootstrap'}
   <div class="bundle-entry" class:open={!empty && expanded[bundle.url]} class:dimmed={empty}>

--- a/packages/mochi/src/debug-bar/utils.test.ts
+++ b/packages/mochi/src/debug-bar/utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from 'bun:test';
+import { isSvelteInput } from './utils';
+import { cleanInputPath } from '../compiler/bundleInputPaths';
+
+describe('isSvelteInput', () => {
+  test('matches svelte under both linker layouts', () => {
+    // The regression from #275: the isolated linker's store form kept a `svelte@<version>` prefix, so the old
+    // `startsWith('svelte/')` predicate stopped matching and "Hide Svelte" filtered nothing in production.
+    expect(isSvelteInput('svelte/src/internal/client/errors.js')).toBe(true);
+    expect(isSvelteInput('svelte@5.56.8+7da81a596917ee3f/src/internal/client/errors.js')).toBe(true);
+  });
+
+  test('does not match other packages that merely start with svelte', () => {
+    expect(isSvelteInput('svelte-toolbelt/dist/index.js')).toBe(false);
+    expect(isSvelteInput('svelte-toolbelt@1.0.0/dist/index.js')).toBe(false);
+    expect(isSvelteInput('@sveltejs/kit@2.0.0/dist/x.js')).toBe(false);
+    expect(isSvelteInput('runed@0.25.0/dist/index.js')).toBe(false);
+    expect(isSvelteInput('src/demos/mode-watcher/ModeControls.svelte')).toBe(false);
+  });
+
+  // Guards against format drift: cleanInputPath is the producer, isSvelteInput the consumer — if either side's
+  // notion of a svelte path changes, this fails. This is the assertion #275 would have tripped.
+  test('matches the store-form path cleanInputPath actually produces', () => {
+    const cleaned = cleanInputPath('../../node_modules/.bun/svelte@5.56.8+7da81a596917ee3f/node_modules/svelte/src/internal/client/errors.js');
+
+    expect(cleaned).toBe('svelte@5.56.8+7da81a596917ee3f/src/internal/client/errors.js');
+    expect(isSvelteInput(cleaned)).toBe(true);
+  });
+});

--- a/packages/mochi/src/debug-bar/utils.ts
+++ b/packages/mochi/src/debug-bar/utils.ts
@@ -2,6 +2,14 @@ import prettyBytes from '../vendor/pretty-bytes';
 
 export const formatSize = prettyBytes;
 
+// cleanInputPath (compiler/bundleInputPaths.ts) renders svelte as `svelte/…` under the hoisted linker but
+// `svelte@<version>/…` under Bun's default isolated-linker store — match the package across both forms.
+export function isSvelteInput(path: string): boolean {
+  const seg = path.split('/', 1)[0] ?? '';
+  const name = seg.startsWith('@') ? seg : seg.split('@')[0];
+  return name === 'svelte';
+}
+
 export const highlightColors = {
   keyColor: '#b8d5be',
   numberColor: '#e9a89a',


### PR DESCRIPTION
## The bug

The **JS Bundles** panel's "Hide Svelte" toggle no longer filters anything.

## Root cause

`BundlesPanel.svelte` filtered inputs with `path.startsWith('svelte/')`. Commit #275 (`3c9f9af`) reworked `cleanInputPath` to keep the install-store version segment so paths stay injective. Under Bun's **default isolated linker** (production, and any npm consumer that hasn't pinned the hoisted linker), a svelte module input now renders as:

```
svelte@5.56.8+7da81a596917ee3f/src/internal/client/errors.js
```

instead of `svelte/...`. The `startsWith('svelte/')` predicate matches the hoisted-linker form only, so "Hide Svelte" matches nothing. It's masked locally because root `bunfig.toml` pins `linker = "hoisted"`, keeping paths as `svelte/...`.

## The fix

- Add `isSvelteInput()` to `debug-bar/utils.ts` — matches the `svelte` package across both `svelte/…` (hoisted) and `svelte@<version>/…` (isolated store) forms, while still excluding `svelte-toolbelt`, `@sveltejs/*`, etc. It lives in `utils.ts` (already imported by the panel, client-safe) rather than `compiler/bundleInputPaths.ts`, which transitively pulls in `svelte/compiler`.
- Use it in `BundlesPanel.svelte` for both the row filter and the byte-total subtraction.

## Regression test

New `debug-bar/utils.test.ts` covers both path forms plus non-matches, and an integration case that feeds a raw isolated-linker path through `cleanInputPath` and asserts the result is matched by `isSvelteInput` — tying the producer and consumer together so they can't drift apart again. Verified the test fails against the old `startsWith('svelte/')` predicate.

`bun run checks` passes (lint + format + typecheck + test).