### PR TITLE
perf: skip request-invariant post-render scans on island-free pages

### DIFF
--- a/packages/docs/145-cache.md
+++ b/packages/docs/145-cache.md
@@ -52,6 +52,33 @@ Use it from a page or API route:
 
 </Callout>
 
+### Caching expensive serverProps
+
+A page's latency is usually dominated by its data loading, not the render — so `serverProps` resolvers are the highest-leverage place to cache. Construct a `MochiCache` at module scope and wrap the slow call in `fetch()`, keyed per route params:
+
+```ts
+// file: src/index.ts
+import { Mochi, MochiCache } from 'mochi-framework';
+import { loadPokemon } from './lib/pokemon';
+
+const pokemonCache = new MochiCache({
+  minTimeToStale: 10_000, // serve fresh for 10s
+  maxTimeToLive: 300_000, // hard expiry at 5min
+});
+
+await Mochi.serve({
+  routes: {
+    '/pokemon/:id': Mochi.page('./src/Pokemon.svelte', {
+      serverProps: async (_req, params) => ({
+        pokemon: await pokemonCache.fetch(`pokemon:${params.id}`, () => loadPokemon(params.id)),
+      }),
+    }),
+  },
+});
+```
+
+The first request per key pays the load; later requests follow the fresh / stale / expired lifecycle below. Everything that shapes the result must be in the key — route params as above, plus any cookie- or locals-derived dimension per the warning above.
+
 ### Behavior
 
 - **Fresh** (within `minTimeToStale`): cached value returned, no fetch.

--- a/packages/docs/40-defining-routes.md
+++ b/packages/docs/40-defining-routes.md
@@ -85,6 +85,8 @@ await Mochi.serve({
 });
 ```
 
+For a resolver that hits a slow upstream, wrap the load in a shared cache — see [Caching expensive serverProps](/docs/cache/).
+
 `actions` is a `MochiFormActions` map that handles POST submissions to the route.
 
 <Callout type="warning">

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -1542,27 +1542,30 @@ export class ComponentRegistry {
 
     let output = body;
 
-    output = output.replace(/__MOCHI_COMPONENT_URL__(\w+)__/g, (_, name: string) => this.componentEntryUrls.get(name) ?? '');
-
     // Track which islands are lazy (have CSS_URL placeholders) during replacement
     const lazyIslandPaths = new Set<string>();
-    output = output.replace(/__MOCHI_CSS_URL__(\w+)__/g, (_, name: string) => {
-      const h = hydratablesByName.get(name);
-      if (h) {
-        lazyIslandPaths.add(h.resolvedPath);
-        return this.cssFileUrls.get(h.resolvedPath) ?? '';
-      }
-      return '';
-    });
-
     let hasServerCssPlaceholders = false;
-    output = output.replace(/__MOCHI_SERVER_CSS_URL__(\w+)__/g, (_, name: string) => {
-      hasServerCssPlaceholders = true;
-      const resolvedPath = this.serverIslandPaths.get(name);
-      return resolvedPath ? (this.cssFileUrls.get(resolvedPath) ?? '') : '';
-    });
+    // Placeholders only exist in island wrapper attributes, so one probe spares island-free pages four full-body scans.
+    if (output.includes('__MOCHI_')) {
+      output = output.replace(/__MOCHI_COMPONENT_URL__(\w+)__/g, (_, name: string) => this.componentEntryUrls.get(name) ?? '');
 
-    output = output.replaceAll('__MOCHI_ASSET_PREFIX__', this.assetPrefix);
+      output = output.replace(/__MOCHI_CSS_URL__(\w+)__/g, (_, name: string) => {
+        const h = hydratablesByName.get(name);
+        if (h) {
+          lazyIslandPaths.add(h.resolvedPath);
+          return this.cssFileUrls.get(h.resolvedPath) ?? '';
+        }
+        return '';
+      });
+
+      output = output.replace(/__MOCHI_SERVER_CSS_URL__(\w+)__/g, (_, name: string) => {
+        hasServerCssPlaceholders = true;
+        const resolvedPath = this.serverIslandPaths.get(name);
+        return resolvedPath ? (this.cssFileUrls.get(resolvedPath) ?? '') : '';
+      });
+
+      output = output.replaceAll('__MOCHI_ASSET_PREFIX__', this.assetPrefix);
+    }
 
     const shouldStrip = opts?.stripMarkers !== false && hydratables.length === 0;
     const hasIslandsOrServerIslands = hydratables.length > 0 || hasServerCssPlaceholders;
@@ -1737,10 +1740,9 @@ export class ComponentRegistry {
       }
     }
 
-    // Always collapse the doubled-marker pattern (Svelte SSR bug for
-    // `$state` arrays + `{@attach}`). Strictly matched open+close so it only
-    // fires on the actual bug; no-op otherwise.
-    const normalized = normalizeIslandHydrationMarkers(output);
+    // Collapse the doubled-marker Svelte SSR bug (`$state` arrays + `{@attach}`); only island wrappers can carry it,
+    // so island-free renders skip the scan.
+    const normalized = hydratables.length > 0 ? normalizeIslandHydrationMarkers(output) : output;
     const headStr = head ?? '';
     return {
       body: normalized,


### PR DESCRIPTION
Ships the low-risk recommendations of the SSR-caching viability evaluation. Two commits:

### 1. \`perf:\` gate request-invariant post-render scans (framework)
In \`renderComponent\`:
- The four \`__MOCHI_*\` placeholder replaces only ever match island wrapper attributes, so island-free pages paid four full-body scans per request for nothing — now gated behind a single \`output.includes('__MOCHI_')\` probe.
- \`normalizeIslandHydrationMarkers\` is skipped when the render has no hydratable islands (only their wrappers can carry the doubled-marker pattern).

Both are byte-identical by construction: a missed probe means zero matches, and the side-computed \`hasServerCssPlaceholders\` stays correct. Island pages are unaffected.

### 2. \`docs:\` caching expensive serverProps
New section on the cache page showing the \`cache.fetch()\`-in-\`serverProps\` pattern (data loading dominates page latency — measured at ~90% on the site's own pages), plus a pointer from the defining-routes page.

## Verification
- \`bun run checks\` green across all workspaces.
- The evaluation's whole-site byte-diff crawl (135 pages) validated these gates as part of the larger candidate patch; the gates are the zero-risk subset of it.

## Not in this PR (evaluated, deliberately deferred)
- **Regex fast-path marker stripping** (\`stripHydrationMarkersFast\`, ~24× faster than the HTMLRewriter strip on island-free pages, −67–78% \`renderComponent\`) — pulled at review; the HTMLRewriter path stays.
- **Site-level static-page byte cache** (cached hits 0.07–0.11ms vs 6–17ms) — to be solved separately.
- Evaluation artifacts (benchmarks, spikes, report) live uncommitted under \`packages/mochi/scripts/bench/\`.