### PR TITLE
chore(support): add HEALTHCHECK to Dockerfile.production

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -180,7 +180,7 @@ colima start            # only if `colima status` says not running
 docker build ...
 ```
 
-Build targets default to `WORKSPACE=site` (override `--build-arg WORKSPACE=demos`): `Dockerfile` = dev-mode image (the variant deployed for site + demos, site ≈ 423 MB); `Dockerfile.production` = prebuilt SSR + `--omit=dev` (site ≈ 294 MB), used to deploy `packages/support` and by `docker-shell.sh` for `minimal`. `.github/workflows/build.yml` picks between them per matrix leg via a `dockerfile` field. Note `Dockerfile.production` carries no `HEALTHCHECK` on purpose — it's shared with `minimal`, which has no `/health` route. A bad cached `install` layer can fail a prod build with a misleading `Could not read .../index.ts` parse error — a `--no-cache` rebuild fixes it; reproduce in a clean container before blaming source.
+Build targets default to `WORKSPACE=site` (override `--build-arg WORKSPACE=demos`): `Dockerfile` = dev-mode image (the variant deployed for site + demos, site ≈ 423 MB); `Dockerfile.production` = prebuilt SSR + `--omit=dev` (site ≈ 294 MB), used to deploy `packages/support` and by `docker-shell.sh` for `minimal`. `.github/workflows/build.yml` picks between them per matrix leg via a `dockerfile` field. Both `Dockerfile` and `Dockerfile.production` carry a `HEALTHCHECK` that probes the canonical `/health/`; every workspace built from either — site, demos, support, and `minimal` — serves a `/health` route so the probe passes. A bad cached `install` layer can fail a prod build with a misleading `Could not read .../index.ts` parse error — a `--no-cache` rebuild fixes it; reproduce in a clean container before blaming source.
 
 ## Hydration notes
 

--- a/Dockerfile.production
+++ b/Dockerfile.production
@@ -106,4 +106,12 @@ RUN mkdir -p /data/image-cache && chown -R bun:bun /data
 
 USER bun
 EXPOSE ${PORT}/tcp
+
+# No curl/wget in the alpine base; bun is on PATH, so probe with fetch. Reads
+# PORT from the env above and hits the canonical /health/ (trailingSlash:'always'
+# would otherwise 308 a bare /health) so the redirect hop never happens. Every
+# workspace built from this file serves /health — site, demos, support, minimal.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+  CMD bun --eval "fetch('http://127.0.0.1:'+process.env.PORT+'/health/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
 ENTRYPOINT [ "sh", "-c", "exec bun --cwd=packages/$WORKSPACE run start" ]

--- a/packages/minimal/src/index.isolated.test.ts
+++ b/packages/minimal/src/index.isolated.test.ts
@@ -6,6 +6,7 @@ import { Mochi } from 'mochi-framework';
 
 const routes = {
   '/': Mochi.page('./src/HelloWorld.svelte'),
+  '/health': Mochi.api(() => Response.json({ status: 'ok' })),
 };
 
 describe('minimal app', () => {
@@ -38,5 +39,11 @@ describe('minimal app', () => {
     const res = await fetch(base);
     expect(res.status).toBe(200);
     expect(await res.text()).toContain('Hello Mochi!');
+  });
+
+  test('GET /health reports ok', async () => {
+    const res = await fetch(`${base}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
   });
 });

--- a/packages/minimal/src/index.ts
+++ b/packages/minimal/src/index.ts
@@ -12,6 +12,7 @@ await Mochi.serve({
   },
   routes: {
     '/': Mochi.page('./src/HelloWorld.svelte'),
+    '/health': Mochi.api(() => Response.json({ status: 'ok' })),
   },
 });
 


### PR DESCRIPTION
## What

Adds a Docker `HEALTHCHECK` to `Dockerfile.production` so the **support** container reports a health status.

## Why

The support container (`ghcr.io/khromov/mochi-support`) was showing no health state (`Up`, not `Up (healthy)`), unlike site and demos which run on the dev-mode `Dockerfile` and already have a healthcheck. `Dockerfile.production` deliberately had no `HEALTHCHECK` because it's shared with `minimal`, which had no `/health` route.

## Changes

- **`Dockerfile.production`**: add the same fetch-based probe the dev `Dockerfile` uses, hitting the canonical `/health/` (avoids the `trailingSlash: 'always'` 308 hop). Support already serves `/health`.
- **`packages/minimal`**: add a `'/health'` route (and a test asserting `GET /health` → `{ status: 'ok' }`) so every workspace built from `Dockerfile.production` — site, demos, support, and minimal — passes the probe. This also flows into the `create-mochi` template.
- **`CLAUDE.md`**: update the note that documented the (now-removed) 'no healthcheck' constraint.

## Verification

`bun run checks` passes across all workspaces, including the new `mochi-minimal` `/health` test.