### PR TITLE
fix: stop the docker dev script pinning a CPU core while idling

### DIFF
--- a/packages/docker/scripts/dev.ts
+++ b/packages/docker/scripts/dev.ts
@@ -3,6 +3,13 @@ import path from 'node:path';
 
 const root = path.resolve(import.meta.dir, '..');
 
+// A bare never-resolving promise pins a CPU core at 100% in Bun; an anchored
+// timer parks the event loop instead.
+const idleForever = (): Promise<never> => {
+  setInterval(() => {}, 60_000);
+  return new Promise(() => {});
+};
+
 const dockerAvailable = async (): Promise<boolean> => {
   try {
     const probe = spawn({ cmd: ['docker', 'info'], stdout: 'ignore', stderr: 'ignore', stdin: 'ignore' });
@@ -16,7 +23,7 @@ if (!(await dockerAvailable())) {
   console.warn('Docker is not available — skipping Postgres + Adminer.');
   // Idle instead of exiting: the root dev.ts tears down every dev server as
   // soon as the first child exits, even with code 0.
-  await new Promise(() => {});
+  await idleForever();
 }
 
 const proc = spawn({
@@ -52,4 +59,4 @@ if (shuttingDown) {
 // than from our shutdown signal: idle instead of exiting so the root dev.ts's
 // first-exit-wins teardown can't take the other dev servers down with it.
 console.warn(`docker compose exited (code ${code}) — idling so the other dev servers keep running.`);
-await new Promise(() => {});
+await idleForever();


### PR DESCRIPTION
## Problem

Running `bun run dev` with Docker unavailable (e.g. colima stopped) pins one CPU core at ~100% for the entire session.

The culprit is `packages/docker/scripts/dev.ts`. When `docker info` fails it deliberately idles forever rather than exiting, so the root `dev.ts`'s first-exit-wins teardown can't take the other dev servers down with it. It idled with a bare `await new Promise(() => {})`.

That leaves Bun's event loop with no registered handle to block on and no deadline to sleep until, so it re-iterates as fast as it can instead of parking.

## Reproduction

A file containing only `await new Promise(() => {})` sits at **97.5% CPU** under Bun 1.3.14. (Node exits instead; neither should busy-wait.)

## Fix

An `idleForever()` helper registers a no-op `setInterval` before awaiting, giving the loop a deadline to sleep against. Applied to both idle sites — the no-Docker branch and the compose-exited branch.

## Verification

| | CPU |
|---|---|
| Standalone repro, before | 97.5% |
| Standalone repro, with timer anchor | 0.0% |
| Real `scripts/dev.ts`, Docker unavailable, before | 99.3% |
| Real `scripts/dev.ts`, Docker unavailable, after (70s, across a timer tick) | 0.0% |

Shutdown behaviour is unchanged — the promise still never resolves, so `await` stays parked; the timer only makes "forever" cheap.

Likely an upstream Bun bug (an idle process with no pending work shouldn't burn a core), but the anchor is a fine permanent workaround.