### PR TITLE
fix(queues): apply deadLetter on the standalone worker path

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
         "@joint-ops/hitlimit-bun": "1.5.0",
         "@noble/ciphers": "2.2.0",
         "@noble/hashes": "2.2.0",
-        "bun-boss": "^0.3.0",
+        "bun-boss": "^0.4.0",
         "chokidar": "^5.0.0",
         "css-tree": "^3.2.1",
         "deepmerge": "^4.3.1",
@@ -689,7 +689,7 @@
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
-    "bun-boss": ["bun-boss@0.3.0", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-IDKEIHUH4ahIAG16ZRE48WkncFcK9bpZgYwXYNX6iocgzrIE3PQbvVL/wECNKHjmRH6ZZKbmapZNHPPp92p5ng=="],
+    "bun-boss": ["bun-boss@0.4.0", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-U53gBNod/73poQ7XadIzNm9twb3VPwNw8vXgHjRfDXfMvx0a84I2XVxT5oOBvV+M5r/sS6uB0SYaIvxXLXWiPA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -143,7 +143,7 @@ process.on('SIGTERM', async () => {
 });
 ```
 
-Like standalone producers, workers are ensure-only: stored queue options are trusted as-is, with no re-sync — declare the options you rely on wherever the queue is actually mounted by `Mochi.serve()`, or on a fresh queue's first creator. `worker.stop()` deregisters the worker's queues (waiting for in-flight jobs) while the runtime stays up for producing; `Mochi.stop()` tears the runtime down.
+Like standalone producers, workers are ensure-only: stored queue options are trusted as-is, with no re-sync — declare the options you rely on wherever the queue is actually mounted by `Mochi.serve()`, or on a fresh queue's first creator. A worker sees its whole `queues` array, so it does apply a [`deadLetter`](#dead-letter-queues) link when it first creates the queue and the target is declared in the same array (created target-first, so the link's queue exists); a `deadLetter` naming a queue outside the worker's array is skipped with a warning — declare it where that queue is mounted. `worker.stop()` deregisters the worker's queues (waiting for in-flight jobs) while the runtime stays up for producing; `Mochi.stop()` tears the runtime down.
 
 <Callout type="info">
 
@@ -226,7 +226,7 @@ Mochi.queue('webhooks', {
 
 ### Dead-letter queues
 
-Point `deadLetter` at another queue in the same array and terminally failed jobs move there — same payload — instead of parking in the failed state:
+Point `deadLetter` at another queue in the same array and a terminally failed job is copied there — same payload — for handling or inspection, while the original stays `failed` in its source queue as an audit trail:
 
 ```ts
 await Mochi.serve({

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -106,7 +106,7 @@
     "@joint-ops/hitlimit-bun": "1.5.0",
     "@noble/ciphers": "2.2.0",
     "@noble/hashes": "2.2.0",
-    "bun-boss": "^0.3.0",
+    "bun-boss": "^0.4.0",
     "chokidar": "^5.0.0",
     "css-tree": "^3.2.1",
     "deepmerge": "^4.3.1",

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -575,12 +575,11 @@ async function stopQueue(name: string): Promise<void> {
   }
 }
 
-// Ensure-only creation (createQueue is ON CONFLICT DO NOTHING) and never updateQueue: the standalone paths must not
-// rewrite options a Mochi.serve() deployment owns. deadLetter is dropped because its target queue may not exist here.
-async function ensureQueueExists(name: string, options: MochiQueueRuntimeOptions | undefined): Promise<void> {
+// Memoized ensure-only creation (createQueue is ON CONFLICT DO NOTHING): standalone paths never updateQueue, so an
+// existing queue's options — which a Mochi.serve() deployment owns — are left as they are.
+function ensureQueueCreated(name: string, createOptions: UpdateQueueOptions): Promise<void> {
   let ensured = registry.ensured.get(name);
   if (!ensured) {
-    const { deadLetter: _, ...createOptions } = toBossQueueOptions(name, options);
     ensured = requireBoss()
       .createQueue(name, createOptions)
       .catch((err: unknown) => {
@@ -589,7 +588,79 @@ async function ensureQueueExists(name: string, options: MochiQueueRuntimeOptions
       });
     registry.ensured.set(name, ensured);
   }
-  await ensured;
+  return ensured;
+}
+
+// A standalone producer sees one descriptor with no array, so it can't know its deadLetter target exists — drop it
+// (createQueue would throw on a missing target). A standalone worker keeps it via ensureWorkerQueues instead.
+async function ensureQueueExists(name: string, options: MochiQueueRuntimeOptions | undefined): Promise<void> {
+  const { deadLetter: _, ...createOptions } = toBossQueueOptions(name, options);
+  await ensureQueueCreated(name, createOptions);
+}
+
+// Create a standalone worker's queues, applying an in-array deadLetter on first creation. A worker receives its whole
+// queues subset up front, so — unlike a lone producer — it can resolve targets: an out-of-array target is dropped with
+// a warning (it may be mounted elsewhere) and a self-reference throws, matching Mochi.serve(). Ordered so each target
+// is created before the queue pointing at it (bun-boss createQueue asserts the target exists); still ensure-only, so an
+// existing queue keeps the options its owner declared.
+async function ensureWorkerQueues(queues: MountableQueue[]): Promise<void> {
+  const declared = new Set(queues.map((q) => q.name));
+  const resolved = queues.map((q) => {
+    const bossOptions = toBossQueueOptions(q.name, q.options);
+    const deadLetter = bossOptions.deadLetter;
+    if (deadLetter === undefined) {
+      return { name: q.name, bossOptions };
+    }
+    if (deadLetter === q.name) {
+      throw new Error(`Mochi.worker(): "${q.name}" names itself as its deadLetter queue.`);
+    }
+    if (!declared.has(deadLetter)) {
+      logger.warn(
+        `[queue] "${q.name}" names "${deadLetter}" as its deadLetter queue, but no queue named "${deadLetter}" is in this worker's queues array — the link is skipped. Declare it where "${deadLetter}" is mounted.`,
+      );
+      return { name: q.name, bossOptions: withoutDeadLetter(bossOptions) };
+    }
+    return { name: q.name, bossOptions };
+  });
+  for (const { name, bossOptions } of orderByDeadLetter(resolved)) {
+    await ensureQueueCreated(name, bossOptions);
+  }
+}
+
+function withoutDeadLetter(options: UpdateQueueOptions): UpdateQueueOptions {
+  const { deadLetter: _, ...rest } = options;
+  return rest;
+}
+
+// Topologically order by the single deadLetter out-edge so a target precedes its referencer. Any queue left over is in
+// a deadLetter cycle (createQueue can't satisfy the mutual FK from scratch) — create it without the link and warn.
+function orderByDeadLetter(items: { name: string; bossOptions: UpdateQueueOptions }[]): { name: string; bossOptions: UpdateQueueOptions }[] {
+  const ordered: { name: string; bossOptions: UpdateQueueOptions }[] = [];
+  const emitted = new Set<string>();
+  let progressed = true;
+  while (progressed) {
+    progressed = false;
+    for (const item of items) {
+      if (emitted.has(item.name)) {
+        continue;
+      }
+      const target = item.bossOptions.deadLetter;
+      if (target === undefined || emitted.has(target)) {
+        ordered.push(item);
+        emitted.add(item.name);
+        progressed = true;
+      }
+    }
+  }
+  for (const item of items) {
+    if (emitted.has(item.name)) {
+      continue;
+    }
+    logger.warn(`[queue] "${item.name}" is part of a deadLetter cycle — created without the link.`);
+    ordered.push({ name: item.name, bossOptions: withoutDeadLetter(item.bossOptions) });
+    emitted.add(item.name);
+  }
+  return ordered;
 }
 
 /** Implements `Mochi.queue(name, config)` — see its JSDoc there. */
@@ -763,8 +834,8 @@ export function createWorker(queues: MountableQueue[], storage?: MochiQueueStora
           );
         }
         const boss = requireBoss();
+        await ensureWorkerQueues(queues);
         for (const q of queues) {
-          await ensureQueueExists(q.name, q.options);
           if (!registry.byName.has(q.name)) {
             registry.byName.set(q.name, producerMethods(q.name));
           }

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -575,8 +575,8 @@ async function stopQueue(name: string): Promise<void> {
   }
 }
 
-// Memoized ensure-only creation (createQueue is ON CONFLICT DO NOTHING): standalone paths never updateQueue, so an
-// existing queue's options — which a Mochi.serve() deployment owns — are left as they are.
+// Create the queue if it's missing, remembering the attempt so it runs once. createQueue leaves an existing queue as
+// it is and the standalone paths never update it, so options a Mochi.serve() app set are left alone.
 function ensureQueueCreated(name: string, createOptions: UpdateQueueOptions): Promise<void> {
   let ensured = registry.ensured.get(name);
   if (!ensured) {
@@ -591,18 +591,18 @@ function ensureQueueCreated(name: string, createOptions: UpdateQueueOptions): Pr
   return ensured;
 }
 
-// A standalone producer sees one descriptor with no array, so it can't know its deadLetter target exists — drop it
-// (createQueue would throw on a missing target). A standalone worker keeps it via ensureWorkerQueues instead.
+// The producer path (a bare `queue.add()`) only knows the queue being added to, not the deadLetter queue it points at,
+// so it can't tell whether that target exists yet — drop the link (createQueue errors on a missing target). A worker
+// knows its whole queues list, so ensureWorkerQueues keeps the link.
 async function ensureQueueExists(name: string, options: MochiQueueRuntimeOptions | undefined): Promise<void> {
   const { deadLetter: _, ...createOptions } = toBossQueueOptions(name, options);
   await ensureQueueCreated(name, createOptions);
 }
 
-// Create a standalone worker's queues, applying an in-array deadLetter on first creation. A worker receives its whole
-// queues subset up front, so — unlike a lone producer — it can resolve targets: an out-of-array target is dropped with
-// a warning (it may be mounted elsewhere) and a self-reference throws, matching Mochi.serve(). Ordered so each target
-// is created before the queue pointing at it (bun-boss createQueue asserts the target exists); still ensure-only, so an
-// existing queue keeps the options its owner declared.
+// Create the worker's queues. When a queue names another of this worker's queues as its deadLetter, set that link as
+// the queue is created (creating the target first, since it must exist). Only a brand-new queue gets the link — an
+// existing one is left as it is; a deadLetter naming a queue this worker doesn't list is skipped with a warning, and a
+// queue naming itself throws, as Mochi.serve() does.
 async function ensureWorkerQueues(queues: MountableQueue[]): Promise<void> {
   const declared = new Set(queues.map((q) => q.name));
   const resolved = queues.map((q) => {
@@ -622,8 +622,19 @@ async function ensureWorkerQueues(queues: MountableQueue[]): Promise<void> {
     }
     return { name: q.name, bossOptions };
   });
+  const boss = requireBoss();
   for (const { name, bossOptions } of orderByDeadLetter(resolved)) {
     await ensureQueueCreated(name, bossOptions);
+    // createQueue skips a queue that already exists, so one left from an earlier deploy (or a producer add in this
+    // process) keeps the deadLetter it was stored with — warn that the declared link wasn't applied rather than dropping it silently.
+    if (bossOptions.deadLetter !== undefined) {
+      const stored = (await boss.getQueue(name))?.deadLetter ?? undefined;
+      if (stored !== bossOptions.deadLetter) {
+        logger.warn(
+          `[queue] "${name}" declares "${bossOptions.deadLetter}" as its deadLetter queue, but the queue already exists ${stored ? `linked to "${stored}"` : 'without a deadLetter link'} — a worker only sets the link when it first creates the queue. Migrate with Mochi.boss().updateQueue("${name}", { deadLetter: "${bossOptions.deadLetter}" }).`,
+        );
+      }
+    }
   }
 }
 
@@ -632,8 +643,9 @@ function withoutDeadLetter(options: UpdateQueueOptions): UpdateQueueOptions {
   return rest;
 }
 
-// Topologically order by the single deadLetter out-edge so a target precedes its referencer. Any queue left over is in
-// a deadLetter cycle (createQueue can't satisfy the mutual FK from scratch) — create it without the link and warn.
+// Order the queues so each deadLetter target comes before the queue pointing at it, since createQueue needs the target
+// to already exist. Anything left over points in a loop (A→B→A), which can't be built from scratch — create those
+// without the link and warn.
 function orderByDeadLetter(items: { name: string; bossOptions: UpdateQueueOptions }[]): { name: string; bossOptions: UpdateQueueOptions }[] {
   const ordered: { name: string; bossOptions: UpdateQueueOptions }[] = [];
   const emitted = new Set<string>();
@@ -652,13 +664,17 @@ function orderByDeadLetter(items: { name: string; bossOptions: UpdateQueueOption
       }
     }
   }
-  for (const item of items) {
-    if (emitted.has(item.name)) {
-      continue;
+  const cyclic = items.filter((item) => !emitted.has(item.name));
+  if (cyclic.length > 0) {
+    // One warning for the whole loop, not one per queue. A worker can't build a deadLetter loop (createQueue needs each
+    // target to exist first), while Mochi.serve() can — it creates every queue, then adds the links — so use serve for loops.
+    logger.warn(
+      `[queue] deadLetter loop among ${cyclic.map((item) => `"${item.name}"`).join(', ')} — created without their links; a worker cannot create a deadLetter loop (mount these under Mochi.serve() if you need it).`,
+    );
+    for (const item of cyclic) {
+      ordered.push({ name: item.name, bossOptions: withoutDeadLetter(item.bossOptions) });
+      emitted.add(item.name);
     }
-    logger.warn(`[queue] "${item.name}" is part of a deadLetter cycle — created without the link.`);
-    ordered.push({ name: item.name, bossOptions: withoutDeadLetter(item.bossOptions) });
-    emitted.add(item.name);
   }
   return ordered;
 }

--- a/packages/mochi/src/queueWorker.test.ts
+++ b/packages/mochi/src/queueWorker.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, afterEach, describe, expect, test } from 'bun:test';
+import { afterAll, afterEach, describe, expect, spyOn, test } from 'bun:test';
 import { mkdtempSync, rmSync } from 'node:fs';
 import path from 'node:path';
 import { Mochi } from './Mochi';
@@ -7,6 +7,7 @@ import type { MochiJob } from './queue';
 import { mochiEvents } from './events';
 import { initExtensions } from './extensions';
 import { resetStartupMilestones } from './lifecycle';
+import { logger } from './utils/log';
 
 const dataDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-queue-worker-'));
 
@@ -118,5 +119,54 @@ describe('Mochi.worker()', () => {
     await startQueueRuntime('memory');
     const worker = Mochi.worker({ queues: [Mochi.queue('served', { storage: 'memory' })] });
     expect(worker.start()).rejects.toThrow(/this process is serving/);
+  });
+
+  test('applies an in-array deadLetter on first creation, so a terminally failed job lands in the DLQ', async () => {
+    const file = path.join(dataDir, 'worker-dlq.sqlite');
+    const landed = deferred<MochiJob<{ payload: string }>>();
+    const work = Mochi.queue<{ payload: string }>('work', {
+      storage: { sqlite: file },
+      pollingIntervalSeconds: 0.5,
+      retryLimit: 0,
+      deadLetter: 'work-dlq',
+      process: async () => {
+        throw new Error('unprocessable');
+      },
+    });
+    // The dead-letter queue is declared after the queue that references it, proving order doesn't matter.
+    const dlq = Mochi.queue<{ payload: string }>('work-dlq', {
+      storage: { sqlite: file },
+      pollingIntervalSeconds: 0.5,
+      process: async (job: MochiJob<{ payload: string }>) => landed.resolve(job),
+    });
+
+    await Mochi.worker({ queues: [work, dlq] }).start();
+    expect((await getBoss().getQueue('work'))?.deadLetter).toBe('work-dlq');
+
+    await work.add({ payload: 'keep-me' });
+    const job = await landed.promise;
+    expect(job.queue).toBe('work-dlq');
+    expect(job.data).toEqual({ payload: 'keep-me' });
+  }, 20_000);
+
+  test('skips a deadLetter that names a queue outside the worker array, with a warning, and still mounts', async () => {
+    const file = path.join(dataDir, 'worker-dlq-outside.sqlite');
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const worker = Mochi.worker({
+        queues: [Mochi.queue('lonely', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'elsewhere', process: async () => {} })],
+      });
+      await worker.start();
+      expect((await getBoss().getQueue('lonely'))?.deadLetter).toBeNull();
+      expect(warn.mock.calls.some((args) => String(args[0]).includes('names "elsewhere" as its deadLetter'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  }, 20_000);
+
+  test('rejects a queue that names itself as its deadLetter', async () => {
+    const file = path.join(dataDir, 'worker-dlq-self.sqlite');
+    const worker = Mochi.worker({ queues: [Mochi.queue('selfref', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'selfref', process: async () => {} })] });
+    expect(worker.start()).rejects.toThrow(/names itself as its deadLetter/);
   });
 });

--- a/packages/mochi/src/queueWorker.test.ts
+++ b/packages/mochi/src/queueWorker.test.ts
@@ -169,4 +169,28 @@ describe('Mochi.worker()', () => {
     const worker = Mochi.worker({ queues: [Mochi.queue('selfref', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'selfref', process: async () => {} })] });
     expect(worker.start()).rejects.toThrow(/names itself as its deadLetter/);
   });
+
+  test('warns (does not silently drop) when a declared deadLetter cannot be applied because the queue already exists', async () => {
+    const file = path.join(dataDir, 'worker-dlq-preexisting.sqlite');
+    // A prior deploy created the queue without a deadLetter link.
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'pre' }, { name: 'pre-dlq' }]);
+    await closeAllQueueResources();
+
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const worker = Mochi.worker({
+        queues: [
+          Mochi.queue('pre', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'pre-dlq', process: async () => {} }),
+          Mochi.queue('pre-dlq', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, process: async () => {} }),
+        ],
+      });
+      await worker.start();
+      // Ensure-only: the existing queue keeps its null link, but the drop is surfaced, not silent.
+      expect((await getBoss().getQueue('pre'))?.deadLetter).toBeNull();
+      expect(warn.mock.calls.some((args) => String(args[0]).includes('"pre"') && String(args[0]).includes('already exists') && String(args[0]).includes('updateQueue'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+  }, 20_000);
 });


