### PR TITLE
fix(mochi): stop a Windows rename livelock in the image cache

### DIFF
--- a/packages/mochi/src/cache/cache-storage.ts
+++ b/packages/mochi/src/cache/cache-storage.ts
@@ -203,6 +203,10 @@ async function renameWithRetry(from: string, to: string): Promise<void> {
   // Ramp to a 100ms poll and keep retrying for a few seconds: under heavy write
   // contention a peer's handle on the destination can linger longer than a short
   // window, and a rename that ultimately succeeds beats a spurious hard failure.
+  // The delay is jittered because a steady cadence can phase-lock with a reader that
+  // reopens the destination on its own steady cycle — every retry then lands inside the
+  // reader's open window and the writer starves until the budget runs out. Jitter keeps
+  // the mean backoff but decorrelates the two, so a retry eventually falls in the gap.
   for (let attempt = 0; ; attempt++) {
     try {
       return await rename(from, to);
@@ -211,7 +215,7 @@ async function renameWithRetry(from: string, to: string): Promise<void> {
       if (attempt >= 50 || !RENAME_RETRY_CODES.has(code)) {
         throw err;
       }
-      await Bun.sleep(Math.min(100, 10 * (attempt + 1)));
+      await Bun.sleep(Math.min(100, 10 * (attempt + 1)) * (0.5 + Math.random()));
     }
   }
 }

--- a/packages/mochi/src/image/imageCache.test.ts
+++ b/packages/mochi/src/image/imageCache.test.ts
@@ -395,12 +395,19 @@ describe('ImageCache.setPlaceholder', () => {
 
     let sawMiss = false;
     let stop = false;
+    let reads = 0;
     const reader = (async () => {
       while (!stop) {
         if ((await cache.inspect(key)) == null) {
           sawMiss = true;
         }
-        await Promise.resolve();
+        reads++;
+        // A timer yield, not a microtask drain: `await Promise.resolve()` resolves within the
+        // same tick, so the loop reopens the destination without the event loop ever turning
+        // and a queued rename cannot complete. On Windows a rename fails outright while any
+        // handle is held, so the writer below starved rather than raced. This still samples
+        // ~50x per rewrite, well inside the window a non-atomic publish would leave open.
+        await Bun.sleep(0);
       }
     })();
     for (let i = 0; i < 20; i++) {
@@ -410,6 +417,9 @@ describe('ImageCache.setPlaceholder', () => {
     await reader;
 
     expect(sawMiss).toBe(false);
+    // Guards the assertion above from going vacuous: it only means anything if the reader
+    // actually sampled while the rewrites were in flight.
+    expect(reads).toBeGreaterThan(100);
   });
 });
 


### PR DESCRIPTION
## What

Fixes the intermittent `EPERM: operation not permitted, rename` failure on the Bun-canary Windows leg, in `imageCache.test.ts` → `renameWithRetry` (`cache/cache-storage.ts`).

## The race

Windows refuses a `rename` while **any** handle to the destination is open (POSIX rename is atomic and unaffected — it takes the existing `platform !== 'win32'` fast path, which is why only Windows was hit).

`imageCache.test.ts`'s "a rewrite never leaves the key absent" test spins a reader calling `cache.inspect(key)` — which opens the destination via `Bun.file(path).text()` — while 20 writes each rename a temp file **onto that same path**. The writer has to slip into the gap between the reader's close and its next open.

Two things made that gap effectively unwinnable:

1. **The reader never let the event loop turn.** It yielded with `await Promise.resolve()`, which resolves within the same tick, so a queued rename could not complete and the destination stayed open for essentially all of wall-clock. Starvation, not a race.
2. **The retry cadence was fixed.** `min(100, 10×(n+1))` on a steady cycle can phase-lock with a reader on its own steady cycle, so every retry lands inside the open window until the ~4.5s budget runs out.

## The fix

- **Jitter the backoff** (Windows-only path, same mean, decorrelated cycles) so a retry eventually falls in the gap.
- **Yield through a timer in the test's reader**, giving the rename a real window. Coverage goes *up*, not down: 947 reads across the 20 rewrites (~50 samples per rewrite) versus 20 with a 1ms sleep. A new `expect(reads).toBeGreaterThan(100)` keeps the "never absent" assertion from going vacuous if that loop is ever changed again.

The retry budget is deliberately **not** raised — the test has no custom timeout, so the default 5s cap means a longer budget would just convert an EPERM into a timeout.

## Notes

- Unrelated to any feature work; split out of #312 deliberately since it touches shared cache-storage code.
- The failing leg is `continue-on-error: true` (non-blocking early warning for Bun 1.4.0), so this was never gating. It passed 4× on the same branch and on `main` before failing once, and stable-Bun Windows was green throughout.
- The Windows behaviour is reasoned, not reproduced locally (no Windows host); worth watching the canary-Windows leg over a few runs.

## Testing

`bun run checks` green — including `cache-storage-file.test.ts` (37 pass), `cache-storage-memory.test.ts` (7 pass), and `imageCache.test.ts`.