### PR TITLE
fix(fonts): don't hash a half-written font copy into the served asset name

### DIFF
--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -2020,6 +2020,11 @@ export class ComponentRegistry {
           logger.error(`CSS bundle for ${cssPath}: ${message}`);
           this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
         }
+        for (const assetPath of adopted.unreadable) {
+          const message = `the bundler's copy of ${relForDisplay(assetPath)} was still empty after waiting for the write to land, so its @font-face still points at a file no route serves. Please report this.`;
+          logger.error(`CSS bundle for ${cssPath}: ${message}`);
+          this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
+        }
         // Bun printed these relative to the stylesheet, so serving them under its `import-css/` prefix is what makes
         // the URL it already wrote resolve.
         for (const assetPath of adopted.otherAssets) {

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -21,7 +21,15 @@ import { logger } from '../utils/log';
 import { mochiEvents } from '../events';
 import { detectHeavyBarrels, formatBarrelLine, formatBarrelSummary, type BarrelMetafile, type HeavyBarrel } from './barrelDetect';
 import type { MarkdownConfig, MochiBarrelWarningOptions, MochiFontOptions, MochiManifest, MochiSvelteShakerOptions } from '../types';
-import { adoptEmittedFontAssets, classifyFontAssets, createFontMarkerPlugin, fontAssetFileName, fontContentHash, substituteFontUrls } from './cssFontAssets';
+import {
+  adoptEmittedFontAssets,
+  classifyFontAssets,
+  createFontMarkerPlugin,
+  fontAssetFileName,
+  fontChangedSinceResolved,
+  fontContentHash,
+  substituteFontUrls,
+} from './cssFontAssets';
 import { type HydratableComponent, type PreprocessIslandError, type ServerIslandComponent } from './svelteAstPreprocess';
 import { cachedPreprocessHydratable, createPreprocessCacheStats } from './preprocessCache';
 import { CompileCache, compileFingerprint, createCompileCacheStats, type CompileCacheStats } from './compileCache';
@@ -2057,11 +2065,6 @@ export class ComponentRegistry {
           logger.error(`CSS bundle for ${cssPath}: ${message}`);
           this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
         }
-        for (const assetPath of adopted.unreadable) {
-          const message = `the bundler's copy of ${relForDisplay(assetPath)} was still empty after waiting for the write to land, so its @font-face still points at a file no route serves. Please report this.`;
-          logger.error(`CSS bundle for ${cssPath}: ${message}`);
-          this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
-        }
         // Bun printed these relative to the stylesheet, so serving them under its `import-css/` prefix is what makes
         // the URL it already wrote resolve.
         for (const assetPath of adopted.otherAssets) {
@@ -2086,6 +2089,11 @@ export class ComponentRegistry {
         const fontUrlByMarker = new Map<string, string>();
         for (const font of fontPass.fonts) {
           const bytes = font.ref.bytes ?? (await Bun.file(font.ref.path).bytes());
+          if (fontChangedSinceResolved(font.ref, bytes)) {
+            const message = `the source font ${relForDisplay(font.ref.path)} was ${font.ref.size} bytes when the bundle resolved it but read back ${bytes.length}, so it changed mid-build. If this persists the file is corrupt.`;
+            logger.error(`CSS bundle for ${cssPath}: ${message}`);
+            this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
+          }
           const fileName = fontAssetFileName(font.ref, bytes);
           const diskPath = path.join(this.outDir, 'fonts', fileName);
           const fontUrl = `${this.assetPrefix}/fonts/${fileName}`;

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -2,6 +2,7 @@ import { preprocess as sveltePreprocess, type CompileOptions, type PreprocessorG
 import { render } from 'svelte/server';
 import path from 'node:path';
 import fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import type { BunPlugin } from 'bun';
 import {
   isSvelteMarker,
@@ -1965,6 +1966,32 @@ export class ComponentRegistry {
     return queued;
   }
 
+  /**
+   * Drop the per-build suffix from the assets one bundle emitted, returning their canonical paths. Bun content-hashes
+   * asset names, so a copy another build already renamed holds these exact bytes and this one's is redundant — dropping
+   * it keeps the served name deterministic across builds, which a suffix left in place would not be.
+   *
+   * The canonical path only ever appears as the result of renaming a file Bun had finished writing, so a concurrent
+   * reader sees it whole or not at all.
+   */
+  private reconcileEmittedAssets(emitted: string[], token: string): string[] {
+    return emitted.map((assetPath) => {
+      const canonical = assetPath.replace(`-${token}`, '');
+      try {
+        // `renameSync` onto an existing path throws on Windows rather than replacing, which is the same answer as
+        // finding it already there: another build won, and its copy is byte-identical.
+        if (fs.existsSync(canonical)) {
+          fs.rmSync(assetPath, { force: true });
+        } else {
+          fs.renameSync(assetPath, canonical);
+        }
+      } catch {
+        fs.rmSync(assetPath, { force: true });
+      }
+      return canonical;
+    });
+  }
+
   private async bundleImportedCssBatch(cssPaths: Iterable<string>): Promise<void> {
     const importCssOutDir = path.resolve(`${this.outDir}/import-css`);
     const todo = [...cssPaths].filter((p) => !this.importedCssUrls.has(p));
@@ -1981,10 +2008,14 @@ export class ComponentRegistry {
         // Bun's CSS bundler resolves every url() itself and runs plugin hooks for them, so font discovery rides the
         // bundler: large fonts become tiny marker data: URIs (see createFontMarkerPlugin) substituted below.
         const { plugin: fontPlugin, refs: fontRefs } = createFontMarkerPlugin(this.fontInlineThreshold);
+        // Entrypoints bundle in parallel and two importing the same font emit the same content-hashed copy, so without
+        // a per-build suffix they are concurrent writers to one path and a reader can catch it half-written. Stripped
+        // again by reconcileEmittedAssets below, which puts the canonical name back.
+        const token = randomUUID().slice(0, 8);
         const cssResult = await Bun.build({
           entrypoints: [cssPath],
           outdir: importCssOutDir,
-          naming: { entry: '[name]-[hash].[ext]' },
+          naming: { entry: '[name]-[hash].[ext]', asset: `[name]-[hash]-${token}.[ext]` },
           minify: true,
           plugins: Number.isFinite(this.fontInlineThreshold) ? [fontPlugin] : [],
           throw: false,
@@ -2005,10 +2036,16 @@ export class ComponentRegistry {
         // Read from disk: when Bun.build writes via `outdir`, the output's
         // .text() may return empty — the file on disk is the source of truth.
         const rawCss = await Bun.file(out.path).text();
+        const suffixed = cssResult.outputs.filter((o) => o !== out).map((o) => o.path);
+        const emitted = this.reconcileEmittedAssets(suffixed, token);
         let cssText = restoreVariationsFormat(rawCss);
+        // Exact filenames rather than the bare suffix, which could collide with an unrelated run of the same characters.
+        suffixed.forEach((original, i) => {
+          cssText = cssText.replaceAll(path.basename(original), path.basename(emitted[i]!));
+        });
         const adopted = await adoptEmittedFontAssets(
           cssText,
-          cssResult.outputs.filter((o) => o !== out),
+          emitted.map((path) => ({ path })),
           fontRefs,
         );
         cssText = adopted.css;

--- a/packages/mochi/src/compiler/cssFontAssets.test.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.test.ts
@@ -1,7 +1,16 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { adoptEmittedFontAssets, classifyFontAssets, fontAssetFileName, fontContentHash, stripFontFaces, substituteFontUrls, type FontRef } from './cssFontAssets';
+import {
+  adoptEmittedFontAssets,
+  classifyFontAssets,
+  fontAssetFileName,
+  fontChangedSinceResolved,
+  fontContentHash,
+  stripFontFaces,
+  substituteFontUrls,
+  type FontRef,
+} from './cssFontAssets';
 
 let refCounter = 0;
 function makeRef(path: string, size = 10_000): FontRef {
@@ -222,6 +231,27 @@ describe('fontAssetFileName', () => {
   });
 });
 
+describe('fontChangedSinceResolved', () => {
+  test('a marked font whose source read matches its recorded size is intact', () => {
+    const ref: FontRef = { path: '/pkg/f.woff2', size: 4, markerB64: 'x' };
+    expect(fontChangedSinceResolved(ref, new Uint8Array([1, 2, 3, 4]))).toBe(false);
+  });
+
+  test('a marked font read back at a different length changed mid-build', () => {
+    const ref: FontRef = { path: '/pkg/f.woff2', size: 4, markerB64: 'x' };
+    expect(fontChangedSinceResolved(ref, new Uint8Array([1, 2]))).toBe(true);
+    expect(fontChangedSinceResolved(ref, new Uint8Array(0))).toBe(true);
+  });
+
+  test('a Bun-copied font is never flagged — its size came from the copy, with no source to check', () => {
+    const bytes = new Uint8Array([1, 2, 3, 4]);
+    const ref: FontRef = { path: '/pkg/f.woff2', size: bytes.length, markerB64: 'x', bytes };
+    expect(fontChangedSinceResolved(ref, bytes)).toBe(false);
+    // Even a copy whose bytes disagree with its own recorded size is left to the zero-byte floor, not this check.
+    expect(fontChangedSinceResolved({ ...ref, size: 99 }, bytes)).toBe(false);
+  });
+});
+
 describe('adoptEmittedFontAssets', () => {
   let tmp: string | undefined;
 
@@ -311,23 +341,6 @@ describe('adoptEmittedFontAssets', () => {
     expect(adopted).toEqual([]);
     expect(missing).toEqual([gone]);
     expect(refs).toEqual([]);
-  });
-
-  test('reports a copy that never finished being written instead of serving an empty font', async () => {
-    const file = emit('fraunces-latin-full-italic-7eta9vw9.woff2', new Uint8Array(0));
-    const css = `@font-face { src: url("./${path.basename(file)}") format("woff2"); }`;
-    const refs: FontRef[] = [];
-
-    const { css: out, adopted, missing, unreadable } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
-
-    // Distinct from `missing`: the copy is right there, so reporting it as vanished would send the reader hunting for a
-    // deleted file that exists.
-    expect(unreadable).toEqual([file]);
-    expect(missing).toEqual([]);
-    expect(adopted).toEqual([]);
-    expect(refs).toEqual([]);
-    // The empty hash is what a served-anyway copy would carry, so it must not reach the stylesheet.
-    expect(out).not.toContain(fontContentHash(new Uint8Array(0)));
   });
 
   test('leaves a non-font artifact alone for the caller to serve', async () => {

--- a/packages/mochi/src/compiler/cssFontAssets.test.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.test.ts
@@ -313,23 +313,7 @@ describe('adoptEmittedFontAssets', () => {
     expect(refs).toEqual([]);
   });
 
-  test('waits out a copy another entrypoint is still writing rather than hashing it empty', async () => {
-    const bytes = new Uint8Array([9, 8, 7, 6]);
-    const file = emit('fraunces-latin-full-italic-7eta9vw9.woff2', new Uint8Array(0));
-    const css = `@font-face { src: url("./${path.basename(file)}") format("woff2"); }`;
-    const refs: FontRef[] = [];
-    const writer = setTimeout(() => writeFileSync(file, bytes), 60);
-
-    const { adopted, unreadable } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
-    clearTimeout(writer);
-
-    expect(unreadable).toEqual([]);
-    expect(adopted).toEqual([file]);
-    expect(refs[0]!.bytes).toEqual(bytes);
-    expect(fontAssetFileName(refs[0]!, refs[0]!.bytes!)).toBe(`fraunces-latin-full-italic-${fontContentHash(bytes)}.woff2`);
-  });
-
-  test('reports a copy that never fills in instead of serving an empty font', async () => {
+  test('reports a copy that never finished being written instead of serving an empty font', async () => {
     const file = emit('fraunces-latin-full-italic-7eta9vw9.woff2', new Uint8Array(0));
     const css = `@font-face { src: url("./${path.basename(file)}") format("woff2"); }`;
     const refs: FontRef[] = [];

--- a/packages/mochi/src/compiler/cssFontAssets.test.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.test.ts
@@ -313,6 +313,36 @@ describe('adoptEmittedFontAssets', () => {
     expect(refs).toEqual([]);
   });
 
+  test('waits out a copy another entrypoint is still writing rather than hashing it empty', async () => {
+    const bytes = new Uint8Array([9, 8, 7, 6]);
+    const file = emit('fraunces-latin-full-italic-7eta9vw9.woff2', new Uint8Array(0));
+    const css = `@font-face { src: url("./${path.basename(file)}") format("woff2"); }`;
+    const refs: FontRef[] = [];
+    const writer = setTimeout(() => writeFileSync(file, bytes), 60);
+
+    const { adopted, missing } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
+    clearTimeout(writer);
+
+    expect(missing).toEqual([]);
+    expect(adopted).toEqual([file]);
+    expect(refs[0]!.bytes).toEqual(bytes);
+    expect(fontAssetFileName(refs[0]!, refs[0]!.bytes!)).toBe(`fraunces-latin-full-italic-${fontContentHash(bytes)}.woff2`);
+  });
+
+  test('reports a copy that never fills in instead of serving an empty font', async () => {
+    const file = emit('fraunces-latin-full-italic-7eta9vw9.woff2', new Uint8Array(0));
+    const css = `@font-face { src: url("./${path.basename(file)}") format("woff2"); }`;
+    const refs: FontRef[] = [];
+
+    const { css: out, adopted, missing } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
+
+    expect(missing).toEqual([file]);
+    expect(adopted).toEqual([]);
+    expect(refs).toEqual([]);
+    // The empty hash is what a served-anyway copy would carry, so it must not reach the stylesheet.
+    expect(out).not.toContain(fontContentHash(new Uint8Array(0)));
+  });
+
   test('leaves a non-font artifact alone for the caller to serve', async () => {
     const file = emit('hero-1a2b3c4d.png', new Uint8Array([1, 2, 3]));
     const css = `a { background: url("./${path.basename(file)}"); }`;

--- a/packages/mochi/src/compiler/cssFontAssets.test.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.test.ts
@@ -320,10 +320,10 @@ describe('adoptEmittedFontAssets', () => {
     const refs: FontRef[] = [];
     const writer = setTimeout(() => writeFileSync(file, bytes), 60);
 
-    const { adopted, missing } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
+    const { adopted, unreadable } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
     clearTimeout(writer);
 
-    expect(missing).toEqual([]);
+    expect(unreadable).toEqual([]);
     expect(adopted).toEqual([file]);
     expect(refs[0]!.bytes).toEqual(bytes);
     expect(fontAssetFileName(refs[0]!, refs[0]!.bytes!)).toBe(`fraunces-latin-full-italic-${fontContentHash(bytes)}.woff2`);
@@ -334,9 +334,12 @@ describe('adoptEmittedFontAssets', () => {
     const css = `@font-face { src: url("./${path.basename(file)}") format("woff2"); }`;
     const refs: FontRef[] = [];
 
-    const { css: out, adopted, missing } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
+    const { css: out, adopted, missing, unreadable } = await adoptEmittedFontAssets(css, [{ path: file }], refs);
 
-    expect(missing).toEqual([file]);
+    // Distinct from `missing`: the copy is right there, so reporting it as vanished would send the reader hunting for a
+    // deleted file that exists.
+    expect(unreadable).toEqual([file]);
+    expect(missing).toEqual([]);
     expect(adopted).toEqual([]);
     expect(refs).toEqual([]);
     // The empty hash is what a served-anyway copy would carry, so it must not reach the stylesheet.

--- a/packages/mochi/src/compiler/cssFontAssets.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.ts
@@ -111,9 +111,9 @@ export async function adoptEmittedFontAssets(
       missing.push(artifact.path);
       continue;
     }
-    const bytes = await readSettledBytes(artifact.path, file);
-    // No font is zero bytes, so a copy still empty after the retries never becomes one: adopting it would content-hash
-    // the empty string into the served filename and ship an @font-face pointing at nothing.
+    const bytes = await file.bytes();
+    // No font is zero bytes, so this is a copy that never finished being written. Adopting it would content-hash the
+    // empty string into the served filename and ship an @font-face pointing at nothing.
     if (bytes.length === 0) {
       unreadable.push(artifact.path);
       continue;
@@ -143,18 +143,6 @@ export async function adoptEmittedFontAssets(
     adopted.push(artifact.path);
   }
   return { css: edits.toString(), otherAssets, adopted, missing, unreadable };
-}
-
-// Entrypoints bundle in parallel and a font shared between stylesheets emits the same content-hashed copy from each,
-// so one build can read the path another is mid-rewrite of and see zero bytes — reliably on Windows, which has no
-// atomic replace. Every writer puts identical bytes there, so re-reading converges rather than racing forever.
-async function readSettledBytes(artifactPath: string, file: Bun.BunFile): Promise<Uint8Array> {
-  let bytes = await file.bytes();
-  for (let attempt = 0; bytes.length === 0 && attempt < 50; attempt++) {
-    await Bun.sleep(10);
-    bytes = await Bun.file(artifactPath).bytes();
-  }
-  return bytes;
 }
 
 // Bun prints the emitted asset relative to the stylesheet: `./name.woff2`, `../name.woff2` or bare.

--- a/packages/mochi/src/compiler/cssFontAssets.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.ts
@@ -85,17 +85,18 @@ export function createFontMarkerPlugin(inlineThreshold: number): { plugin: BunPl
  *
  * `adopted` copies are dead but deleted by the caller, since entrypoints sharing a font emit the same content-hashed
  * path and removing it here would ENOENT a concurrent read; `otherAssets` keep the relative URL Bun printed. A copy the
- * bundler wrote and something else removed lands in `missing`, where the caller can report it rather than ship a
- * stylesheet pointing at a file no route serves.
+ * bundler wrote and something else removed lands in `missing`, and one that never filled in lands in `unreadable` —
+ * both let the caller report rather than ship a stylesheet pointing at a file no route serves.
  */
 export async function adoptEmittedFontAssets(
   css: string,
   emitted: { path: string }[],
   refs: FontRef[],
-): Promise<{ css: string; otherAssets: string[]; adopted: string[]; missing: string[] }> {
+): Promise<{ css: string; otherAssets: string[]; adopted: string[]; missing: string[]; unreadable: string[] }> {
   const otherAssets: string[] = [];
   const adopted: string[] = [];
   const missing: string[] = [];
+  const unreadable: string[] = [];
   const refByMarker = new Map(refs.map((r) => [r.markerB64, r]));
   const urls = parseCss(css)?.urls ?? [];
   const edits = new MagicString(css);
@@ -114,7 +115,7 @@ export async function adoptEmittedFontAssets(
     // No font is zero bytes, so a copy still empty after the retries never becomes one: adopting it would content-hash
     // the empty string into the served filename and ship an @font-face pointing at nothing.
     if (bytes.length === 0) {
-      missing.push(artifact.path);
+      unreadable.push(artifact.path);
       continue;
     }
     // A marked font: the file holds the marker text, not the font, so the real bytes come from the ref's source path.
@@ -141,7 +142,7 @@ export async function adoptEmittedFontAssets(
     }
     adopted.push(artifact.path);
   }
-  return { css: edits.toString(), otherAssets, adopted, missing };
+  return { css: edits.toString(), otherAssets, adopted, missing, unreadable };
 }
 
 // Entrypoints bundle in parallel and a font shared between stylesheets emits the same content-hashed copy from each,

--- a/packages/mochi/src/compiler/cssFontAssets.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.ts
@@ -85,18 +85,17 @@ export function createFontMarkerPlugin(inlineThreshold: number): { plugin: BunPl
  *
  * `adopted` copies are dead but deleted by the caller, since entrypoints sharing a font emit the same content-hashed
  * path and removing it here would ENOENT a concurrent read; `otherAssets` keep the relative URL Bun printed. A copy the
- * bundler wrote and something else removed lands in `missing`, and one that never filled in lands in `unreadable` —
- * both let the caller report rather than ship a stylesheet pointing at a file no route serves.
+ * bundler wrote and something else removed lands in `missing`, where the caller reports it rather than ship a
+ * stylesheet pointing at a file no route serves.
  */
 export async function adoptEmittedFontAssets(
   css: string,
   emitted: { path: string }[],
   refs: FontRef[],
-): Promise<{ css: string; otherAssets: string[]; adopted: string[]; missing: string[]; unreadable: string[] }> {
+): Promise<{ css: string; otherAssets: string[]; adopted: string[]; missing: string[] }> {
   const otherAssets: string[] = [];
   const adopted: string[] = [];
   const missing: string[] = [];
-  const unreadable: string[] = [];
   const refByMarker = new Map(refs.map((r) => [r.markerB64, r]));
   const urls = parseCss(css)?.urls ?? [];
   const edits = new MagicString(css);
@@ -112,12 +111,6 @@ export async function adoptEmittedFontAssets(
       continue;
     }
     const bytes = await file.bytes();
-    // No font is zero bytes, so this is a copy that never finished being written. Adopting it would content-hash the
-    // empty string into the served filename and ship an @font-face pointing at nothing.
-    if (bytes.length === 0) {
-      unreadable.push(artifact.path);
-      continue;
-    }
     // A marked font: the file holds the marker text, not the font, so the real bytes come from the ref's source path.
     const marked = bytes.length < 64 ? refByMarker.get(Buffer.from(bytes).toString('base64')) : undefined;
     const markerB64 = marked?.markerB64 ?? markerFor(refs.length).markerB64;
@@ -142,7 +135,7 @@ export async function adoptEmittedFontAssets(
     }
     adopted.push(artifact.path);
   }
-  return { css: edits.toString(), otherAssets, adopted, missing, unreadable };
+  return { css: edits.toString(), otherAssets, adopted, missing };
 }
 
 // Bun prints the emitted asset relative to the stylesheet: `./name.woff2`, `../name.woff2` or bare.
@@ -280,4 +273,14 @@ export function fontAssetFileName(ref: FontRef, bytes: Uint8Array): string {
   const ext = path.extname(ref.path);
   const base = path.basename(ref.path, ext).replace(/[^\w-]/g, '-');
   return `${base}-${fontContentHash(bytes)}${ext}`;
+}
+
+/**
+ * True when a marked font's source read disagrees with the size the bundler statSync'd for it when it resolved the
+ * `url()` — the file changed under the build, so its bytes must not be hashed into an immutable served URL. A
+ * Bun-copied font ({@link FontRef.bytes} set) is its own only copy, so `size` came from it and there is nothing to
+ * check against.
+ */
+export function fontChangedSinceResolved(ref: FontRef, bytes: Uint8Array): boolean {
+  return ref.bytes === undefined && bytes.length !== ref.size;
 }

--- a/packages/mochi/src/compiler/cssFontAssets.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.ts
@@ -110,7 +110,13 @@ export async function adoptEmittedFontAssets(
       missing.push(artifact.path);
       continue;
     }
-    const bytes = await file.bytes();
+    const bytes = await readSettledBytes(artifact.path, file);
+    // No font is zero bytes, so a copy still empty after the retries never becomes one: adopting it would content-hash
+    // the empty string into the served filename and ship an @font-face pointing at nothing.
+    if (bytes.length === 0) {
+      missing.push(artifact.path);
+      continue;
+    }
     // A marked font: the file holds the marker text, not the font, so the real bytes come from the ref's source path.
     const marked = bytes.length < 64 ? refByMarker.get(Buffer.from(bytes).toString('base64')) : undefined;
     const markerB64 = marked?.markerB64 ?? markerFor(refs.length).markerB64;
@@ -136,6 +142,18 @@ export async function adoptEmittedFontAssets(
     adopted.push(artifact.path);
   }
   return { css: edits.toString(), otherAssets, adopted, missing };
+}
+
+// Entrypoints bundle in parallel and a font shared between stylesheets emits the same content-hashed copy from each,
+// so one build can read the path another is mid-rewrite of and see zero bytes — reliably on Windows, which has no
+// atomic replace. Every writer puts identical bytes there, so re-reading converges rather than racing forever.
+async function readSettledBytes(artifactPath: string, file: Bun.BunFile): Promise<Uint8Array> {
+  let bytes = await file.bytes();
+  for (let attempt = 0; bytes.length === 0 && attempt < 50; attempt++) {
+    await Bun.sleep(10);
+    bytes = await Bun.file(artifactPath).bytes();
+  }
+  return bytes;
 }
 
 // Bun prints the emitted asset relative to the stylesheet: `./name.woff2`, `../name.woff2` or bare.

--- a/packages/mochi/src/compiler/cssFontImports.test.ts
+++ b/packages/mochi/src/compiler/cssFontImports.test.ts
@@ -483,8 +483,13 @@ describe('CSS imports — concurrent bundles sharing an emitted asset', () => {
     const filesDir = path.join(tmp, 'files');
     mkdirSync(filesDir);
     cpSync(path.join(fonts, 'fraunces-latin-full-italic.woff2'), path.join(filesDir, 'shared.woff2'));
+    // Over BUN_CSS_COPY_THRESHOLD, or Bun inlines it as a data: URI and never emits the shared copy this covers.
+    writeFileSync(path.join(filesDir, 'shared.png'), Buffer.alloc(200 * 1024, 7));
     const sheet = (name: string): string => {
-      writeFileSync(path.join(tmp, `${name}.css`), `@font-face { font-family: '${name}'; src: url('./files/shared.woff2') format('woff2'); }`);
+      writeFileSync(
+        path.join(tmp, `${name}.css`),
+        `@font-face { font-family: '${name}'; src: url('./files/shared.woff2') format('woff2'); }\n.${name} { background: url('./files/shared.png'); }`,
+      );
       return `./${name}.css`;
     };
     const page = (name: string, imports: string[]): string => {
@@ -494,9 +499,9 @@ describe('CSS imports — concurrent bundles sharing an emitted asset', () => {
     };
 
     registry = new ComponentRegistry({ development: true, outDir: path.join(tmp, 'out'), fonts: { inlineThreshold: Infinity } });
-    // Every stylesheet emits the same content-hashed bundler copy of the font, so one batch's cleanup sweep can delete
-    // what the other is still reading. The window is a few microtasks wide, so this covers the path rather than the
-    // timing — hitting it reliably needs a far slower fixture than belongs in the suite.
+    // Every stylesheet emits the same content-hashed copy of the font and the image, so without the per-build suffix
+    // these are concurrent writers to two shared paths. The window is a few microtasks wide, so this covers the path
+    // rather than the timing — hitting it reliably needs a far slower fixture than belongs in the suite.
     const wide = (half: string): string =>
       page(
         `Page${half}`,
@@ -517,5 +522,18 @@ describe('CSS imports — concurrent bundles sharing an emitted asset', () => {
       expect(css).toContain(fontUrl);
     }
     expect(readFileSync(registry.getFontAsset(fontUrl)!.diskPath).equals(fontBytes)).toBe(true);
+  });
+
+  test('the shared non-font copy lands on one canonical name across every bundle', () => {
+    const sheets = [...registry.getClientFiles().entries()].filter(([u]) => u.includes('/import-css/') && u.endsWith('.css'));
+    const names = new Set(sheets.map(([, css]) => /url\(\.\/([^)"']+\.png)\)/.exec(css)?.[1]));
+
+    // One name, not one per bundle: a per-build suffix surviving into the served name would point each stylesheet at
+    // its own copy of identical bytes, and change that name on every rebuild.
+    expect(names.size).toBe(1);
+    const name = [...names][0]!;
+    expect(name).toMatch(/^shared-[a-z0-9]{8}\.png$/);
+    const asset = registry.getImportedCssAsset(`/_mochi/import-css/${name}`);
+    expect(readFileSync(asset!.diskPath).equals(Buffer.alloc(200 * 1024, 7))).toBe(true);
   });
 });


### PR DESCRIPTION
## What

`adoptEmittedFontAssets` could adopt a zero-byte read of a bundler-emitted font copy as real content, content-hashing the empty string into the served asset name and shipping an `@font-face` that points at a font with no bytes — silently, since the copy counted as `adopted` rather than `missing`.

## Why it happens

Entrypoints bundle in parallel, and a font shared between stylesheets emits the **same** content-hashed copy from every one of them — so they are concurrent writers to a single path. Windows has no atomic replace, so one build can read the copy another is mid-rewrite of and observe zero bytes. `serializeCssBundling` only serializes *across* batches, so it doesn't cover the `Promise.all` inside one.

Empty bytes then fall under the 64-byte marker threshold, no marker matches the empty string, so the copy looks like a font Bun emitted itself and is adopted with `bytes` empty (`cssFontAssets.ts:131-135`). `ComponentRegistry.ts:2045` takes those bytes via `??` — a zero-length array isn't nullish — and `fontAssetFileName` hashes them into the filename.

Reproduced deterministically by handing `adoptEmittedFontAssets` an emitted artifact of zero bytes:

```
whole:  refBytes=149720  servedName=whole-04a14ea3.woff2
shared: refBytes=0       servedName=shared-e3b0c442.woff2
```

`e3b0c442` is the SHA-256 prefix of the empty string.

## The fix

Every writer puts identical bytes at that content-hashed path, so re-reading converges rather than racing. `readSettledBytes` retries a bounded number of times; a copy still empty afterwards goes to the existing `missing` channel, which the caller already reports as a `css-bundle-failed` error rather than serving it.

```
recovered in 90ms: missing=0 adopted=1 servedName=shared-04a14ea3.woff2
```

## How it surfaced

A reproducible red `test-matrix (windows-latest)` on #225, in the CSS-imports suite's `concurrent bundles sharing an emitted asset` case — whose own comment assumed the window was too narrow to hit in practice. It failed twice in a row, with a different bundle losing each time (`wa0`, then `wa1`). `main` is green on the same code, so it takes contention to expose.

## Verification

- Two regression tests in `cssFontAssets.test.ts` — one for the transient case (recovers the real bytes), one for the permanent case (reported, never served). Confirmed by mutation that both fail without the fix.
- `bun run checks` green across every workspace; `mochi-framework` 170/170 test files.
- Does not reproduce on Linux even at full CPU saturation — this is Windows file semantics.