### PR TITLE
fix(public): resolve publicDir to an absolute path at scan time

### DIFF
--- a/packages/mochi/src/runtime/publicDir.test.ts
+++ b/packages/mochi/src/runtime/publicDir.test.ts
@@ -64,6 +64,14 @@ describe('scanPublicDir', () => {
     const files = await scanPublicDir(`${dir}/`);
     expect(files.get('/favicon.ico')).toBe(path.join(dir, 'favicon.ico'));
   });
+
+  test('resolves disk paths to absolute even when given a relative dir', async () => {
+    const relDir = path.relative(process.cwd(), dir);
+    const files = await scanPublicDir(relDir);
+    const diskPath = files.get('/favicon.ico');
+    expect(path.isAbsolute(diskPath!)).toBe(true);
+    expect(diskPath).toBe(path.join(dir, 'favicon.ico'));
+  });
 });
 
 describe('publicRouteKey', () => {

--- a/packages/mochi/src/runtime/publicDir.ts
+++ b/packages/mochi/src/runtime/publicDir.ts
@@ -1,6 +1,6 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { toPosixPath } from '../utils';
+import { toPosixPath, relForDisplay } from '../utils';
 import { logger } from '../utils/log';
 import { applyFilter } from '../extensions';
 import type { BunRouteValue } from '../types';
@@ -79,7 +79,7 @@ export function registerPublicRoutes(routes: Record<string, BunRouteValue>, file
   for (const [urlPath, diskPath] of files) {
     const routeKey = publicRouteKey(urlPath);
     if (routeKey in routes) {
-      logger.warn(`Public file "${diskPath}" skipped: URL "${urlPath}" is already registered as a route.`);
+      logger.warn(`Public file "${relForDisplay(diskPath)}" skipped: URL "${urlPath}" is already registered as a route.`);
       continue;
     }
     routes[routeKey] = Bun.file(diskPath);

--- a/packages/mochi/src/runtime/publicDir.ts
+++ b/packages/mochi/src/runtime/publicDir.ts
@@ -43,6 +43,9 @@ export async function scanPublicDir(dir: string): Promise<Map<string, string>> {
   if (!existsSync(dir)) {
     return new Map();
   }
+  // Pin the base to absolute while cwd is still valid, so `Bun.file()` can't re-resolve a relative disk path against a
+  // later-changed or deleted cwd and turn every static file into a 404.
+  const absDir = path.resolve(dir);
   const result = new Map<string, string>();
   const glob = new Bun.Glob('**/*');
   // Bun.Glob yields backslash separators on Windows, so normalizing first keeps the URL key at `/a/b` and lets
@@ -52,7 +55,7 @@ export async function scanPublicDir(dir: string): Promise<Map<string, string>> {
     if (isExcludedDotPath(rel)) {
       continue;
     }
-    result.set('/' + rel, path.join(dir, rel));
+    result.set('/' + rel, path.join(absDir, rel));
   }
   return result;
 }


### PR DESCRIPTION
## Summary

Mochi registers static files with a **relative** disk path. `registerPublicRoutes()` does `routes[key] = Bun.file(diskPath)`, and because `diskPath` is relative (default `publicDir` is `'./public'`), `Bun.file()` re-resolves it against `process.cwd()` **on every request** — not at registration time.

This makes static serving fragile: if the process's working directory changes or is deleted after startup, every static file 404s while SSR pages and dynamic routes (loaded modules that don't touch cwd) keep working — so the failure looks like "only static files are broken."

### Repro (observed in the wild)

Two `bunx codebay@latest` instances sharing one bunx cache dir:
1. Instance A boots, `chdir`s into `.../node_modules/codebay`, registers `Bun.file('public/sounds/done.wav')`.
2. Instance B reinstalls `codebay` into the same cache, so bun renames A's package dir out from under it and deletes it.
3. A's cwd now points at a deleted directory → relative `Bun.file('public/...')` 404s for **every** static file.

The shared cache is only the trigger; the root cause is that relative disk paths assume the startup cwd survives for the life of the server.

## Fix

Resolve the directory to absolute once, at scan time (while cwd is still valid), in `scanPublicDir()`:

```ts
const absDir = path.resolve(dir);
...
result.set('/' + rel, path.join(absDir, rel));
```

- URL keys stay relative (`'/' + rel`); only the disk **value** becomes absolute.
- All three consumers funnel through `scanPublicDir`, so one edit covers them: the startup scan (`Mochi.ts`), the dev-watcher re-scan (`devWatcher.ts`), and the build-time collision check (`cli/build.ts`).
- Fixes the whole class of bug for every Mochi app, not just this deployment.

## Tests

Added a regression test in `publicDir.test.ts` asserting that a **relative** `dir` still yields **absolute** disk values. Existing assertions (already using an absolute temp dir) are unaffected.

`bun run checks` passes cleanly across all workspaces (lint, format, typecheck, 170/170 test files in mochi-framework).