### PR TITLE
feat(cache): add MochiCache.whenIdle()

### DIFF
--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -69,10 +69,31 @@ Use it from a page or API route:
 | `markStale(key)`           | `Promise<void>`                      |
 | `delete(key)`              | `Promise<void>`                      |
 | `clearItems()`             | `Promise<void>`                      |
+| `whenIdle()`               | `Promise<void>`                      |
 
 `peek(key)` reports a key's `status` and value **without** running `fn`, revalidating, or emitting `cache:read` — a pure probe that returns `null` on a miss. `markStale(key)` backdates an entry so its next read serves stale-while-revalidate. It is a no-op on a missing or already-stale key, and it never freshens or un-expires one. Both run through the `storage` interface, so they apply to any backend. `set(key, value)` writes a value directly, stamped fresh. Prefer `set` over `delete(key)` then `fetch`: that sequence leaves the key absent, so concurrent readers each start their own recompute.
 
 `status` is `'fresh' | 'stale' | 'expired' | 'miss'`.
+
+#### Waiting for background revalidations
+
+<VersionNote since="0.10.0" message="whenIdle() was added in 0.10.0." />
+
+A stale read returns at once and refreshes in the background, so the new value is not readable when `fetch` resolves. `whenIdle()` waits for those background runs to finish — including the storage write, not just the upstream call — which is what you want before shutting down, or in a test that asserts on the refreshed value.
+
+```ts
+const stale = await cache.fetchWithStatus('users', loadUsers); // 'stale', old value
+await cache.whenIdle();
+const fresh = await cache.fetchWithStatus('users', loadUsers); // 'fresh', new value
+```
+
+<Callout type="warning">
+
+`whenIdle()` waits for whatever is in flight, so on a busy cache it keeps waiting as new revalidations start. Treat it as a shutdown or test primitive — don't await it on a request path.
+
+</Callout>
+
+A run that throws settles it like any other, so a failing upstream can't leave it hanging. `ImageCache` exposes the same method for its own regenerations.
 
 ### Options
 

--- a/packages/mochi/src/cache/cache.test.ts
+++ b/packages/mochi/src/cache/cache.test.ts
@@ -461,6 +461,70 @@ describe('MochiCache stale-while-revalidate', () => {
   });
 });
 
