### PR TITLE
fix: minify imported CSS bundles

### DIFF
--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -1985,6 +1985,7 @@ export class ComponentRegistry {
           entrypoints: [cssPath],
           outdir: importCssOutDir,
           naming: { entry: '[name]-[hash].[ext]' },
+          minify: true,
           plugins: Number.isFinite(this.fontInlineThreshold) ? [fontPlugin] : [],
           throw: false,
         });

--- a/packages/mochi/src/compiler/cssFontImports.test.ts
+++ b/packages/mochi/src/compiler/cssFontImports.test.ts
@@ -78,7 +78,7 @@ describe('CSS imports — font asset extraction', () => {
   test('rewrites the large woff2 to a served font URL and drops the base64 payload', () => {
     const css = bundledCss();
     // Bun unquotes the plain `woff2` format keyword — both forms are valid CSS.
-    expect(css).toMatch(new RegExp(`url\\(/_mochi/fonts/demo-latin-400-normal-${fontContentHash(woff2)}\\.woff2\\) format\\(["']?woff2["']?\\)`));
+    expect(css).toMatch(new RegExp(`url\\(/_mochi/fonts/demo-latin-400-normal-${fontContentHash(woff2)}\\.woff2\\)\\s*format\\(["']?woff2["']?\\)`));
   });
 
   test('drops the legacy woff source entirely', () => {

--- a/packages/mochi/src/compiler/cssImports.test.ts
+++ b/packages/mochi/src/compiler/cssImports.test.ts
@@ -48,6 +48,17 @@ describe('CSS imports — happy path', () => {
     expect(cssOutput?.size).toBeGreaterThan(0);
   });
 
+  test('minifies the bundled CSS', () => {
+    const cssOutput = registry.getClientStats()?.outputs.find((o) => o.name.startsWith('styles-'));
+    expect(cssOutput).toBeDefined();
+    const cssText = registry.getClientFile(`/_mochi/import-css/${cssOutput!.name}`);
+    expect(cssText).toBeDefined();
+    // Minified output drops the source-path banner comment and all indentation.
+    expect(cssText).not.toContain('/*');
+    expect(cssText).not.toMatch(/\n\s{2,}/);
+    expect(cssText!.trim()).toContain('body{color:red}');
+  });
+
   test('renderComponent links the bundled CSS URL', async () => {
     const { requestContext } = await import('../runtime/requestContext');
     const { MochiCookieJar } = await import('../runtime/cookies');


### PR DESCRIPTION
## Summary

`import './theme.css'` from a component produced an `/_mochi/import-css/*` asset that kept its source formatting — indentation, blank lines, and the leading `/* src/... */` banner comment. Every other `Bun.build()` in the compiler passes `minify: true` (component CSS, the Svelte client bundle, the debug bar, the inline web component); `bundleImportedCssBatch` was the sole exception, reading as an oversight rather than a decision.

This passes `minify: true` on that build too, matching the rest of the compiler. Unconditional — no new serve option, since no other build exposes a minify toggle.

On a real 28,850-byte stylesheet: today's bundle is 22,747 bytes; minified it is 18,994 (~17% smaller, ~5% after gzip). Small on the wire, but it matters for consistency, uncompressed size, and the `publicDir → import` migration path (publicDir files can't be compressed at all, so moving a stylesheet into an import shouldn't quietly hand back a *less* optimised artifact).

## Why the post-processing survives minification

- `restoreVariationsFormat` — regex over `format(woff2-variations)` etc.; same token shape, already a no-op on Bun 1.4.
- `adoptEmittedFontAssets` / `substituteFontUrls` — match on the marker `data:` URIs the font plugin emits inside `url()`; `data:` URIs are preserved verbatim by the minifier.
- The re-hash-and-rewrite branch recomputes the content hash after substitution, so the smaller minified bytes get a correct immutable filename.

## Tests

- `cssImports.test.ts` — new assertion that imported CSS is minified (no banner comment, no indentation). This path previously had no minification coverage.
- `cssFontImports.test.ts` — made one assertion whitespace-tolerant: minification legitimately drops the optional space between `url()` and `format()`; the substitution output is otherwise unchanged.

## Verification

- Both suites pass (30/30).
- Live smoke test of the site homepage: the served `/_mochi/import-css/*` asset now comes back as a minified single line, with font-URL substitution and `format('woff2-variations')` re-quoting both intact.

Closes the "Imported CSS is not minified" report.