### PR DESCRIPTION
## Problem

A queue declared with `deadLetter` had that option **silently stripped** when the queue was created by a standalone path (`Mochi.worker()`). Every other option (`retryLimit`, `retryDelay`, `retryBackoff`, `retryDelayMax`, `concurrency`) was applied on the same call — only `deadLetter` was discarded, with no warning and no error.

This breaks the natural heavy-queue topology: the web server runs with queues unmounted, and a separate `Mochi.worker()` process drains the backlog. In that shape **no process ever calls `Mochi.serve({ queues })`**, so `deadLetter` — which was only ever applied by the serve path — was never written by anything. The dead-letter queue existed, was mounted, was polled, and never received a job. The failure was only visible by querying storage and noticing `dead_letter IS NULL`.

## Fix

The worker receives its whole `queues` subset up front, so it can resolve targets the way `Mochi.serve()` does. New `ensureWorkerQueues()` (in `packages/mochi/src/queue.ts`):

- **Orders** the queues so a `deadLetter` target is created before the queue that points at it (bun-boss `createQueue` asserts the target exists), then `createQueue`s each **with** its `deadLetter`.
- Stays strictly **ensure-only** — `createQueue` is `ON CONFLICT DO NOTHING`, never `updateQueue` — so the link is set only on the **creating write**; an existing queue owned by a `Mochi.serve()` deployment is never rewritten. This preserves the documented "workers are ensure-only, no re-sync" invariant.
- **Throws** on a self-referential `deadLetter` (parity with serve), and **skips with a warning** a target declared outside the worker's own array (it may be mounted elsewhere) — no more silent drop.