+describe('MochiCache.whenIdle', () => {
+  test('resolves immediately when nothing is in flight', async () => {
+    const cache = new MochiCache({ minTimeToStale: 10, maxTimeToLive: 5_000 });
+    await cache.fetch('k', () => 1);
+    await cache.whenIdle();
+    expect(await cache.fetch('k', () => 2)).toBe(1);
+  });
+
+  test('waits for a background revalidation to finish, write included', async () => {
+    const writes: string[] = [];
+    const store = new Map<string, unknown>();
+    const storage: Storage = {
+      getItem: (key) => store.get(key) ?? null,
+      // The write is the last thing a run does, so a whenIdle() that returned
+      // early would let the assertion below observe the pre-refresh value.
+      setItem: async (key, value) => {
+        await wait(30);
+        store.set(key, value);
+        writes.push(key);
+      },
+      removeItem: (key) => void store.delete(key),
+      clear: () => void store.clear(),
+    };
+    const cache = new MochiCache({ minTimeToStale: 10, maxTimeToLive: 5_000, storage });
+
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      await wait(20);
+      return calls;
+    };
+
+    expect(await cache.fetch('k', fn)).toBe(1);
+    await wait(30); // now stale
+
+    const stale = await cache.fetchWithStatus('k', fn);
+    expect(stale.status).toBe('stale');
+    expect(stale.value).toBe(1); // background refresh still running
+
+    await cache.whenIdle();
+    expect(writes).toContain('k');
+    expect((await cache.fetchWithStatus('k', fn)).value).toBe(2);
+  });
+
+  test('a failed background revalidation still settles it', async () => {
+    const cache = new MochiCache({ minTimeToStale: 10, maxTimeToLive: 5_000 });
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      if (calls > 1) {
+        throw new Error('upstream down');
+      }
+      return 1;
+    };
+
+    expect(await cache.fetch('k', fn)).toBe(1);
+    await wait(30);
+    expect((await cache.fetchWithStatus('k', fn)).status).toBe('stale');
+
+    await cache.whenIdle(); // must not hang or reject on the rejected run
+    expect(calls).toBe(2);
+  });
+});
+
 describe('MochiCache config validation', () => {
   test('throws when minTimeToStale is not less than maxTimeToLive', () => {
     expect(() => new MochiCache({ minTimeToStale: 5_000, maxTimeToLive: 5_000 })).toThrow(/must be less than/);

--- a/packages/mochi/src/cache/cache.ts
+++ b/packages/mochi/src/cache/cache.ts
@@ -241,6 +241,22 @@ export class MochiCache {
     }
   }
 
+  /**
+   * Resolves once every compute this cache is currently running has settled, including the fire-and-forget background
+   * revalidations a stale read starts. A run is tracked from before its `fn` is invoked until after its storage write,
+   * so an awaited `whenIdle()` guarantees the refreshed value is readable — unlike waiting on `cache:revalidate`, which
+   * only marks the start.
+   *
+   * Each pass also picks up work a settling run started, so this drains a chain of revalidations rather than one level.
+   * It waits for whatever is in flight: under continuous writes it keeps waiting, so treat it as a shutdown/quiescence
+   * primitive rather than something to await on a hot request path. A failed run settles it like any other.
+   */
+  async whenIdle(): Promise<void> {
+    while (this.inflight.size > 0) {
+      await Promise.allSettled([...this.inflight.values()]);
+    }
+  }
+
   async clearItems(): Promise<void> {
     // Drop in-flight runs first so a pending revalidation can't repopulate a key
     // after the storage is cleared.

--- a/packages/mochi/src/image/imageCache.test.ts
+++ b/packages/mochi/src/image/imageCache.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { Storage } from '../cache/cache';
-import { MemoryStorage } from '../cache/cache-storage';
+import { FileStorage, MemoryStorage } from '../cache/cache-storage';
 import { mochiEvents } from '../events';
 import type { MochiImageDeleteEvent, MochiImageStoreEvent } from '../events';
 import { ImageCache, originalId, variantId, type ImageCacheOptions, type RegenResult } from './imageCache';
@@ -42,16 +42,21 @@ function makeCache(overrides: Partial<ImageCacheOptions> = {}): ImageCache {
 const SRC = 'https://example.com/a.png';
 const ID = variantId(SRC, CFG);
 
-// Wait for a fire-and-forget background revalidation to land. A fixed `Bun.sleep`
-// flakes when the regen's disk write is slower than the wait (Windows CI), so poll
-// the observable effect until it holds or a generous deadline passes. The predicate
-// may be async so callers can drive convergence from within it (a variant only
-// re-regenerates when it is read).
-async function settle(predicate: () => boolean | Promise<boolean>, timeoutMs = 2_000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (!(await predicate()) && Date.now() < deadline) {
-    await Bun.sleep(5);
+// Drive a fire-and-forget background revalidation to completion. Waiting on `whenIdle()` rather than a wall clock is
+// what keeps this off a slow disk's timing: the earlier poll-until-deadline version failed on Windows CI once two
+// chained regen writes outlasted its budget. `MAX_HOPS` bounds convergence in hops of real work, not milliseconds —
+// a variant only re-regenerates when it is read, so each pass drains pending work and then re-reads.
+const MAX_HOPS = 6;
+async function settle(cache: ImageCache, predicate: () => boolean | Promise<boolean>): Promise<void> {
+  for (let hop = 0; hop < MAX_HOPS; hop++) {
+    await cache.whenIdle();
+    if (await predicate()) {
+      return;
+    }
   }
+  // Reporting the exhaustion here keeps a non-convergence from surfacing as a
+  // baffling value mismatch on the caller's next assertion.
+  throw new Error(`settle: predicate never held within ${MAX_HOPS} regen hops`);
 }
 
 function origFn(bytes: number[], contentType = 'image/jpeg', counter?: { n: number }) {
@@ -102,7 +107,7 @@ describe('ImageCache.getOriginal', () => {
     expect(stale.status).toBe('stale');
     expect(Array.from(stale.entry.bytes)).toEqual([1]); // old bytes served immediately
 
-    await settle(() => counter.n === 2);
+    await settle(cache, () => counter.n === 2);
     expect(counter.n).toBe(2); // revalidated in the background
   });
 
@@ -190,7 +195,7 @@ describe('ImageCache.getVariant (generation-stamped)', () => {
     expect(stale.status).toBe('stale');
     expect(Array.from(stale.entry.bytes)).toEqual([1]); // old bytes served immediately
 
-    await settle(() => counter.n === 2);
+    await settle(cache, () => counter.n === 2);
     expect(counter.n).toBe(2); // variant regenerated in the background
   });
 
@@ -231,11 +236,10 @@ describe('ImageCache.getVariant (generation-stamped)', () => {
 
     // Converges once the original's background refresh lands: the generation
     // mismatch forces one more regen against the new bytes — the variant must not
-    // stay pinned to [10] as fresh. Each read is what drives the regen, so poll by
-    // re-reading, bounded by a deadline rather than a fixed request count (a
-    // Windows regen write can outlast any fixed budget).
+    // stay pinned to [10] as fresh. Each read is what drives the next regen, so
+    // re-read between hops.
     let bytes: number[] = [];
-    await settle(async () => {
+    await settle(cache, async () => {
       const read = await cache.getVariant(SRC, ID, transform());
       bytes = Array.from(read.entry.bytes);
       return bytes[0] === 20;
@@ -360,7 +364,7 @@ describe('ImageCache.getPlaceholder', () => {
     await cache.invalidateOriginal(SRC, false);
     await cache.getOriginal(SRC, fetchFn); // serves stale, kicks the refresh
     let refreshed = orig.entry.meta.createdAt;
-    await settle(async () => {
+    await settle(cache, async () => {
       refreshed = (await cache.getOriginal(SRC, fetchFn)).entry.meta.createdAt;
       return refreshed !== orig.entry.meta.createdAt;
     });
@@ -582,5 +586,50 @@ describe('ImageCache custom storage', () => {
     // This used to report the original as a *variant*; unattributed is the honest answer.
     const swept = await cache.sweep(Date.now() + 1_000_000);
     expect(swept).toEqual({ removedVariants: 0, removedOriginals: 0, removedOther: 1 });
+  });
+});
+
+describe('convergence does not depend on how fast the disk is', () => {
+  // Regression guard for a Windows CI failure: this scenario converges over two chained background writes (the
+  // original's refresh, then the variant's regen against it), and the test used to poll for the result on a 2s wall
+  // clock. A slow enough disk outran that budget and the variant read back as its pre-refresh generation. Taxing only
+  // `setItem` reproduces exactly that pressure — at 400ms per write the old deadline expired, so a revert to any
+  // clock-based wait fails here rather than months later on a loaded runner.
+  function slowWrites(inner: Storage, ms: number): Storage {
+    return {
+      getItem: (key) => inner.getItem(key),
+      setItem: async (key, value) => {
+        await Bun.sleep(ms);
+        return inner.setItem(key, value);
+      },
+      removeItem: (key) => inner.removeItem(key),
+      clear: () => inner.clear(),
+    };
+  }
+
+  test('a soft invalidation still propagates when every write is slow', async () => {
+    const dir = tmp();
+    const cache = makeCache({ storage: slowWrites(new FileStorage({ directory: dir }), 400) });
+
+    let upstream = [1];
+    const fetchFn = async () => ({ bytes: new Uint8Array(upstream), contentType: 'image/jpeg' });
+    const transform = (): (() => Promise<RegenResult>) => async () => {
+      const { entry } = await cache.getOriginal(SRC, fetchFn);
+      return { bytes: new Uint8Array([entry.bytes[0]! * 10]), contentType: 'image/webp', width: 100, height: 100, format: 'webp', originalCreatedAt: entry.meta.createdAt };
+    };
+
+    await cache.getOriginal(SRC, fetchFn);
+    expect(Array.from((await cache.getVariant(SRC, ID, transform())).entry.bytes)).toEqual([10]);
+
+    upstream = [2];
+    await cache.invalidateOriginal(SRC, false);
+    expect((await cache.getVariant(SRC, ID, transform())).status).toBe('stale');
+
+    let bytes: number[] = [];
+    await settle(cache, async () => {
+      bytes = Array.from((await cache.getVariant(SRC, ID, transform())).entry.bytes);
+      return bytes[0] === 20;
+    });
+    expect(bytes).toEqual([20]);
   });
 });

--- a/packages/mochi/src/image/imageCache.ts
+++ b/packages/mochi/src/image/imageCache.ts
@@ -345,6 +345,11 @@ export class ImageCache {
     await this.cache.clearItems();
   }
 
+  /** Resolves once in-flight regenerations — including the background ones a stale read starts — have settled. See {@link MochiCache.whenIdle}. */
+  async whenIdle(): Promise<void> {
+    await this.cache.whenIdle();
+  }
+
   /** Entries currently cached — originals, variants, placeholders, and transient in-flight markers — as a rough size indicator for the dev debug bar. `0` when the backend can't count. */
   async count(): Promise<number> {
     return (await this.storage.count?.()) ?? 0;


### PR DESCRIPTION
## Why

A stale read serves its in-hand value and refreshes in the background, so the refreshed value isn't readable when `fetch()` resolves. There was no way to wait for that — `cache:revalidate` fires when a refresh *starts*, not when it lands.

`imageCache.test.ts` needed exactly that wait and approximated it with a wall clock, which failed the Windows CI leg:

```
- 20,
+ 10,
   at packages/mochi/src/image/imageCache.test.ts:243
```

That scenario converges over **two chained background writes** — the original's refresh, then the variant's regen against the new generation — and the poll gave both a flat 2000ms. Reproduced with no Windows involved, by wrapping the real `FileStorage` to tax storage latency:

| storage latency | old wall-clock poll (2s) | `whenIdle()` |
| --- | --- | --- |
| 5 ms | `[20]` in 77 ms | `[20]` in 24 ms |
| 150 ms | `[20]` in 1816 ms — 184 ms of margin left | `[20]` in 751 ms |
| 400 ms | **`[10]` — fails** | `[20]` in 3204 ms |

The 150ms row is the real finding: the test was already running within ~9% of its budget at moderate latency. Not a rare flake — a test on a cliff edge.

## What

**`MochiCache.whenIdle()`** drains in-flight computes. The cache already tracked the right signal: a run is registered before its `fn` is invoked and cleared in a `finally` *after* its storage write, so an awaited `whenIdle()` guarantees the refreshed value is readable. Each pass also picks up work a settling run started, so it drains a chain rather than one level. A rejected run settles it like any other. `ImageCache.whenIdle()` delegates to it.

`settle()` in the image test now advances in **hops of real work** instead of milliseconds, and throws on exhaustion rather than letting a non-convergence resurface as a value mismatch on the next assertion.

## Verification

Mutation-tested both directions rather than trusting green:

- Stubbing `whenIdle()` to a no-op fails the new `waits for a background revalidation to finish, write included` test **and** the image guard.
- Reverting `settle()` to the old 2s wall clock fails the new guard with exactly the CI diff (`-20 / +10`).

New tests: three for `whenIdle()` directly (no-op when idle; waits through the storage write; a *rejected* run still settles it rather than hanging), plus a regression guard running the real scenario against `FileStorage` wrapped so every `setItem` takes 400ms — the latency at which the old code provably fails. It costs ~4.8s, in a file whose existing tests already take 3.8–8.9s on CI.

`bun run checks` green: 170/170 framework, 12/12 site, 2/2 support.

## Not covered

`setPlaceholder > a rewrite never leaves the key absent` is also red on `main`'s canary-Windows leg. Despite living in the same file it's a different shape — a spin-loop reader racing 20 sequential writes, asserting the replace is atomic — and `whenIdle()` does not address it. Worth investigating separately, and worth *not* assuming it's flake: a non-atomic replace-over-open-file would be a genuine Windows bug rather than timing noise.
