### PR TITLE
chore(memtest): hard-fail on stale code instead of running it

### DIFF
--- a/memtest/loop.sh
+++ b/memtest/loop.sh
@@ -13,7 +13,9 @@
 # Override the 24h window with CYCLE_SECONDS for a quick end-to-end test.
 #
 # No `set -e`: the loop must outlive a failed pull/build/run, so fallible
-# commands are guarded individually instead of aborting the supervisor.
+# commands are guarded individually instead of aborting the supervisor. The one
+# deliberate abort is stale code (non-ff divergence / dirty tree) — it exits
+# $FATAL_STALE so systemd stops in `failed` rather than exercising old code.
 set -uo pipefail
 
 cd "$(dirname "$0")/.."
@@ -24,6 +26,7 @@ FAIL_BACKOFF_SECONDS="${FAIL_BACKOFF_SECONDS:-3600}" # retry sooner than a full 
 CONTAINER="${CONTAINER:-mochi-memtest}"          # names below are the ones run.sh reads
 SNAPSHOT_DIR="${SNAPSHOT_DIR:-$PWD/snapshots}"
 PORT="${PORT:-3333}"
+FATAL_STALE=78                                    # sysexits EX_CONFIG: can't reach origin/$BRANCH; fail loud instead of running stale (unit pairs this with RestartPreventExitStatus)
 
 log() { echo "[$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)] $*"; }
 
@@ -46,17 +49,17 @@ pull_and_maybe_reexec() {
 
   if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
     if [ "${MEMTEST_LOOP_RESET:-0}" != "1" ]; then
-      log "working tree dirty — skipping pull (set MEMTEST_LOOP_RESET=1 to hard-reset)"
-      return 0
+      log "FATAL: working tree dirty — refusing to run possibly-stale code; clean the tree or set MEMTEST_LOOP_RESET=1 to auto-hard-reset, then restart"
+      exit "$FATAL_STALE"
     fi
     log "working tree dirty — MEMTEST_LOOP_RESET=1, hard-resetting to origin/$BRANCH"
     if ! git reset --hard "origin/$BRANCH"; then
-      log "reset failed — running current checkout, will retry next cycle"
-      return 0
+      log "FATAL: hard-reset to origin/$BRANCH failed — refusing to run stale code; reconcile manually, then restart"
+      exit "$FATAL_STALE"
     fi
   elif ! git merge --ff-only --quiet "origin/$BRANCH"; then
-    log "ff-only merge failed (non-ff) — running current checkout, will retry next cycle"
-    return 0
+    log "FATAL: local $BRANCH diverged from origin/$BRANCH (non-ff) — refusing to run stale code; reconcile (e.g. git reset --hard origin/$BRANCH), then restart"
+    exit "$FATAL_STALE"
   fi
   after="$(git rev-parse HEAD)"
 

--- a/memtest/mochi-memtest-loop.service
+++ b/memtest/mochi-memtest-loop.service
@@ -17,6 +17,9 @@ WorkingDirectory=/home/k/mochi
 ExecStart=/home/k/mochi/memtest/loop.sh
 Restart=always
 RestartSec=30
+# loop.sh exits 78 when it detects stale code (non-ff divergence / dirty tree); do
+# not auto-restart that — land in `failed` so a human reconciles the branch first.
+RestartPreventExitStatus=78
 # Give loop.sh's SIGTERM trap room to `docker stop` the container before the kill.
 TimeoutStopSec=30
 KillSignal=SIGTERM


### PR DESCRIPTION
## Problem

`memtest/loop.sh` is a self-updating supervisor: each cycle it fetches `origin/main`, fast-forwards, rebuilds, and runs the harness. But whenever it *couldn't* advance to `origin/main` it fell back to **running the current checkout anyway** and only logged a line — so the memtest box could silently exercise stale code forever.

This actually happened: after a history rewrite the box ended up **70 behind / 11 ahead** (non-ff divergence), and every cycle hit `ff-only merge failed (non-ff) — running current checkout` and kept running month-old code. The whole point of the box is to exercise *fresh* code, so a silent fallback defeats it.

## Change

Make the "can't reach `origin/main`" conditions **fatal** instead of silently stale:

- **Non-ff divergence** and **dirty working tree** (without `MEMTEST_LOOP_RESET=1`) now log `FATAL …` and `exit 78` (sysexits `EX_CONFIG`).
- The unit adds `RestartPreventExitStatus=78`, so systemd lands the service in **`failed`** and waits for a human to reconcile the branch — rather than crash-looping every 30s (the divergence can't self-heal without intervention anyway).

Deliberately **unchanged**:

- **Transient `git fetch` failures** still log and retry next cycle — a network blip shouldn't take the box down.
- **`MEMTEST_LOOP_RESET=1`** still auto-heals a dirty tree by hard-resetting to `origin/main`.
- Clean `SIGTERM` shutdown (exit 0) and normal build/run failures (`Restart=always` + backoff) are untouched.

## Deploying to the box

The live unit at `/etc/systemd/system/` is separate from the repo copy, so after merge, on the box:

```sh
sudo cp memtest/mochi-memtest-loop.service /etc/systemd/system/
sudo systemctl daemon-reload
```

`loop.sh` itself is picked up automatically — the loop re-execs when `memtest/loop.sh` changes on `origin/main`.

## Testing

- `bash -n memtest/loop.sh` passes.
- Not covered by `bun run checks` (shell + systemd unit, no shell linter in the gate).