The lone standalone *producer* path still drops `deadLetter` (a single descriptor has no array to validate a target against) — unchanged and out of scope.

### Secondary: docs/behavior correction

bun-boss keeps the terminally failed job as `failed` in its source queue **and** inserts a *copy* into the dead-letter queue (with `source_name`/`source_id` provenance) — verified in `failJobsBody`. The docs said failed jobs "move there … instead of parking in the failed state"; corrected to describe the copy + retained audit row.

### Dependency

Bumps **bun-boss `0.3.0` → `0.4.0`**. The fix was re-verified against 0.4.0 on both SQLite and PGlite/Postgres.

## Verification

- Reproduced the bug (`dead_letter IS NULL`, DLQ empty), then confirmed the fix (link set, jobs land in the DLQ) on **both** SQLite and PGlite/Postgres storage.
- New tests in `queueWorker.test.ts`: in-array link applied + job lands in the DLQ (target declared *after* its referencer, proving ordering); out-of-array target skipped with a warning while the queue still mounts; self-reference throws. The existing "never re-syncs stored options" test still passes.
- `bun run checks` (lint + format + typecheck + full test suite) passes.

## Note for consumers migrating an existing deployment

Because the worker path is ensure-only, it applies `deadLetter` **only on first creation**. A queue that already exists in the database with `dead_letter = NULL` will **not** be retroactively linked — declare `deadLetter` on the descriptor for fresh deployments, and run a one-time `Mochi.boss().updateQueue(name, { deadLetter })` (or delete + recreate the queue) to migrate an existing one.