### PR TITLE
feat!: make declared queue config authoritative over storage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
         "@joint-ops/hitlimit-bun": "1.5.0",
         "@noble/ciphers": "2.2.0",
         "@noble/hashes": "2.2.0",
-        "bun-boss": "^0.4.0",
+        "bun-boss": "^0.5.0",
         "chokidar": "^5.0.0",
         "css-tree": "^3.2.1",
         "deepmerge": "^4.3.1",
@@ -689,7 +689,7 @@
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
-    "bun-boss": ["bun-boss@0.4.0", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-U53gBNod/73poQ7XadIzNm9twb3VPwNw8vXgHjRfDXfMvx0a84I2XVxT5oOBvV+M5r/sS6uB0SYaIvxXLXWiPA=="],
+    "bun-boss": ["bun-boss@0.5.0", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-63Va9FnVg5oNOp/V6CJd7eGmGcS3fcsM1p4egHCAMBeiLt9gq2bIX0aL5/eoqozvqkTtHkyBRnPz2G3wmxG3vA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -254,9 +254,11 @@ A descriptor-form target does not need to be in the `queues` array — it is ens
 
 Drain or replay a dead-letter queue through the [escape hatch](#mochiboss): `Mochi.boss().redrive('webhooks-dlq')` moves its jobs back to their source queue.
 
-<Callout type="warning">
+Removing the link is a config change like any other: delete the option from code and migrate — [`sync`](#storage) clears it, or run the `updateQueue(name, { deadLetter: null })` the mismatch error prints.
 
-**Removing a link needs a reset.** bun-boss's `updateQueue` cannot clear a stored `deadLetter`, so deleting the option from code is a boot error even under `queueConfig: 'sync'`. Repoint it instead, or reset the queue: `Mochi.boss().deleteQueue(name)` and reboot — this discards the queue's jobs, and a queue still referenced as another's `deadLetter` cannot be deleted until its referrers are repointed or deleted first.
+<Callout type="info">
+
+**Resetting a queue.** `Mochi.boss().deleteQueue(name)` removes a queue outright — jobs included, pending backlog and failed-job audit trail alike; the next boot recreates it from the declaration. A queue still referenced as another's `deadLetter` cannot be deleted until its referrers are repointed or deleted first.
 
 </Callout>
 

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -113,7 +113,7 @@ await emails.addBulk(jobs);
 await emails.stop();
 ```
 
-- A producer creates the queue if missing and leaves stored options untouched — [option re-sync](#storage) stays with `Mochi.serve()`. To consume without a server, see [standalone workers](#standalone-workers).
+- A producer declaring no options simply ensures the queue exists. Declared options are enforced like everywhere else — [config is code-authoritative](#storage) — and a descriptor-form [`deadLetter`](#dead-letter-queues) is created with its link intact even when the producer runs first on fresh storage. To consume without a server, see [standalone workers](#standalone-workers).
 - `queue.stop()` stops that queue in this process — its worker deregisters after in-flight jobs finish, and the shared runtime closes once the last active queue stops. [`Mochi.stop()`](#mochistop) remains the whole-app teardown; under `Mochi.serve()` queues stop with the server.
 - Your app has **one queue storage**. Declare it on the descriptor (`storage`), app-wide via the serve-level [`queueStorage`](#storage) option, or both when they agree — conflicting declarations are a boot error. Standalone, a descriptor without `storage` throws on `add()`.
 - `Mochi.serve()` inherits the descriptors' storage when `queueStorage` is unset, and a serve on the same storage adopts an already-connected standalone runtime — on a different storage it refuses to start.
@@ -143,7 +143,7 @@ process.on('SIGTERM', async () => {
 });
 ```
 
-Like standalone producers, workers are ensure-only: stored queue options are trusted as-is, with no re-sync — declare the options you rely on wherever the queue is actually mounted by `Mochi.serve()`, or on a fresh queue's first creator. A worker sees its whole `queues` array, so it does apply a [`deadLetter`](#dead-letter-queues) link when it first creates the queue and the target is declared in the same array (created target-first, so the link's queue exists); a `deadLetter` naming a queue outside the worker's array is skipped with a warning — declare it where that queue is mounted. `worker.stop()` deregisters the worker's queues (waiting for in-flight jobs) while the runtime stays up for producing; `Mochi.stop()` tears the runtime down.
+Queue config follows the same rule as every other path — [code is authoritative](#storage): a worker creates missing queues with their full declared config ([`deadLetter`](#dead-letter-queues) links included, targets first) and refuses to start when storage disagrees; `Mochi.worker({ queueConfig: 'sync' })` writes the declared config to storage instead. `worker.stop()` deregisters the worker's queues (waiting for in-flight jobs) while the runtime stays up for producing; `Mochi.stop()` tears the runtime down.
 
 <Callout type="info">
 
@@ -189,7 +189,21 @@ See [Persistence](/docs/persistence/) for how queue storage compares to the othe
 
 Postgres storage installs its tables into a dedicated `mochi_queue` schema on first start, away from your application's tables. The schema name is fixed, so every app sharing one database shares one queue namespace — give each app its own database to keep their queues apart.
 
-On durable storage, queue options re-sync from your code on every `Mochi.serve()` boot — but only **additively**: an option you leave undeclared (including `expireInSeconds`) keeps its previously stored value. Set the old value back explicitly (e.g. `retryLimit: 2`) rather than deleting the line; a removed `deadLetter` can only be repointed, not cleared. [Standalone producers](#standalone-producers) leave stored options untouched.
+On durable storage, **declared config is authoritative and storage is a cache of it**. At every boot — `Mochi.serve()`, `Mochi.worker()`, and standalone producers alike — each declared queue is created with its full config if missing, and verified field-by-field against storage if present. A mismatch is a boot error naming the queue, the fields, and both values; an option you leave undeclared is expected to hold its bun-boss default. A declaration with no persisted options at all (`Mochi.queue(name, { storage })`) only asserts the queue exists.
+
+To change a queue's config, change the code — then let one deploy write it through:
+
+```ts
+await Mochi.serve({ queues, queueConfig: 'sync' }); // or MOCHI_QUEUE_SYNC=1 in the environment
+```
+
+`'sync'` replaces the mismatch error with a repair: the declared config is written to storage and every changed field is logged. `MOCHI_QUEUE_SYNC=1` forces sync process-wide (standalone producers included) and wins over the option — set it on the one deploy that migrates, or leave `queueConfig: 'sync'` on permanently for code-always-wins. The mismatch error also prints a ready-to-paste `Mochi.boss().updateQueue(…)` call for migrating by hand.
+
+<Callout type="warning">
+
+**Share one descriptor across processes.** Every process that declares a queue asserts its config — a producer script declaring different options than the server is a boot error, not a silent divergence. Export the descriptor from one module and import it everywhere. The `queue:expireInSeconds` filter counts as declared config too, so processes must register the same extensions.
+
+</Callout>
 
 ### PGlite
 
@@ -226,19 +240,25 @@ Mochi.queue('webhooks', {
 
 ### Dead-letter queues
 
-Point `deadLetter` at another queue in the same array and a terminally failed job is copied there — same payload — for handling or inspection, while the original stays `failed` in its source queue as an audit trail:
+Point `deadLetter` at another queue and a terminally failed job is copied there — same payload — for handling or inspection, while the original stays `failed` in its source queue as an audit trail. Pass the target's **descriptor** and the reference is self-sufficient: whichever process boots first — server, worker, or a lone producer — creates the target before the queue that points at it, link intact:
 
 ```ts
-await Mochi.serve({
-  queues: [
-    Mochi.queue('webhooks', { process: deliverWebhook, retryLimit: 3, deadLetter: 'webhooks-dlq' }),
-    // No `process`: jobs wait here for inspection. Give it one to handle failures automatically.
-    Mochi.queue('webhooks-dlq'),
-  ],
-});
+// No `process`: jobs wait here for inspection. Give it one to handle failures automatically.
+export const webhooksDlq = Mochi.queue('webhooks-dlq');
+export const webhooks = Mochi.queue('webhooks', { process: deliverWebhook, retryLimit: 3, deadLetter: webhooksDlq });
+
+await Mochi.serve({ queues: [webhooks, webhooksDlq] });
 ```
 
+A descriptor-form target does not need to be in the `queues` array — it is ensured in storage either way, but only mounted (worker started, handle resolvable) where it is declared. The string form (`deadLetter: 'webhooks-dlq'`) still works when the target is declared in the same array or already exists in storage. A dead-letter _loop_ (A→B→A) cannot be created from scratch — each target must exist before its referrer — though an existing loop that matches the declaration passes.
+
 Drain or replay a dead-letter queue through the [escape hatch](#mochiboss): `Mochi.boss().redrive('webhooks-dlq')` moves its jobs back to their source queue.
+
+<Callout type="warning">
+
+**Removing a link needs a reset.** bun-boss's `updateQueue` cannot clear a stored `deadLetter`, so deleting the option from code is a boot error even under `queueConfig: 'sync'`. Repoint it instead, or reset the queue: `Mochi.boss().deleteQueue(name)` and reboot — this discards the queue's jobs, and a queue still referenced as another's `deadLetter` cannot be deleted until its referrers are repointed or deleted first.
+
+</Callout>
 
 ### Long-running jobs
 

--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -150,7 +150,7 @@ await Mochi.serve({
 });
 ```
 
-In production, the check refuses every form mutation until `proxy.origin` (or `proxy.hostHeader`) is set, so the deployment break is loud. In development the request is allowed through with a `[mochi]` warning.
+In production, the check refuses every form mutation until `proxy.origin` (or `proxy.hostHeader`) is set, so the deployment break is loud. In development the request is allowed through with a `[mochi]` warning. Routes declaring form `actions` without either option also warn once at boot — in both modes — so the misconfiguration is visible before deploy, not first discovered as a production 403.
 
 ### Proxy
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -106,7 +106,7 @@
     "@joint-ops/hitlimit-bun": "1.5.0",
     "@noble/ciphers": "2.2.0",
     "@noble/hashes": "2.2.0",
-    "bun-boss": "^0.4.0",
+    "bun-boss": "^0.5.0",
     "chokidar": "^5.0.0",
     "css-tree": "^3.2.1",
     "deepmerge": "^4.3.1",

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -46,7 +46,7 @@ import type {
 } from './types';
 import { isFormFail, isFormSuccess, isRedirect } from './runtime/forms';
 import { isEnhanceRequest, jsonError, jsonFailure, jsonRedirect, jsonSuccess } from './runtime/formsJson';
-import { csrfCheck, DEFAULT_FORM_CONTENT_TYPES, DEFAULT_PROTECTED_METHODS } from './runtime/csrf';
+import { csrfCheck, csrfBootWarning, DEFAULT_FORM_CONTENT_TYPES, DEFAULT_PROTECTED_METHODS } from './runtime/csrf';
 import { applyFilter, initExtensions, runHook } from './extensions';
 import { escapeHtmlAttr } from './utils/htmlEscape';
 import { buildPublicUrl } from './runtime/proxy';
@@ -84,6 +84,9 @@ import {
   createWorker,
   storageEquals,
   assertNoConflictingStandaloneRuntime,
+  deadLetterName,
+  resolveQueueConfigMode,
+  collectQueueStorageDeclarations,
 } from './queue';
 import { pinGlobal } from './utils/globalState';
 import { resetStartupMilestones } from './lifecycle';
@@ -223,7 +226,7 @@ export class Mochi {
    * Declare a background job queue. The returned descriptor is both the declaration `Mochi.serve({ queues: [q] })`
    * mounts (workers start there, and the queue drains gracefully on shutdown) and a directly-usable producer handle:
    * `q.add(...)` works anywhere. In a process that never serves, give it `storage` and the first add lazily connects a
-   * producer-only runtime — no server, no workers, no option re-sync; tear down with `Mochi.stop()`.
+   * producer-only runtime — no server, no workers; tear down with `Mochi.stop()`.
    */
   static queue<T = unknown, R = unknown>(name: string, config: MochiQueueOptions<T, R> = {}): MochiQueueDescriptor<T, R> {
     return createQueueDescriptor<T, R>(name, config);
@@ -239,12 +242,12 @@ export class Mochi {
 
   /**
    * Declare a standalone worker: consume queues in a process that never calls `Mochi.serve()`. `start()` connects to
-   * the app's queue storage (from the descriptors or the `storage` option) and begins polling. Ensure-only, like
-   * standalone producers — stored queue options are not re-synced, no hooks or milestones fire, and signal handling is
-   * yours to wire (`Mochi.stop()` drains and closes the runtime).
+   * the app's queue storage (from the descriptors or the `storage` option), creates-or-verifies the declared queue
+   * config (code is authoritative — see `queueConfig`), and begins polling. No hooks or milestones fire, and signal
+   * handling is yours to wire (`Mochi.stop()` drains and closes the runtime).
    */
   static worker(options: MochiWorkerOptions): MochiWorker {
-    return createWorker(options.queues, options.storage);
+    return createWorker(options.queues, options.storage, options.queueConfig);
   }
 
   /**
@@ -375,26 +378,25 @@ export class Mochi {
       queueNames.add(config.name);
       const deadLetter = config.options?.deadLetter;
       if (deadLetter !== undefined) {
-        if (deadLetter === config.name) {
+        if (deadLetterName(deadLetter) === config.name) {
           throw new Error(`Mochi.serve({ queues }): "${config.name}" names itself as its deadLetter queue.`);
         }
-        if (!declaredQueues.some((q) => q.name === deadLetter)) {
+        // Descriptor form is self-sufficient — the target is ensured on its own; only a bare name needs the array.
+        if (typeof deadLetter === 'string' && !declaredQueues.some((q) => q.name === deadLetter)) {
           throw new Error(
-            `Mochi.serve({ queues }): "${config.name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues array.`,
+            `Mochi.serve({ queues }): "${config.name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues array. Declare it there, or pass its descriptor (deadLetter: Mochi.queue("${deadLetter}", …)) so it is ensured on its own.`,
           );
         }
       }
     }
-    // An app has one queue storage: declared on the descriptors, app-wide via queueStorage, or both when they agree.
+    // An app has one queue storage: declared on the descriptors (deadLetter targets included), app-wide via
+    // queueStorage, or both when they agree.
     let declaredStorage: { name: string; storage: MochiQueueStorage } | undefined;
-    for (const config of declaredQueues) {
-      if (config.storage === undefined) {
-        continue;
+    for (const { name, storage } of collectQueueStorageDeclarations(declaredQueues)) {
+      if (declaredStorage && !storageEquals(declaredStorage.storage, storage)) {
+        throw new Error(`Mochi.serve({ queues }): "${name}" and "${declaredStorage.name}" declare different storages — an app has one queue storage.`);
       }
-      if (declaredStorage && !storageEquals(declaredStorage.storage, config.storage)) {
-        throw new Error(`Mochi.serve({ queues }): "${config.name}" and "${declaredStorage.name}" declare different storages — an app has one queue storage.`);
-      }
-      declaredStorage ??= { name: config.name, storage: config.storage };
+      declaredStorage ??= { name, storage };
     }
     if (options.queueStorage !== undefined && declaredStorage && !storageEquals(declaredStorage.storage, options.queueStorage)) {
       throw new Error(
@@ -425,6 +427,11 @@ export class Mochi {
     const protectedMethods: ReadonlySet<string> = applyFilter('csrf:protectedMethods', new Set(DEFAULT_PROTECTED_METHODS), { options });
     const trustedOrigins: ReadonlySet<string> = applyFilter('csrf:trustedOrigins', new Set(options.csrf?.trustedOrigins ?? []), { options });
     const cookieDefaults = applyFilter('cookie:defaults', {}, { options });
+
+    const bootCsrfWarning = csrfBootWarning(options);
+    if (bootCsrfWarning) {
+      logger.warn(bootCsrfWarning);
+    }
 
     const development = options.development ?? true;
     const inlineNestedIslands = options.inlineNestedIslands !== false;
@@ -1898,7 +1905,7 @@ export class Mochi {
       if (declaredQueues.length > 0) {
         // kind 'serve' adopts a standalone producer runtime already connected to the same storage.
         await startQueueRuntime(queueStorage, { kind: 'serve' });
-        await mountQueues(declaredQueues);
+        await mountQueues(declaredQueues, resolveQueueConfigMode(options.queueConfig));
       }
     } catch (err) {
       await closeAllQueueResources();

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -84,9 +84,8 @@ import {
   createWorker,
   storageEquals,
   assertNoConflictingStandaloneRuntime,
-  deadLetterName,
   resolveQueueConfigMode,
-  collectQueueStorageDeclarations,
+  collectQueueClosure,
 } from './queue';
 import { pinGlobal } from './utils/globalState';
 import { resetStartupMilestones } from './lifecycle';
@@ -376,23 +375,22 @@ export class Mochi {
         throw new Error(`Mochi.serve({ queues }): two queues are named "${config.name}". Queue names must be unique.`);
       }
       queueNames.add(config.name);
+      // Descriptor form is self-sufficient — the target is ensured on its own; only a bare name needs the array.
+      // Self-references and conflicting duplicates are caught by the closure walk below.
       const deadLetter = config.options?.deadLetter;
-      if (deadLetter !== undefined) {
-        if (deadLetterName(deadLetter) === config.name) {
-          throw new Error(`Mochi.serve({ queues }): "${config.name}" names itself as its deadLetter queue.`);
-        }
-        // Descriptor form is self-sufficient — the target is ensured on its own; only a bare name needs the array.
-        if (typeof deadLetter === 'string' && !declaredQueues.some((q) => q.name === deadLetter)) {
-          throw new Error(
-            `Mochi.serve({ queues }): "${config.name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues array. Declare it there, or pass its descriptor (deadLetter: Mochi.queue("${deadLetter}", …)) so it is ensured on its own.`,
-          );
-        }
+      if (typeof deadLetter === 'string' && !declaredQueues.some((q) => q.name === deadLetter)) {
+        throw new Error(
+          `Mochi.serve({ queues }): "${config.name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues array. Declare it there, or pass its descriptor (deadLetter: Mochi.queue("${deadLetter}", …)) so it is ensured on its own.`,
+        );
       }
     }
     // An app has one queue storage: declared on the descriptors (deadLetter targets included), app-wide via
     // queueStorage, or both when they agree.
     let declaredStorage: { name: string; storage: MochiQueueStorage } | undefined;
-    for (const { name, storage } of collectQueueStorageDeclarations(declaredQueues)) {
+    for (const { name, storage } of collectQueueClosure(declaredQueues, 'Mochi.serve({ queues })')) {
+      if (storage === undefined) {
+        continue;
+      }
       if (declaredStorage && !storageEquals(declaredStorage.storage, storage)) {
         throw new Error(`Mochi.serve({ queues }): "${name}" and "${declaredStorage.name}" declare different storages — an app has one queue storage.`);
       }

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -118,6 +118,7 @@ export type {
   MochiJobOptions,
   MochiQueueOptions,
   MochiQueueRuntimeOptions,
+  MochiDeadLetterTarget,
   MochiWorkerTuning,
   MochiQueueListeners,
   MochiProcessor,

--- a/packages/mochi/src/queue.test.ts
+++ b/packages/mochi/src/queue.test.ts
@@ -526,14 +526,14 @@ describe('Mochi queue', () => {
     expect(worker!.options).not.toHaveProperty('burstWhenBatchFull');
   });
 
-  test('an undeclared expiry is no longer re-sent: a bare remount keeps stored options', async () => {
+  test('a bare declaration is an existence reference: a bare remount keeps stored options', async () => {
     const name = uniqueName();
     const file = path.join(dataDir, 'expiry.sqlite');
     await startWith({ [name]: { options: { expireInSeconds: 42, retryLimit: 7 } } }, { sqlite: file });
     expect((await getBoss().getQueue(name))?.expireInSeconds).toBe(42);
     await closeAllQueueResources();
 
-    // A second process mounting the same queue with a bare Mochi.queue(name) must keep 42, not reset it to the default.
+    // A bare Mochi.queue(name) declares no persisted options, so it asserts existence, not config — 42 must survive.
     await startWith({ [name]: {} }, { sqlite: file });
     const queue = await getBoss().getQueue(name);
     expect(queue?.expireInSeconds).toBe(42);

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -1,6 +1,6 @@
 // The isolation boundary around bun-boss: the only module importing `bun-boss`, and the only one whose rewrite a
 // backend swap would need.
-import { BunBoss, fromBunSqlite, fromPglite } from 'bun-boss';
+import { BunBoss, fromBunSqlite, fromPglite, queueOptionDefaults } from 'bun-boss';
 import type { JobInsert, JobResult, JobWithMetadata, PGliteLike, SendOptions, UpdateQueueOptions, WorkOptions } from 'bun-boss';
 import { SQL } from 'bun';
 import { mkdirSync } from 'node:fs';
@@ -262,20 +262,20 @@ function describeStorage(storage: MochiQueueStorage | null): string {
   return 'pglite' in storage ? '{ pglite: … }' : '{ postgres: … }';
 }
 
-export const DEFAULT_EXPIRE_IN_SECONDS = 900;
+export const DEFAULT_EXPIRE_IN_SECONDS = queueOptionDefaults.expireInSeconds as number;
 
-// Mirrors bun-boss 0.4.0's createQueue COALESCE defaults (its plans.ts): declared code is authoritative and an
-// undeclared option means "the default", so these are what it must read back as — re-verify on every bun-boss bump.
+// The Mochi-managed subset of bun-boss's stored option defaults: declared code is authoritative and an undeclared
+// option means "the default", so these are what it must read back as.
 const QUEUE_OPTION_DEFAULTS = {
-  retryLimit: 2,
-  retryDelay: 0,
-  retryBackoff: false,
-  retryDelayMax: null,
-  expireInSeconds: DEFAULT_EXPIRE_IN_SECONDS,
-  retentionSeconds: 1_209_600,
-  deleteAfterSeconds: 604_800,
-  deadLetter: null,
-} as const;
+  retryLimit: queueOptionDefaults.retryLimit,
+  retryDelay: queueOptionDefaults.retryDelay,
+  retryBackoff: queueOptionDefaults.retryBackoff,
+  retryDelayMax: queueOptionDefaults.retryDelayMax,
+  expireInSeconds: queueOptionDefaults.expireInSeconds,
+  retentionSeconds: queueOptionDefaults.retentionSeconds,
+  deleteAfterSeconds: queueOptionDefaults.deleteAfterSeconds,
+  deadLetter: queueOptionDefaults.deadLetter,
+};
 type ManagedQueueField = keyof typeof QUEUE_OPTION_DEFAULTS;
 type ManagedQueueValue = number | boolean | string | null;
 
@@ -335,18 +335,10 @@ function formatQueueValue(value: ManagedQueueValue): string {
 function queueConfigMismatchError(context: string, name: string, diffs: QueueConfigDiff[]): Error {
   const stored = diffs.map((d) => `${d.field} ${formatQueueValue(d.stored)}`).join(', ');
   const declared = diffs.map((d) => `${d.field} ${formatQueueValue(d.declared)}`).join(', ');
-  const settable = diffs.filter((d) => d.declared !== null);
-  const unclearable = diffs.filter((d) => d.declared === null);
-  const hint = settable.map((d) => `${d.field}: ${typeof d.declared === 'string' ? `"${d.declared}"` : String(d.declared)}`).join(', ');
-  const remedy =
-    settable.length > 0
-      ? `update the declaration to match, migrate the store with Mochi.boss().updateQueue("${name}", { ${hint} }) and restart, or boot once with MOCHI_QUEUE_SYNC=1 (or queueConfig: 'sync') to apply the declared config`
-      : `update the declaration to match`;
-  let message = `${context}: "${name}" already exists in storage with ${stored}, but this code declares ${declared}. Code is authoritative for queue config — ${remedy}.`;
-  if (unclearable.length > 0) {
-    message += ` ${unclearable.map((d) => d.field).join(' and ')} cannot be cleared through bun-boss's updateQueue (absent fields keep their stored value) — keep declaring it, or reset the queue with Mochi.boss().deleteQueue("${name}") and reboot (this discards the queue's jobs).`;
-  }
-  return new Error(message);
+  const hint = diffs.map((d) => `${d.field}: ${typeof d.declared === 'string' ? `"${d.declared}"` : String(d.declared)}`).join(', ');
+  return new Error(
+    `${context}: "${name}" already exists in storage with ${stored}, but this code declares ${declared}. Code is authoritative for queue config — update the declaration to match, migrate the store with Mochi.boss().updateQueue("${name}", { ${hint} }) and restart, or boot once with MOCHI_QUEUE_SYNC=1 (or queueConfig: 'sync') to apply the declared config.`,
+  );
 }
 
 // bun-boss's attorney asserts on key presence, not value, so an explicitly-undefined option must not reach it.
@@ -737,7 +729,7 @@ function orderByDeadLetter(items: DeclaredQueueEntry[]): { ordered: DeclaredQueu
         continue;
       }
       const target = item.bossOptions.deadLetter;
-      if (target === undefined || !names.has(target) || emitted.has(target)) {
+      if (target == null || !names.has(target) || emitted.has(target)) {
         ordered.push(item);
         emitted.add(item.name);
         progressed = true;
@@ -782,7 +774,7 @@ async function verifyOrCreateQueue(boss: BunBoss, entry: DeclaredQueueEntry, con
     await boss.createQueue(name, bossOptions);
   } catch (err) {
     const target = bossOptions.deadLetter;
-    if (target !== undefined && (await boss.getQueue(target).catch(() => null)) == null) {
+    if (target != null && (await boss.getQueue(target).catch(() => null)) == null) {
       throw new Error(
         `${context}: "${name}" names "${target}" as its deadLetter queue, but "${target}" is not declared here and does not exist in storage, so "${name}" cannot be created with its link. Pass the target's descriptor — deadLetter: Mochi.queue("${target}", …) — so it is ensured first.`,
         { cause: err },
@@ -802,13 +794,12 @@ async function verifyOrCreateQueue(boss: BunBoss, entry: DeclaredQueueEntry, con
   if (diffs.length === 0) {
     return;
   }
-  // A declared-unset field can't be repaired either way: updateQueue keeps stored values for absent fields.
-  if (mode === 'verify' || diffs.some((d) => d.declared === null)) {
+  if (mode === 'verify') {
     throw queueConfigMismatchError(context, name, diffs);
   }
-  // Full-field write of concrete values so COALESCE semantics can't keep a stale one.
-  const payload = omitUndefined(Object.fromEntries(Object.entries(expected).map(([k, v]) => [k, v === null ? undefined : v]))) as UpdateQueueOptions;
-  await boss.updateQueue(name, payload);
+  // Full-field write, nulls included: concrete values defeat COALESCE staleness, and the nullable fields
+  // (deadLetter, retryDelayMax) apply by key presence, so a null clears them.
+  await boss.updateQueue(name, expected as UpdateQueueOptions);
   const reread = await boss.getQueue(name);
   const remaining = reread == null ? diffs : diffQueueConfig(expected, reread as unknown as Record<string, unknown>);
   if (remaining.length > 0) {

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -106,6 +106,17 @@ export interface MochiWorkerTuning {
   heartbeatRefreshSeconds?: number;
 }
 
+/**
+ * A queue reference usable as a `deadLetter` target: any descriptor returned by `Mochi.queue()`. Non-generic so a
+ * descriptor of any payload type fits.
+ */
+export interface MochiDeadLetterTarget {
+  readonly __mochiQueue: true;
+  readonly name: string;
+  readonly options?: MochiQueueRuntimeOptions;
+  readonly storage?: MochiQueueStorage;
+}
+
 /** The non-processor settings of a queue — what survives on `MochiQueueConfig.options`. */
 export interface MochiQueueRuntimeOptions {
   /** Jobs of this queue processed in parallel in this process. */
@@ -128,8 +139,11 @@ export interface MochiQueueRuntimeOptions {
   retentionSeconds?: number;
   /** Seconds a completed job is retained. bun-boss default: 7 days. */
   deleteAfterSeconds?: number;
-  /** Name of another queue in the same `queues` map; terminally failed jobs move there. */
-  deadLetter?: string;
+  /**
+   * Where terminally failed jobs move: another queue's descriptor (self-sufficient — the target is ensured before
+   * this queue, from any process), or its name, which must be declared in the same queues array or already exist in storage.
+   */
+  deadLetter?: string | MochiDeadLetterTarget;
 }
 
 /** The full config object passed to `Mochi.queue(name, { process, … })`. */
@@ -195,14 +209,14 @@ interface QueueRegistry {
   byName: Map<string, MochiQueue<unknown>>;
   /** Worker ids per queue, so adds from this process can skip the poll delay via `notifyWorker`. */
   workIds: Map<string, string>;
-  /** Who started the runtime: serve owns workers and the option re-sync; standalone is producer-only. */
+  /** Who started the runtime: serve owns workers; standalone is producer-only. */
   kind: 'serve' | 'standalone' | null;
   /** Storage the running boss was started with, for identity checks against later connect attempts. */
   storage: MochiQueueStorage | null;
   /** In-flight standalone boot, so concurrent first-adds share one `start()`. */
   starting: Promise<void> | null;
-  /** Per-queue ensure-exists memo for standalone producers. */
-  ensured: Map<string, Promise<void>>;
+  /** Per-queue create-and-verify memo, keyed by name; the value's `key` canonicalizes the verified declaration. */
+  ensured: Map<string, { key: string; promise: Promise<void> }>;
 }
 
 // Pinned so every duplicate bundled copy of this module shares one registry, since `closeAllQueueResources` must see
@@ -253,6 +267,95 @@ function describeStorage(storage: MochiQueueStorage | null): string {
 
 export const DEFAULT_EXPIRE_IN_SECONDS = 900;
 
+// Mirrors bun-boss 0.4.0's createQueue COALESCE defaults (its plans.ts): declared code is authoritative and an
+// undeclared option means "the default", so these are what it must read back as — re-verify on every bun-boss bump.
+const QUEUE_OPTION_DEFAULTS = {
+  retryLimit: 2,
+  retryDelay: 0,
+  retryBackoff: false,
+  retryDelayMax: null,
+  expireInSeconds: DEFAULT_EXPIRE_IN_SECONDS,
+  retentionSeconds: 1_209_600,
+  deleteAfterSeconds: 604_800,
+  deadLetter: null,
+} as const;
+type ManagedQueueField = keyof typeof QUEUE_OPTION_DEFAULTS;
+type ManagedQueueValue = number | boolean | string | null;
+
+export function isDeadLetterDescriptor(dl: string | MochiDeadLetterTarget | undefined): dl is MochiDeadLetterTarget {
+  return typeof dl === 'object' && dl !== null && dl.__mochiQueue === true;
+}
+
+export function deadLetterName(dl: string | MochiDeadLetterTarget | undefined): string | undefined {
+  return typeof dl === 'string' ? dl : dl?.name;
+}
+
+/** `MOCHI_QUEUE_SYNC=1` exists for one-shot migration deploys, so it is process-wide and wins over the code option. */
+export function resolveQueueConfigMode(declared?: 'verify' | 'sync'): 'verify' | 'sync' {
+  const env = process.env.MOCHI_QUEUE_SYNC;
+  return env === '1' || env === 'true' ? 'sync' : (declared ?? 'verify');
+}
+
+function expectedQueueOptions(bossOptions: UpdateQueueOptions): Record<ManagedQueueField, ManagedQueueValue> {
+  return { ...QUEUE_OPTION_DEFAULTS, ...bossOptions } as Record<ManagedQueueField, ManagedQueueValue>;
+}
+
+// The sqlite dialect can hand back 0/1 (or string) booleans and string-typed numerics; those must not read as drift.
+function normalizeStoredValue(field: ManagedQueueField, value: unknown): ManagedQueueValue {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (field === 'deadLetter') {
+    return String(value);
+  }
+  if (field === 'retryBackoff') {
+    return Boolean(typeof value === 'string' ? Number(value) : value);
+  }
+  return Number(value);
+}
+
+interface QueueConfigDiff {
+  field: ManagedQueueField;
+  stored: ManagedQueueValue;
+  declared: ManagedQueueValue;
+}
+
+function diffQueueConfig(expected: Record<ManagedQueueField, ManagedQueueValue>, stored: Record<string, unknown>): QueueConfigDiff[] {
+  const diffs: QueueConfigDiff[] = [];
+  for (const field of Object.keys(QUEUE_OPTION_DEFAULTS) as ManagedQueueField[]) {
+    const storedValue = normalizeStoredValue(field, stored[field]);
+    const declaredValue = expected[field] ?? null;
+    if (!Object.is(storedValue, declaredValue)) {
+      diffs.push({ field, stored: storedValue, declared: declaredValue });
+    }
+  }
+  return diffs;
+}
+
+function formatQueueValue(value: ManagedQueueValue): string {
+  if (value === null) {
+    return 'unset';
+  }
+  return typeof value === 'string' ? `"${value}"` : String(value);
+}
+
+function queueConfigMismatchError(context: string, name: string, diffs: QueueConfigDiff[]): Error {
+  const stored = diffs.map((d) => `${d.field} ${formatQueueValue(d.stored)}`).join(', ');
+  const declared = diffs.map((d) => `${d.field} ${formatQueueValue(d.declared)}`).join(', ');
+  const settable = diffs.filter((d) => d.declared !== null);
+  const unclearable = diffs.filter((d) => d.declared === null);
+  const hint = settable.map((d) => `${d.field}: ${typeof d.declared === 'string' ? `"${d.declared}"` : String(d.declared)}`).join(', ');
+  const remedy =
+    settable.length > 0
+      ? `update the declaration to match, migrate the store with Mochi.boss().updateQueue("${name}", { ${hint} }) and restart, or boot once with MOCHI_QUEUE_SYNC=1 (or queueConfig: 'sync') to apply the declared config`
+      : `update the declaration to match`;
+  let message = `${context}: "${name}" already exists in storage with ${stored}, but this code declares ${declared}. Code is authoritative for queue config — ${remedy}.`;
+  if (unclearable.length > 0) {
+    message += ` ${unclearable.map((d) => d.field).join(' and ')} cannot be cleared through bun-boss's updateQueue (absent fields keep their stored value) — keep declaring it, or reset the queue with Mochi.boss().deleteQueue("${name}") and reboot (this discards the queue's jobs).`;
+  }
+  return new Error(message);
+}
+
 // bun-boss's attorney asserts on key presence, not value, so an explicitly-undefined option must not reach it.
 function omitUndefined<T extends Record<string, unknown>>(obj: T): T {
   return Object.fromEntries(Object.entries(obj).filter(([, value]) => value !== undefined)) as T;
@@ -281,8 +384,17 @@ function toBossQueueOptions(name: string, options: MochiQueueRuntimeOptions | un
   // Sent only when declared or filter-overridden: an unchanged default stays omitted so a bare mount on shared durable
   // storage keeps (not resets) another deployment's stored expiry, matching every other option's COALESCE semantics.
   const expireInSeconds = declared !== undefined || filtered !== DEFAULT_EXPIRE_IN_SECONDS ? filtered : undefined;
-  const { retryLimit, retryDelay, retryBackoff, retryDelayMax, retentionSeconds, deleteAfterSeconds, deadLetter } = options ?? {};
-  return omitUndefined({ expireInSeconds, retryLimit, retryDelay, retryBackoff, retryDelayMax, retentionSeconds, deleteAfterSeconds, deadLetter });
+  const { retryLimit, retryDelay, retryBackoff, retryDelayMax, retentionSeconds, deleteAfterSeconds } = options ?? {};
+  return omitUndefined({
+    expireInSeconds,
+    retryLimit,
+    retryDelay,
+    retryBackoff,
+    retryDelayMax,
+    retentionSeconds,
+    deleteAfterSeconds,
+    deadLetter: deadLetterName(options?.deadLetter),
+  });
 }
 
 function requireBoss(): BunBoss {
@@ -322,8 +434,8 @@ export async function startQueueRuntime(storage: MochiQueueStorage, opts?: { kin
   if (registry.boss) {
     if (kind === 'serve' && registry.kind === 'standalone') {
       assertNoConflictingStandaloneRuntime(storage);
-      // Serve adopts a standalone producer runtime on the same storage; mountQueues then layers workers and the
-      // option re-sync on top of it. Producer handles reset so only queues the serve declares stay producible —
+      // Serve adopts a standalone producer runtime on the same storage; mountQueues then layers workers and its own
+      // config verification on top of it. Producer handles reset so only queues the serve declares stay producible —
       // otherwise whether an undeclared queue can produce would depend on whether it raced the boot.
       registry.kind = 'serve';
       registry.byName.clear();
@@ -530,7 +642,7 @@ async function ensureUsable(descriptor: MountableQueue): Promise<void> {
   } else if (!registry.byName.has(name)) {
     throw noStorageError(name);
   }
-  await ensureQueueExists(name, descriptor.options);
+  await verifyOrCreateQueues([descriptor], `Mochi.queue("${name}")`, resolveQueueConfigMode());
   // Re-checked after the await: a serve boot may have adopted the runtime mid-ensure, and registering an undeclared
   // producer past the adoption would make producibility depend on who won that race.
   assertProducibleUnderServe(name);
@@ -575,79 +687,78 @@ async function stopQueue(name: string): Promise<void> {
   }
 }
 
-// Create the queue if it's missing, remembering the attempt so it runs once. createQueue leaves an existing queue as
-// it is and the standalone paths never update it, so options a Mochi.serve() app set are left alone.
-function ensureQueueCreated(name: string, createOptions: UpdateQueueOptions): Promise<void> {
-  let ensured = registry.ensured.get(name);
-  if (!ensured) {
-    ensured = requireBoss()
-      .createQueue(name, createOptions)
-      .catch((err: unknown) => {
-        registry.ensured.delete(name);
-        throw err;
-      });
-    registry.ensured.set(name, ensured);
-  }
-  return ensured;
+interface DeclaredQueueEntry {
+  name: string;
+  bossOptions: UpdateQueueOptions;
+  /** Reached only as a descriptor-form deadLetter target: ensured and verified, never registered as producer/worker. */
+  implicit: boolean;
 }
 
-// The producer path (a bare `queue.add()`) only knows the queue being added to, not the deadLetter queue it points at,
-// so it can't tell whether that target exists yet — drop the link (createQueue errors on a missing target). A worker
-// knows its whole queues list, so ensureWorkerQueues keeps the link.
-async function ensureQueueExists(name: string, options: MochiQueueRuntimeOptions | undefined): Promise<void> {
-  const { deadLetter: _, ...createOptions } = toBossQueueOptions(name, options);
-  await ensureQueueCreated(name, createOptions);
+function declarationKey(bossOptions: UpdateQueueOptions): string {
+  return JSON.stringify(Object.fromEntries(Object.entries(bossOptions).sort(([a], [b]) => (a < b ? -1 : 1))));
 }
 
-// Create the worker's queues. When a queue names another of this worker's queues as its deadLetter, set that link as
-// the queue is created (creating the target first, since it must exist). Only a brand-new queue gets the link — an
-// existing one is left as it is; a deadLetter naming a queue this worker doesn't list is skipped with a warning, and a
-// queue naming itself throws, as Mochi.serve() does.
-async function ensureWorkerQueues(queues: MountableQueue[]): Promise<void> {
-  const declared = new Set(queues.map((q) => q.name));
-  const resolved = queues.map((q) => {
+// Resolve the declared queues plus every descriptor-form deadLetter target, recursively — the closure is what lets a
+// lone producer create its queue with the link intact (the target is known and ensured first).
+function collectQueueClosure(queues: MountableQueue[], context: string): DeclaredQueueEntry[] {
+  const entries = new Map<string, DeclaredQueueEntry>();
+  const pending: Array<{ q: MountableQueue; implicit: boolean; referrer?: string }> = queues.map((q) => ({ q, implicit: false }));
+  while (pending.length > 0) {
+    const { q, implicit, referrer } = pending.shift()!;
     const bossOptions = toBossQueueOptions(q.name, q.options);
-    const deadLetter = bossOptions.deadLetter;
-    if (deadLetter === undefined) {
-      return { name: q.name, bossOptions };
-    }
-    if (deadLetter === q.name) {
-      throw new Error(`Mochi.worker(): "${q.name}" names itself as its deadLetter queue.`);
-    }
-    if (!declared.has(deadLetter)) {
-      logger.warn(
-        `[queue] "${q.name}" names "${deadLetter}" as its deadLetter queue, but no queue named "${deadLetter}" is in this worker's queues array — the link is skipped. Declare it where "${deadLetter}" is mounted.`,
-      );
-      return { name: q.name, bossOptions: withoutDeadLetter(bossOptions) };
-    }
-    return { name: q.name, bossOptions };
-  });
-  const boss = requireBoss();
-  for (const { name, bossOptions } of orderByDeadLetter(resolved)) {
-    await ensureQueueCreated(name, bossOptions);
-    // createQueue skips a queue that already exists, so one left from an earlier deploy (or a producer add in this
-    // process) keeps the deadLetter it was stored with — warn that the declared link wasn't applied rather than dropping it silently.
-    if (bossOptions.deadLetter !== undefined) {
-      const stored = (await boss.getQueue(name))?.deadLetter ?? undefined;
-      if (stored !== bossOptions.deadLetter) {
-        logger.warn(
-          `[queue] "${name}" declares "${bossOptions.deadLetter}" as its deadLetter queue, but the queue already exists ${stored ? `linked to "${stored}"` : 'without a deadLetter link'} — a worker only sets the link when it first creates the queue. Migrate with Mochi.boss().updateQueue("${name}", { deadLetter: "${bossOptions.deadLetter}" }).`,
+    const existing = entries.get(q.name);
+    if (existing) {
+      if (declarationKey(existing.bossOptions) !== declarationKey(bossOptions)) {
+        throw new Error(
+          `${context}: "${q.name}" is declared twice with different options${referrer ? ` — once directly and once as "${referrer}"'s deadLetter descriptor` : ''}. Share one descriptor.`,
         );
       }
+      existing.implicit &&= implicit;
+      continue;
+    }
+    entries.set(q.name, { name: q.name, bossOptions, implicit });
+    const dl = q.options?.deadLetter;
+    if (deadLetterName(dl) === q.name) {
+      throw new Error(`${context}: "${q.name}" names itself as its deadLetter queue.`);
+    }
+    if (isDeadLetterDescriptor(dl)) {
+      if (dl.storage !== undefined && !storageEquals(registry.storage, dl.storage)) {
+        throw storageMismatchError(dl.name, dl.storage);
+      }
+      pending.push({ q: { name: dl.name, options: dl.options, storage: dl.storage }, implicit: true, referrer: q.name });
     }
   }
+  return [...entries.values()];
 }
 
-function withoutDeadLetter(options: UpdateQueueOptions): UpdateQueueOptions {
-  const { deadLetter: _, ...rest } = options;
-  return rest;
+/** Every `(name, storage)` declaration in the queues array and its descriptor-form deadLetter closure, for the one-storage scan. */
+export function collectQueueStorageDeclarations(queues: MountableQueue[]): Array<{ name: string; storage: MochiQueueStorage }> {
+  const out: Array<{ name: string; storage: MochiQueueStorage }> = [];
+  const seen = new Set<string>();
+  const pending = [...queues];
+  while (pending.length > 0) {
+    const q = pending.shift()!;
+    if (seen.has(q.name)) {
+      continue;
+    }
+    seen.add(q.name);
+    if (q.storage !== undefined) {
+      out.push({ name: q.name, storage: q.storage });
+    }
+    const dl = q.options?.deadLetter;
+    if (isDeadLetterDescriptor(dl)) {
+      pending.push({ name: dl.name, options: dl.options, storage: dl.storage });
+    }
+  }
+  return out;
 }
 
 // Order the queues so each deadLetter target comes before the queue pointing at it, since createQueue needs the target
-// to already exist. Anything left over points in a loop (A→B→A), which can't be built from scratch — create those
-// without the link and warn.
-function orderByDeadLetter(items: { name: string; bossOptions: UpdateQueueOptions }[]): { name: string; bossOptions: UpdateQueueOptions }[] {
-  const ordered: { name: string; bossOptions: UpdateQueueOptions }[] = [];
+// to already exist. A target outside the closure is external — its referrer orders freely and the FK decides at create
+// time. Leftovers point in a loop (A→B→A), which cannot be built from scratch; the caller verifies those against storage.
+function orderByDeadLetter(items: DeclaredQueueEntry[]): { ordered: DeclaredQueueEntry[]; cyclic: DeclaredQueueEntry[] } {
+  const names = new Set(items.map((item) => item.name));
+  const ordered: DeclaredQueueEntry[] = [];
   const emitted = new Set<string>();
   let progressed = true;
   while (progressed) {
@@ -657,26 +768,93 @@ function orderByDeadLetter(items: { name: string; bossOptions: UpdateQueueOption
         continue;
       }
       const target = item.bossOptions.deadLetter;
-      if (target === undefined || emitted.has(target)) {
+      if (target === undefined || !names.has(target) || emitted.has(target)) {
         ordered.push(item);
         emitted.add(item.name);
         progressed = true;
       }
     }
   }
-  const cyclic = items.filter((item) => !emitted.has(item.name));
+  return { ordered, cyclic: items.filter((item) => !emitted.has(item.name)) };
+}
+
+/**
+ * The one rule for every path (serve, worker, standalone producer): create each declared queue with its full config,
+ * read it back, and require storage to match the declaration — code is authoritative, storage is a cache of it.
+ * A declaration with no persisted options is a pure existence reference and skips the comparison.
+ */
+async function verifyOrCreateQueues(queues: MountableQueue[], context: string, mode: 'verify' | 'sync'): Promise<DeclaredQueueEntry[]> {
+  const boss = requireBoss();
+  const entries = collectQueueClosure(queues, context);
+  const { ordered, cyclic } = orderByDeadLetter(entries);
   if (cyclic.length > 0) {
-    // One warning for the whole loop, not one per queue. A worker can't build a deadLetter loop (createQueue needs each
-    // target to exist first), while Mochi.serve() can — it creates every queue, then adds the links — so use serve for loops.
-    logger.warn(
-      `[queue] deadLetter loop among ${cyclic.map((item) => `"${item.name}"`).join(', ')} — created without their links; a worker cannot create a deadLetter loop (mount these under Mochi.serve() if you need it).`,
-    );
-    for (const item of cyclic) {
-      ordered.push({ name: item.name, bossOptions: withoutDeadLetter(item.bossOptions) });
-      emitted.add(item.name);
+    const rows = await Promise.all(cyclic.map((item) => boss.getQueue(item.name)));
+    if (rows.some((row) => row == null)) {
+      throw new Error(
+        `${context}: deadLetter loop among ${cyclic.map((item) => `"${item.name}"`).join(', ')} — these queues do not all exist in storage yet, and a loop cannot be created from scratch (each deadLetter target must exist before its referrer). Create them once via Mochi.boss().createQueue()/updateQueue(); an existing loop that matches the declaration passes.`,
+      );
     }
+    // Every member exists, so createQueue is a no-op and only the verification below runs.
+    ordered.push(...cyclic);
   }
-  return ordered;
+  for (const entry of ordered) {
+    const key = declarationKey(entry.bossOptions);
+    const memo = registry.ensured.get(entry.name);
+    if (memo && memo.key === key) {
+      await memo.promise;
+      continue;
+    }
+    const promise = verifyOrCreateQueue(boss, entry, context, mode).catch((err: unknown) => {
+      registry.ensured.delete(entry.name);
+      throw err;
+    });
+    registry.ensured.set(entry.name, { key, promise });
+    await promise;
+  }
+  return entries;
+}
+
+async function verifyOrCreateQueue(boss: BunBoss, entry: DeclaredQueueEntry, context: string, mode: 'verify' | 'sync'): Promise<void> {
+  const { name, bossOptions } = entry;
+  try {
+    await boss.createQueue(name, bossOptions);
+  } catch (err) {
+    const target = bossOptions.deadLetter;
+    if (target !== undefined && (await boss.getQueue(target).catch(() => null)) == null) {
+      throw new Error(
+        `${context}: "${name}" names "${target}" as its deadLetter queue, but "${target}" is not declared here and does not exist in storage, so "${name}" cannot be created with its link. Pass the target's descriptor — deadLetter: Mochi.queue("${target}", …) — so it is ensured first.`,
+        { cause: err },
+      );
+    }
+    throw err;
+  }
+  if (Object.keys(bossOptions).length === 0) {
+    return;
+  }
+  const stored = await boss.getQueue(name);
+  if (!stored) {
+    throw new Error(`${context}: could not read back queue "${name}" after creating it.`);
+  }
+  const expected = expectedQueueOptions(bossOptions);
+  const diffs = diffQueueConfig(expected, stored as unknown as Record<string, unknown>);
+  if (diffs.length === 0) {
+    return;
+  }
+  // A declared-unset field can't be repaired either way: updateQueue keeps stored values for absent fields.
+  if (mode === 'verify' || diffs.some((d) => d.declared === null)) {
+    throw queueConfigMismatchError(context, name, diffs);
+  }
+  // Full-field write of concrete values so COALESCE semantics can't keep a stale one.
+  const payload = omitUndefined(Object.fromEntries(Object.entries(expected).map(([k, v]) => [k, v === null ? undefined : v]))) as UpdateQueueOptions;
+  await boss.updateQueue(name, payload);
+  const reread = await boss.getQueue(name);
+  const remaining = reread == null ? diffs : diffQueueConfig(expected, reread as unknown as Record<string, unknown>);
+  if (remaining.length > 0) {
+    throw queueConfigMismatchError(context, name, remaining);
+  }
+  logger.warn(
+    `[queue] "${name}": synced stored config to the declaration — ${diffs.map((d) => `${d.field} ${formatQueueValue(d.stored)} → ${formatQueueValue(d.declared)}`).join(', ')}.`,
+  );
 }
 
 /** Implements `Mochi.queue(name, config)` — see its JSDoc there. */
@@ -740,25 +918,12 @@ export function createQueueDescriptor<T = unknown, R = unknown>(name: string, co
  * Mount every queue declared in `Mochi.serve({ queues })` on the running boss: ensure each exists with its declared
  * config, then start a worker for each that has a processor.
  */
-export async function mountQueues(queues: MountableQueue[]): Promise<void> {
+export async function mountQueues(queues: MountableQueue[], mode: 'verify' | 'sync' = 'verify'): Promise<void> {
   const boss = requireBoss();
-  const resolved = queues.map((config) => ({ name: config.name, config, bossOptions: toBossQueueOptions(config.name, config.options) }));
-  // createQueue validates that a deadLetter target already exists and is ON CONFLICT DO NOTHING, so pass 1 creates
-  // every queue without deadLetter and pass 2 updates with the full set — declaration order stops mattering. The
-  // re-sync is additive only: updateQueue COALESCEs absent keys, so an option *removed* from code (deadLetter
-  // included — bun-boss can't yet clear it) keeps its persisted value on durable storage.
-  for (const { name, bossOptions } of resolved) {
-    const { deadLetter: _, ...createOptions } = bossOptions;
-    await boss.createQueue(name, createOptions);
-  }
-  for (const { name, bossOptions } of resolved) {
-    // A queue declaring nothing has nothing to re-sync (bun-boss asserts on an empty update).
-    if (Object.keys(bossOptions).length > 0) {
-      await boss.updateQueue(name, bossOptions);
-    }
-  }
-  for (const { name, config } of resolved) {
-    registry.byName.set(name, producerMethods(name));
+  await verifyOrCreateQueues(queues, 'Mochi.serve({ queues })', mode);
+  // Only the declared array is registered — implicit descriptor-form deadLetter targets are ensured, not mounted.
+  for (const config of queues) {
+    registry.byName.set(config.name, producerMethods(config.name));
     if (config.process) {
       await registerQueueWorker(boss, config);
     }
@@ -792,7 +957,7 @@ export interface MochiWorker {
 }
 
 /** Implements `Mochi.worker(options)` — see its JSDoc there. */
-export function createWorker(queues: MountableQueue[], storage?: MochiQueueStorage): MochiWorker {
+export function createWorker(queues: MountableQueue[], storage?: MochiQueueStorage, queueConfig?: 'verify' | 'sync'): MochiWorker {
   if (queues.length === 0) {
     throw new Error('Mochi.worker(): declare at least one queue.');
   }
@@ -850,7 +1015,7 @@ export function createWorker(queues: MountableQueue[], storage?: MochiQueueStora
           );
         }
         const boss = requireBoss();
-        await ensureWorkerQueues(queues);
+        await verifyOrCreateQueues(queues, 'Mochi.worker()', resolveQueueConfigMode(queueConfig));
         for (const q of queues) {
           if (!registry.byName.has(q.name)) {
             registry.byName.set(q.name, producerMethods(q.name));

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -215,8 +215,6 @@ interface QueueRegistry {
   storage: MochiQueueStorage | null;
   /** In-flight standalone boot, so concurrent first-adds share one `start()`. */
   starting: Promise<void> | null;
-  /** Per-queue create-and-verify memo, keyed by name; the value's `key` canonicalizes the verified declaration. */
-  ensured: Map<string, { key: string; promise: Promise<void> }>;
 }
 
 // Pinned so every duplicate bundled copy of this module shares one registry, since `closeAllQueueResources` must see
@@ -229,7 +227,6 @@ const registry = pinGlobal<QueueRegistry>('__mochi_queue_registry__', () => ({
   kind: null,
   storage: null,
   starting: null,
-  ensured: new Map(),
 }));
 
 export function storageEquals(a: MochiQueueStorage | null, b: MochiQueueStorage): boolean {
@@ -282,11 +279,11 @@ const QUEUE_OPTION_DEFAULTS = {
 type ManagedQueueField = keyof typeof QUEUE_OPTION_DEFAULTS;
 type ManagedQueueValue = number | boolean | string | null;
 
-export function isDeadLetterDescriptor(dl: string | MochiDeadLetterTarget | undefined): dl is MochiDeadLetterTarget {
+function isDeadLetterDescriptor(dl: string | MochiDeadLetterTarget | undefined): dl is MochiDeadLetterTarget {
   return typeof dl === 'object' && dl !== null && dl.__mochiQueue === true;
 }
 
-export function deadLetterName(dl: string | MochiDeadLetterTarget | undefined): string | undefined {
+function deadLetterName(dl: string | MochiDeadLetterTarget | undefined): string | undefined {
   return typeof dl === 'string' ? dl : dl?.name;
 }
 
@@ -294,10 +291,6 @@ export function deadLetterName(dl: string | MochiDeadLetterTarget | undefined): 
 export function resolveQueueConfigMode(declared?: 'verify' | 'sync'): 'verify' | 'sync' {
   const env = process.env.MOCHI_QUEUE_SYNC;
   return env === '1' || env === 'true' ? 'sync' : (declared ?? 'verify');
-}
-
-function expectedQueueOptions(bossOptions: UpdateQueueOptions): Record<ManagedQueueField, ManagedQueueValue> {
-  return { ...QUEUE_OPTION_DEFAULTS, ...bossOptions } as Record<ManagedQueueField, ManagedQueueValue>;
 }
 
 // The sqlite dialect can hand back 0/1 (or string) booleans and string-typed numerics; those must not read as drift.
@@ -439,7 +432,6 @@ export async function startQueueRuntime(storage: MochiQueueStorage, opts?: { kin
       // otherwise whether an undeclared queue can produce would depend on whether it raced the boot.
       registry.kind = 'serve';
       registry.byName.clear();
-      registry.ensured.clear();
       return;
     }
     if (kind === 'standalone') {
@@ -611,7 +603,7 @@ function storageMismatchError(name: string, storage: MochiQueueStorage): Error {
 }
 
 /**
- * Make a descriptor's producer methods callable: a no-op when the queue is already mounted/ensured, otherwise the lazy
+ * Make a descriptor's producer methods callable: a no-op when the queue is already mounted, otherwise the lazy
  * standalone path — boot a producer-only runtime against the descriptor's storage and ensure the queue exists.
  */
 async function ensureUsable(descriptor: MountableQueue): Promise<void> {
@@ -680,7 +672,6 @@ async function stopQueue(name: string): Promise<void> {
     registry.workIds.delete(name);
   }
   registry.byName.delete(name);
-  registry.ensured.delete(name);
   // The runtime is shared, so it closes only when the last active queue lets go.
   if (registry.byName.size === 0) {
     await closeAllQueueResources();
@@ -690,21 +681,25 @@ async function stopQueue(name: string): Promise<void> {
 interface DeclaredQueueEntry {
   name: string;
   bossOptions: UpdateQueueOptions;
-  /** Reached only as a descriptor-form deadLetter target: ensured and verified, never registered as producer/worker. */
-  implicit: boolean;
+  storage?: MochiQueueStorage;
 }
 
 function declarationKey(bossOptions: UpdateQueueOptions): string {
   return JSON.stringify(Object.fromEntries(Object.entries(bossOptions).sort(([a], [b]) => (a < b ? -1 : 1))));
 }
 
-// Resolve the declared queues plus every descriptor-form deadLetter target, recursively — the closure is what lets a
-// lone producer create its queue with the link intact (the target is known and ensured first).
-function collectQueueClosure(queues: MountableQueue[], context: string): DeclaredQueueEntry[] {
+/**
+ * Resolve the declared queues plus every descriptor-form deadLetter target, recursively — the closure is what lets a
+ * lone producer create its queue with the link intact (the target is known and ensured first). Also validates
+ * self-references and conflicting duplicate declarations. Pure, so the serve prelude can check the same graph
+ * pre-bind (the dup check compares filter-shaped options, but both sides pass through the same filter, so its verdict
+ * is the same whether or not extensions are initialized yet).
+ */
+export function collectQueueClosure(queues: MountableQueue[], context: string): DeclaredQueueEntry[] {
   const entries = new Map<string, DeclaredQueueEntry>();
-  const pending: Array<{ q: MountableQueue; implicit: boolean; referrer?: string }> = queues.map((q) => ({ q, implicit: false }));
+  const pending: Array<{ q: MountableQueue; referrer?: string }> = queues.map((q) => ({ q }));
   while (pending.length > 0) {
-    const { q, implicit, referrer } = pending.shift()!;
+    const { q, referrer } = pending.shift()!;
     const bossOptions = toBossQueueOptions(q.name, q.options);
     const existing = entries.get(q.name);
     if (existing) {
@@ -713,44 +708,18 @@ function collectQueueClosure(queues: MountableQueue[], context: string): Declare
           `${context}: "${q.name}" is declared twice with different options${referrer ? ` — once directly and once as "${referrer}"'s deadLetter descriptor` : ''}. Share one descriptor.`,
         );
       }
-      existing.implicit &&= implicit;
       continue;
     }
-    entries.set(q.name, { name: q.name, bossOptions, implicit });
+    entries.set(q.name, { name: q.name, bossOptions, storage: q.storage });
     const dl = q.options?.deadLetter;
     if (deadLetterName(dl) === q.name) {
       throw new Error(`${context}: "${q.name}" names itself as its deadLetter queue.`);
     }
     if (isDeadLetterDescriptor(dl)) {
-      if (dl.storage !== undefined && !storageEquals(registry.storage, dl.storage)) {
-        throw storageMismatchError(dl.name, dl.storage);
-      }
-      pending.push({ q: { name: dl.name, options: dl.options, storage: dl.storage }, implicit: true, referrer: q.name });
+      pending.push({ q: { name: dl.name, options: dl.options, storage: dl.storage }, referrer: q.name });
     }
   }
   return [...entries.values()];
-}
-
-/** Every `(name, storage)` declaration in the queues array and its descriptor-form deadLetter closure, for the one-storage scan. */
-export function collectQueueStorageDeclarations(queues: MountableQueue[]): Array<{ name: string; storage: MochiQueueStorage }> {
-  const out: Array<{ name: string; storage: MochiQueueStorage }> = [];
-  const seen = new Set<string>();
-  const pending = [...queues];
-  while (pending.length > 0) {
-    const q = pending.shift()!;
-    if (seen.has(q.name)) {
-      continue;
-    }
-    seen.add(q.name);
-    if (q.storage !== undefined) {
-      out.push({ name: q.name, storage: q.storage });
-    }
-    const dl = q.options?.deadLetter;
-    if (isDeadLetterDescriptor(dl)) {
-      pending.push({ name: dl.name, options: dl.options, storage: dl.storage });
-    }
-  }
-  return out;
 }
 
 // Order the queues so each deadLetter target comes before the queue pointing at it, since createQueue needs the target
@@ -783,7 +752,7 @@ function orderByDeadLetter(items: DeclaredQueueEntry[]): { ordered: DeclaredQueu
  * read it back, and require storage to match the declaration — code is authoritative, storage is a cache of it.
  * A declaration with no persisted options is a pure existence reference and skips the comparison.
  */
-async function verifyOrCreateQueues(queues: MountableQueue[], context: string, mode: 'verify' | 'sync'): Promise<DeclaredQueueEntry[]> {
+async function verifyOrCreateQueues(queues: MountableQueue[], context: string, mode: 'verify' | 'sync'): Promise<void> {
   const boss = requireBoss();
   const entries = collectQueueClosure(queues, context);
   const { ordered, cyclic } = orderByDeadLetter(entries);
@@ -797,25 +766,18 @@ async function verifyOrCreateQueues(queues: MountableQueue[], context: string, m
     // Every member exists, so createQueue is a no-op and only the verification below runs.
     ordered.push(...cyclic);
   }
+  // Idempotent per queue (createQueue is ON CONFLICT DO NOTHING, verification is a read), so no memoization: a queue
+  // reached twice — a shared deadLetter target, a redundant boot — just re-verifies.
   for (const entry of ordered) {
-    const key = declarationKey(entry.bossOptions);
-    const memo = registry.ensured.get(entry.name);
-    if (memo && memo.key === key) {
-      await memo.promise;
-      continue;
-    }
-    const promise = verifyOrCreateQueue(boss, entry, context, mode).catch((err: unknown) => {
-      registry.ensured.delete(entry.name);
-      throw err;
-    });
-    registry.ensured.set(entry.name, { key, promise });
-    await promise;
+    await verifyOrCreateQueue(boss, entry, context, mode);
   }
-  return entries;
 }
 
 async function verifyOrCreateQueue(boss: BunBoss, entry: DeclaredQueueEntry, context: string, mode: 'verify' | 'sync'): Promise<void> {
   const { name, bossOptions } = entry;
+  if (entry.storage !== undefined && !storageEquals(registry.storage, entry.storage)) {
+    throw storageMismatchError(name, entry.storage);
+  }
   try {
     await boss.createQueue(name, bossOptions);
   } catch (err) {
@@ -835,7 +797,7 @@ async function verifyOrCreateQueue(boss: BunBoss, entry: DeclaredQueueEntry, con
   if (!stored) {
     throw new Error(`${context}: could not read back queue "${name}" after creating it.`);
   }
-  const expected = expectedQueueOptions(bossOptions);
+  const expected = { ...QUEUE_OPTION_DEFAULTS, ...bossOptions } as Record<ManagedQueueField, ManagedQueueValue>;
   const diffs = diffQueueConfig(expected, stored as unknown as Record<string, unknown>);
   if (diffs.length === 0) {
     return;
@@ -1092,7 +1054,6 @@ export async function closeAllQueueResources(): Promise<void> {
   registry.starting = null;
   registry.byName.clear();
   registry.workIds.clear();
-  registry.ensured.clear();
   if (boss) {
     try {
       await boss.stop({ graceful: true, timeout: 10_000 });

--- a/packages/mochi/src/queueConfigAuthority.test.ts
+++ b/packages/mochi/src/queueConfigAuthority.test.ts
@@ -85,7 +85,7 @@ describe('code-authoritative queue config', () => {
     expect(resolveQueueConfigMode('sync')).toBe('sync');
   }, 15_000);
 
-  test('clearing a stored deadLetter cannot be synced: even sync mode throws, pointing at the reset recipe', async () => {
+  test('removing a declared deadLetter throws under verify with a null hint, and sync clears it', async () => {
     const file = path.join(dataDir, 'clear.sqlite');
     await startQueueRuntime({ sqlite: file });
     await mountQueues([{ name: 'clear-dlq' }, { name: 'clear-work', options: { retryLimit: 0, deadLetter: 'clear-dlq' } }]);
@@ -94,10 +94,12 @@ describe('code-authoritative queue config', () => {
 
     await startQueueRuntime({ sqlite: file });
     let error: Error | undefined;
-    await mountQueues([{ name: 'clear-dlq' }, { name: 'clear-work', options: { retryLimit: 0 } }], 'sync').catch((err: Error) => (error = err));
+    await mountQueues([{ name: 'clear-dlq' }, { name: 'clear-work', options: { retryLimit: 0 } }]).catch((err: Error) => (error = err));
     expect(error?.message).toContain('"clear-work" already exists in storage with deadLetter "clear-dlq", but this code declares deadLetter unset');
-    expect(error?.message).toContain('deadLetter cannot be cleared');
-    expect(error?.message).toContain('Mochi.boss().deleteQueue("clear-work")');
+    expect(error?.message).toContain('Mochi.boss().updateQueue("clear-work", { deadLetter: null })');
+
+    await mountQueues([{ name: 'clear-dlq' }, { name: 'clear-work', options: { retryLimit: 0 } }], 'sync');
+    expect((await getBoss().getQueue('clear-work'))?.deadLetter).toBeNull();
   }, 15_000);
 
   test('a deadLetter loop cannot be created from scratch, but an existing matching loop passes verification', async () => {

--- a/packages/mochi/src/queueConfigAuthority.test.ts
+++ b/packages/mochi/src/queueConfigAuthority.test.ts
@@ -1,0 +1,133 @@
+import { afterAll, afterEach, describe, expect, spyOn, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { Mochi } from './Mochi';
+import { startQueueRuntime, mountQueues, getBoss, closeAllQueueResources, resolveQueueConfigMode } from './queue';
+import { mochiEvents } from './events';
+import { initExtensions } from './extensions';
+import { resetStartupMilestones } from './lifecycle';
+import { logger } from './utils/log';
+
+const dataDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-queue-authority-'));
+
+afterEach(async () => {
+  mochiEvents.all.clear();
+  resetStartupMilestones();
+  initExtensions({});
+  await closeAllQueueResources();
+});
+
+afterAll(async () => {
+  for (let attempt = 0; attempt < 25; attempt++) {
+    try {
+      rmSync(dataDir, { recursive: true, force: true });
+      return;
+    } catch {
+      await Bun.sleep(100);
+    }
+  }
+});
+
+describe('code-authoritative queue config', () => {
+  test('an identical remount passes; a differing one throws naming the queue, fields, and both migration levers', async () => {
+    const file = path.join(dataDir, 'mismatch.sqlite');
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'strict', options: { retryLimit: 3, retryDelay: 5 } }]);
+    await closeAllQueueResources();
+
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'strict', options: { retryLimit: 3, retryDelay: 5 } }]);
+    await closeAllQueueResources();
+
+    await startQueueRuntime({ sqlite: file });
+    let error: Error | undefined;
+    await mountQueues([{ name: 'strict', options: { retryLimit: 5, retryDelay: 5 } }]).catch((err: Error) => (error = err));
+    expect(error?.message).toContain('Mochi.serve({ queues }): "strict" already exists in storage with retryLimit 3, but this code declares retryLimit 5');
+    expect(error?.message).toContain('Mochi.boss().updateQueue("strict", { retryLimit: 5 })');
+    expect(error?.message).toContain("MOCHI_QUEUE_SYNC=1 (or queueConfig: 'sync')");
+  }, 15_000);
+
+  test('a boolean option does not read as drift on sqlite', async () => {
+    const file = path.join(dataDir, 'boolean.sqlite');
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'backoff', options: { retryBackoff: true, retryDelay: 1 } }]);
+    await closeAllQueueResources();
+
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'backoff', options: { retryBackoff: true, retryDelay: 1 } }]);
+    expect((await getBoss().getQueue('backoff'))?.retryBackoff).toBeTruthy();
+  }, 15_000);
+
+  test('sync mode repairs drift and logs each field; the env var forces sync over the code option', async () => {
+    const file = path.join(dataDir, 'sync.sqlite');
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'drifted', options: { retryLimit: 3 } }]);
+    await closeAllQueueResources();
+
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      await startQueueRuntime({ sqlite: file });
+      await mountQueues([{ name: 'drifted', options: { retryLimit: 9 } }], 'sync');
+      expect((await getBoss().getQueue('drifted'))?.retryLimit).toBe(9);
+      expect(warn.mock.calls.some((args) => String(args[0]).includes('"drifted": synced stored config to the declaration — retryLimit 3 → 9'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
+
+    process.env.MOCHI_QUEUE_SYNC = '1';
+    try {
+      expect(resolveQueueConfigMode('verify')).toBe('sync');
+      expect(resolveQueueConfigMode()).toBe('sync');
+    } finally {
+      delete process.env.MOCHI_QUEUE_SYNC;
+    }
+    expect(resolveQueueConfigMode()).toBe('verify');
+    expect(resolveQueueConfigMode('sync')).toBe('sync');
+  }, 15_000);
+
+  test('clearing a stored deadLetter cannot be synced: even sync mode throws, pointing at the reset recipe', async () => {
+    const file = path.join(dataDir, 'clear.sqlite');
+    await startQueueRuntime({ sqlite: file });
+    await mountQueues([{ name: 'clear-dlq' }, { name: 'clear-work', options: { retryLimit: 0, deadLetter: 'clear-dlq' } }]);
+    expect((await getBoss().getQueue('clear-work'))?.deadLetter).toBe('clear-dlq');
+    await closeAllQueueResources();
+
+    await startQueueRuntime({ sqlite: file });
+    let error: Error | undefined;
+    await mountQueues([{ name: 'clear-dlq' }, { name: 'clear-work', options: { retryLimit: 0 } }], 'sync').catch((err: Error) => (error = err));
+    expect(error?.message).toContain('"clear-work" already exists in storage with deadLetter "clear-dlq", but this code declares deadLetter unset');
+    expect(error?.message).toContain('deadLetter cannot be cleared');
+    expect(error?.message).toContain('Mochi.boss().deleteQueue("clear-work")');
+  }, 15_000);
+
+  test('a deadLetter loop cannot be created from scratch, but an existing matching loop passes verification', async () => {
+    const file = path.join(dataDir, 'loop.sqlite');
+    const loop = () => [
+      { name: 'loop-a', options: { deadLetter: 'loop-b' } },
+      { name: 'loop-b', options: { deadLetter: 'loop-a' } },
+    ];
+    await startQueueRuntime({ sqlite: file });
+    let error: Error | undefined;
+    await mountQueues(loop()).catch((err: Error) => (error = err));
+    expect(error?.message).toContain('deadLetter loop among "loop-a", "loop-b"');
+    expect(error?.message).toContain('cannot be created from scratch');
+
+    // Build the loop by hand, as the error suggests, and remount: matching storage passes.
+    await getBoss().createQueue('loop-a');
+    await getBoss().createQueue('loop-b', { deadLetter: 'loop-a' });
+    await getBoss().updateQueue('loop-a', { deadLetter: 'loop-b' });
+    await mountQueues(loop());
+    expect((await getBoss().getQueue('loop-a'))?.deadLetter).toBe('loop-b');
+    expect((await getBoss().getQueue('loop-b'))?.deadLetter).toBe('loop-a');
+  }, 15_000);
+
+  test('the same name declared directly and as a differing descriptor deadLetter is rejected', async () => {
+    const file = path.join(dataDir, 'dup.sqlite');
+    await startQueueRuntime({ sqlite: file });
+    const target = Mochi.queue('dup-dlq', { retryLimit: 5 });
+    let error: Error | undefined;
+    await mountQueues([{ name: 'dup-dlq' }, { name: 'dup-work', options: { deadLetter: target } }]).catch((err: Error) => (error = err));
+    expect(error?.message).toContain('"dup-dlq" is declared twice with different options');
+    expect(error?.message).toContain('once directly and once as "dup-work"\'s deadLetter descriptor');
+  }, 15_000);
+});

--- a/packages/mochi/src/queueStandalone.test.ts
+++ b/packages/mochi/src/queueStandalone.test.ts
@@ -115,21 +115,45 @@ describe('standalone queue producers', () => {
     expect(await q.add({ n: 3 })).toBeString();
   });
 
-  test('a standalone producer never re-syncs consumer-owned queue options', async () => {
+  test('a bare producer is an existence reference: stored options survive, while a differing declaration is rejected', async () => {
     const name = uniqueName();
-    const file = path.join(dataDir, 'noresync.sqlite');
+    const file = path.join(dataDir, 'authority.sqlite');
     // A consumer deployment mounts the queue with its own expiry/retry settings...
     await startQueueRuntime({ sqlite: file });
     await mountQueues([{ name, options: { expireInSeconds: 42, retryLimit: 7 } }]);
     expect((await getBoss().getQueue(name))?.expireInSeconds).toBe(42);
     await closeAllQueueResources();
 
-    // ...then a bare producer (different options in code) enqueues: the stored options must survive untouched.
-    const producer = Mochi.queue<{ n: number }>(name, { storage: { sqlite: file }, expireInSeconds: 900, retryLimit: 1 });
-    await producer.add({ n: 1 });
+    // ...then a bare producer (no persisted options declared) enqueues: it asserts existence, not config.
+    const bare = Mochi.queue<{ n: number }>(name, { storage: { sqlite: file } });
+    await bare.add({ n: 1 });
     const stored = await getBoss().getQueue(name);
     expect(stored?.expireInSeconds).toBe(42);
     expect(stored?.retryLimit).toBe(7);
+    await closeAllQueueResources();
+
+    // A producer that does declare options is held to them: code is authoritative, and this code disagrees with storage.
+    const differing = Mochi.queue<{ n: number }>(name, { storage: { sqlite: file }, expireInSeconds: 900, retryLimit: 1 });
+    await expect(differing.add({ n: 2 })).rejects.toThrow(/already exists in storage with retryLimit 7, expireInSeconds 42.*declares retryLimit 1, expireInSeconds 900/);
+  }, 15_000);
+
+  test('a producer-first enqueue creates the queue with its descriptor-form deadLetter link intact', async () => {
+    const file = path.join(dataDir, 'producer-dlq.sqlite');
+    const dlq = Mochi.queue<{ n: number }>('producer-work-dlq', { storage: { sqlite: file } });
+    const work = Mochi.queue<{ n: number }>('producer-work', { storage: { sqlite: file }, retryLimit: 0, deadLetter: dlq });
+
+    // The issue's repro: on fresh storage the producer runs first — the link must exist without any migration.
+    expect(await work.add({ n: 1 })).toBeString();
+    expect((await getBoss().getQueue('producer-work'))?.deadLetter).toBe('producer-work-dlq');
+    // The target was ensured, but only the queue actually added to is registered as a producer handle.
+    expect(await getBoss().getQueue('producer-work-dlq')).not.toBeNull();
+    expect(() => getQueue('producer-work-dlq')).toThrow();
+  }, 15_000);
+
+  test('a producer with a string deadLetter whose target does not exist is rejected with the descriptor remedy', async () => {
+    const file = path.join(dataDir, 'producer-dlq-missing.sqlite');
+    const work = Mochi.queue<{ n: number }>('orphan-work', { storage: { sqlite: file }, deadLetter: 'orphan-dlq' });
+    await expect(work.add({ n: 1 })).rejects.toThrow(/"orphan-dlq" is not declared here and does not exist in storage.*Pass the target's descriptor/);
   }, 15_000);
 
   test('queue.stop() releases the queue and closes the runtime when it was the last one', async () => {

--- a/packages/mochi/src/queueStandalonePglite.test.ts
+++ b/packages/mochi/src/queueStandalonePglite.test.ts
@@ -5,8 +5,8 @@ import { closeAllQueueResources, getBoss, mountQueues, startQueueRuntime } from 
 import { mochiEvents } from './events';
 import { resetStartupMilestones } from './lifecycle';
 
-// The standalone lazy-connect + no-resync contract on the embedded pglite backend, mirroring queueStandalone.test.ts's
-// sqlite coverage; the caller owns the PGlite instance, so this test closes it itself.
+// The standalone lazy-connect + code-authoritative-config contract on the embedded pglite backend, mirroring
+// queueStandalone.test.ts's sqlite coverage; the caller owns the PGlite instance, so this test closes it itself.
 describe('standalone queue producer on pglite storage', () => {
   let db: PGlite;
 
@@ -17,7 +17,7 @@ describe('standalone queue producer on pglite storage', () => {
     await db?.close();
   });
 
-  test('lazily connects producer-only and never re-syncs consumer-owned options', async () => {
+  test('lazily connects producer-only; a bare handle passes while a differing declaration is rejected', async () => {
     db = await PGlite.create();
 
     // A consumer deployment mounts the queue with its own settings first.
@@ -26,8 +26,8 @@ describe('standalone queue producer on pglite storage', () => {
     expect((await getBoss().getQueue('pglite-standalone'))?.expireInSeconds).toBe(42);
     await closeAllQueueResources();
 
-    // A bare producer's first add reconnects lazily, registers no worker, and leaves the stored options alone.
-    const producer = Mochi.queue<{ n: number }>('pglite-standalone', { storage: { pglite: db }, expireInSeconds: 900, retryLimit: 1 });
+    // A bare producer's first add reconnects lazily, registers no worker, and asserts existence, not config.
+    const producer = Mochi.queue<{ n: number }>('pglite-standalone', { storage: { pglite: db } });
     const jobId = await producer.add({ n: 1 });
     expect(jobId).toBeString();
     expect(getBoss().getWipData()).toHaveLength(0);
@@ -35,6 +35,11 @@ describe('standalone queue producer on pglite storage', () => {
     const stored = await getBoss().getQueue('pglite-standalone');
     expect(stored?.expireInSeconds).toBe(42);
     expect(stored?.retryLimit).toBe(7);
+    await Mochi.stop();
+
+    // A producer that does declare options is held to them — code is authoritative, and this code disagrees.
+    const differing = Mochi.queue<{ n: number }>('pglite-standalone', { storage: { pglite: db }, expireInSeconds: 900, retryLimit: 1 });
+    await expect(differing.add({ n: 2 })).rejects.toThrow(/already exists in storage with retryLimit 7, expireInSeconds 42/);
 
     // Mochi.stop() drains the runtime but must not close the caller-owned instance.
     await Mochi.stop();

--- a/packages/mochi/src/queueWorker.test.ts
+++ b/packages/mochi/src/queueWorker.test.ts
@@ -86,33 +86,42 @@ describe('Mochi.worker()', () => {
     expect(worker.start()).rejects.toThrow(/no storage declared/);
   });
 
-  test('never re-syncs stored queue options and refuses a second start', async () => {
-    const file = path.join(dataDir, 'worker-noresync.sqlite');
-    // A serve-style deployment mounts the queue with its own settings first.
+  test('rejects declared options that differ from storage, and queueConfig sync repairs them', async () => {
+    const file = path.join(dataDir, 'worker-authority.sqlite');
+    // A prior deployment mounted the queue with different settings.
     await startQueueRuntime({ sqlite: file });
     await mountQueues([{ name: 'owned-jobs', options: { expireInSeconds: 42, retryLimit: 7 } }]);
     await closeAllQueueResources();
 
     const done = deferred<void>();
-    const worker = Mochi.worker({
-      queues: [
-        Mochi.queue('owned-jobs', {
-          pollingIntervalSeconds: 0.5,
-          expireInSeconds: 900,
-          retryLimit: 1,
-          process: async () => done.resolve(),
-        }),
-      ],
-      storage: { sqlite: file },
-    });
-    await worker.start();
-    expect(worker.start()).rejects.toThrow(/already started/);
+    const queues = () => [
+      Mochi.queue('owned-jobs', {
+        storage: { sqlite: file },
+        pollingIntervalSeconds: 0.5,
+        expireInSeconds: 900,
+        retryLimit: 1,
+        process: async () => done.resolve(),
+      }),
+    ];
+    await expect(Mochi.worker({ queues: queues() }).start()).rejects.toThrow(
+      /"owned-jobs" already exists in storage with retryLimit 7, expireInSeconds 42, but this code declares retryLimit 1, expireInSeconds 900/,
+    );
+
+    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      const worker = Mochi.worker({ queues: queues(), queueConfig: 'sync' });
+      await worker.start();
+      expect(worker.start()).rejects.toThrow(/already started/);
+      const stored = await getBoss().getQueue('owned-jobs');
+      expect(stored?.expireInSeconds).toBe(900);
+      expect(stored?.retryLimit).toBe(1);
+      expect(warn.mock.calls.some((args) => String(args[0]).includes('synced stored config to the declaration'))).toBe(true);
+    } finally {
+      warn.mockRestore();
+    }
 
     await Mochi.getQueue<Record<string, never>>('owned-jobs').add({});
     await done.promise;
-    const stored = await getBoss().getQueue('owned-jobs');
-    expect(stored?.expireInSeconds).toBe(42);
-    expect(stored?.retryLimit).toBe(7);
   }, 20_000);
 
   test('refuses to start in a serving process', async () => {
@@ -149,19 +158,26 @@ describe('Mochi.worker()', () => {
     expect(job.data).toEqual({ payload: 'keep-me' });
   }, 20_000);
 
-  test('skips a deadLetter that names a queue outside the worker array, with a warning, and still mounts', async () => {
+  test('rejects a string deadLetter whose target is neither declared nor in storage, and accepts one that already exists', async () => {
     const file = path.join(dataDir, 'worker-dlq-outside.sqlite');
-    const warn = spyOn(logger, 'warn').mockImplementation(() => {});
-    try {
-      const worker = Mochi.worker({
-        queues: [Mochi.queue('lonely', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'elsewhere', process: async () => {} })],
-      });
-      await worker.start();
-      expect((await getBoss().getQueue('lonely'))?.deadLetter).toBeNull();
-      expect(warn.mock.calls.some((args) => String(args[0]).includes('names "elsewhere" as its deadLetter'))).toBe(true);
-    } finally {
-      warn.mockRestore();
-    }
+    const declare = () => Mochi.queue('lonely', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'elsewhere', process: async () => {} });
+    await expect(Mochi.worker({ queues: [declare()] }).start()).rejects.toThrow(/"elsewhere" is not declared here and does not exist in storage.*Pass the target's descriptor/);
+
+    // Once the target exists in storage, the same string-form declaration creates the queue with its link.
+    await getBoss().createQueue('elsewhere');
+    await Mochi.worker({ queues: [declare()] }).start();
+    expect((await getBoss().getQueue('lonely'))?.deadLetter).toBe('elsewhere');
+  }, 20_000);
+
+  test('ensures a descriptor-form deadLetter target outside the queues array automatically', async () => {
+    const file = path.join(dataDir, 'worker-dlq-descriptor.sqlite');
+    const dlq = Mochi.queue('desc-dlq', { storage: { sqlite: file } });
+    const worker = Mochi.worker({
+      queues: [Mochi.queue('desc-work', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: dlq, process: async () => {} })],
+    });
+    await worker.start();
+    expect((await getBoss().getQueue('desc-work'))?.deadLetter).toBe('desc-dlq');
+    expect(await getBoss().getQueue('desc-dlq')).not.toBeNull();
   }, 20_000);
 
   test('rejects a queue that names itself as its deadLetter', async () => {
@@ -170,25 +186,26 @@ describe('Mochi.worker()', () => {
     expect(worker.start()).rejects.toThrow(/names itself as its deadLetter/);
   });
 
-  test('warns (does not silently drop) when a declared deadLetter cannot be applied because the queue already exists', async () => {
+  test('rejects a pre-existing queue missing its declared deadLetter link, and sync repoints it', async () => {
     const file = path.join(dataDir, 'worker-dlq-preexisting.sqlite');
     // A prior deploy created the queue without a deadLetter link.
     await startQueueRuntime({ sqlite: file });
     await mountQueues([{ name: 'pre' }, { name: 'pre-dlq' }]);
     await closeAllQueueResources();
 
+    const queues = () => [
+      Mochi.queue('pre', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'pre-dlq', process: async () => {} }),
+      Mochi.queue('pre-dlq', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, process: async () => {} }),
+    ];
+    await expect(Mochi.worker({ queues: queues() }).start()).rejects.toThrow(
+      /"pre" already exists in storage with deadLetter unset, but this code declares deadLetter "pre-dlq".*MOCHI_QUEUE_SYNC=1/,
+    );
+
     const warn = spyOn(logger, 'warn').mockImplementation(() => {});
     try {
-      const worker = Mochi.worker({
-        queues: [
-          Mochi.queue('pre', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, deadLetter: 'pre-dlq', process: async () => {} }),
-          Mochi.queue('pre-dlq', { storage: { sqlite: file }, pollingIntervalSeconds: 0.5, process: async () => {} }),
-        ],
-      });
-      await worker.start();
-      // Ensure-only: the existing queue keeps its null link, but the drop is surfaced, not silent.
-      expect((await getBoss().getQueue('pre'))?.deadLetter).toBeNull();
-      expect(warn.mock.calls.some((args) => String(args[0]).includes('"pre"') && String(args[0]).includes('already exists') && String(args[0]).includes('updateQueue'))).toBe(true);
+      await Mochi.worker({ queues: queues(), queueConfig: 'sync' }).start();
+      expect((await getBoss().getQueue('pre'))?.deadLetter).toBe('pre-dlq');
+      expect(warn.mock.calls.some((args) => String(args[0]).includes('deadLetter unset → "pre-dlq"'))).toBe(true);
     } finally {
       warn.mockRestore();
     }

--- a/packages/mochi/src/runtime/csrf.test.ts
+++ b/packages/mochi/src/runtime/csrf.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, spyOn, test, type Mock } from 'bun:test';
-import { csrfCheck, isFormContentType } from './csrf';
+import { csrfBootWarning, csrfCheck, isFormContentType } from './csrf';
 import { initExtensions } from '../extensions';
 
 const SAME = 'http://localhost:3333';
@@ -471,5 +471,33 @@ describe('csrfCheck via csrf:check filter', () => {
     // delegating returns it unchanged.
     expect(captured.decision?.status).toBe(403);
     expect(out).toBe(captured.decision as Response);
+  });
+});
+
+describe('csrfBootWarning', () => {
+  const page = (actions?: Record<string, unknown>) => ({ __mochiPage: true, actions });
+  const routesWithActions = { '/contact': page({ default: async () => null }), '/about': page() };
+
+  test('warns when a route declares actions and no trusted origin is configured', () => {
+    const warning = csrfBootWarning({ routes: routesWithActions });
+    expect(warning).toContain('1 route(s) declare form actions (e.g. "/contact")');
+    expect(warning).toContain('blocked with 403 in production');
+    expect(warning).toContain("proxy: { origin: '...' }");
+  });
+
+  test('stays silent without action routes, and for pages with an empty actions map', () => {
+    expect(csrfBootWarning({ routes: { '/about': page(), '/empty': page({}) } })).toBeNull();
+    expect(csrfBootWarning({ routes: {} })).toBeNull();
+    expect(csrfBootWarning({})).toBeNull();
+  });
+
+  test('stays silent when a trusted origin is configured', () => {
+    expect(csrfBootWarning({ routes: routesWithActions, proxy: { origin: 'https://app.example' } })).toBeNull();
+    expect(csrfBootWarning({ routes: routesWithActions, proxy: { hostHeader: 'x-forwarded-host' } })).toBeNull();
+  });
+
+  test('stays silent when the check is disabled or overridden by a csrf:check filter', () => {
+    expect(csrfBootWarning({ routes: routesWithActions, csrf: { checkOrigin: false } })).toBeNull();
+    expect(csrfBootWarning({ routes: routesWithActions, filters: { 'csrf:check': () => null } })).toBeNull();
   });
 });

--- a/packages/mochi/src/runtime/csrf.ts
+++ b/packages/mochi/src/runtime/csrf.ts
@@ -68,6 +68,30 @@ export function isFormContentType(contentType: string | null, formContentTypes: 
 }
 
 /**
+ * Boot-time visibility for a production-only failure: without a trusted origin every form-action POST 403s in
+ * production while development only warns per-request — invisible until deploy. Returns the warning line, or null.
+ * The page marker is checked structurally ("__mochiPage") because importing types.ts here would be a module cycle.
+ */
+export function csrfBootWarning(options: {
+  csrf?: MochiCsrfOptions;
+  proxy?: MochiProxyOptions;
+  filters?: { 'csrf:check'?: unknown };
+  routes?: Record<string, unknown>;
+}): string | null {
+  if (options.csrf?.checkOrigin === false || options.filters?.['csrf:check'] !== undefined || options.proxy?.origin || options.proxy?.hostHeader) {
+    return null;
+  }
+  const actionRoutes = Object.entries(options.routes ?? {}).filter(([, handler]) => {
+    const page = handler as { __mochiPage?: boolean; actions?: Record<string, unknown> } | undefined;
+    return page?.__mochiPage === true && page.actions !== undefined && Object.keys(page.actions).length > 0;
+  });
+  if (actionRoutes.length === 0) {
+    return null;
+  }
+  return `CSRF: ${actionRoutes.length} route(s) declare form actions (e.g. "${actionRoutes[0]?.[0]}") but no proxy.origin or proxy.hostHeader is configured — their form POSTs will be blocked with 403 in production, because the expected origin can't be trusted. Set Mochi.serve({ proxy: { origin: '...' } }) before deploying.`;
+}
+
+/**
  * Resolve the framework's default CSRF decision and run it through the `csrf:check` filter, the single override point
  * for extensions. The filter receives that decision — `null` to pass, `Response` to block — and returns the input
  * unchanged to delegate, `null` to bypass, or a fresh `Response` to substitute a custom block.

--- a/packages/mochi/src/serveAdoptsStandaloneMismatch.test.ts
+++ b/packages/mochi/src/serveAdoptsStandaloneMismatch.test.ts
@@ -5,8 +5,8 @@ import { Mochi } from './Mochi';
 import { closeAllQueueResources } from './queue';
 import { resetStartupMilestones } from './lifecycle';
 
-// The adoption path re-verifies: serve clears the standalone runtime's per-queue memo when it takes over, so its own
-// declaration is checked against storage even though the producer already ensured the queue in this process.
+// The adoption path re-verifies: serve runs its own create-and-verify over its declaration, so it is checked against
+// storage even though the producer already ensured the queue in this process.
 describe('Mochi.serve() adopting a standalone runtime re-verifies queue config', () => {
   let outDir: string;
 

--- a/packages/mochi/src/serveAdoptsStandaloneMismatch.test.ts
+++ b/packages/mochi/src/serveAdoptsStandaloneMismatch.test.ts
@@ -1,0 +1,37 @@
+import { afterAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { Mochi } from './Mochi';
+import { closeAllQueueResources } from './queue';
+import { resetStartupMilestones } from './lifecycle';
+
+// The adoption path re-verifies: serve clears the standalone runtime's per-queue memo when it takes over, so its own
+// declaration is checked against storage even though the producer already ensured the queue in this process.
+describe('Mochi.serve() adopting a standalone runtime re-verifies queue config', () => {
+  let outDir: string;
+
+  afterAll(async () => {
+    await closeAllQueueResources();
+    resetStartupMilestones();
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('a serve declaring options that differ from the producer-created queue fails its boot', async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-serve-adopt-mismatch-'));
+    const file = path.join(outDir, 'shared.sqlite');
+    // A bare producer creates the queue first — a fresh create materializes bun-boss defaults (retryLimit 2).
+    const producer = Mochi.queue<{ n: number }>('adopt-mismatch', { storage: { sqlite: file } });
+    await producer.add({ n: 1 });
+
+    await expect(
+      Mochi.serve({
+        port: 0,
+        development: false,
+        logger: { enabled: false },
+        outDir,
+        routes: {},
+        queues: [Mochi.queue('adopt-mismatch', { storage: { sqlite: file }, retryLimit: 7, process: async () => null })],
+      }),
+    ).rejects.toThrow(/"adopt-mismatch" already exists in storage with retryLimit 2, but this code declares retryLimit 7/);
+  }, 20_000);
+});

--- a/packages/mochi/src/serveQueues.test.ts
+++ b/packages/mochi/src/serveQueues.test.ts
@@ -153,9 +153,12 @@ describe('Mochi.serve({ queues })', () => {
     const processed: string[] = [];
     const completed = deferred<{ queue: string; result: unknown }>();
 
+    // A descriptor-form deadLetter target outside the queues array: ensured in storage, never mounted.
+    const dlq = Mochi.queue<{ to: string }>('serve-queue-dlq', { storage: { sqlite: sqliteFile } });
     const jobs = Mochi.queue<{ to: string }>('serve-queue-jobs', {
       pollingIntervalSeconds: 0.5,
       storage: { sqlite: sqliteFile },
+      deadLetter: dlq,
       process: async (job) => {
         processed.push(job.data.to);
         return { sent: true };
@@ -189,6 +192,12 @@ describe('Mochi.serve({ queues })', () => {
 
   test('Mochi.boss() resolves the shared bun-boss instance once queues are mounted', () => {
     expect(typeof Mochi.boss().send).toBe('function');
+  });
+
+  test('a descriptor-form deadLetter target is ensured in storage with the link, but not mounted', async () => {
+    expect((await Mochi.boss().getQueue('serve-queue-jobs'))?.deadLetter).toBe('serve-queue-dlq');
+    expect(await Mochi.boss().getQueue('serve-queue-dlq')).not.toBeNull();
+    expect(() => Mochi.getQueue('serve-queue-dlq')).toThrow(/no such queue/);
   });
 
   test('getQueue() for a name never declared in serve is fatal', () => {

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -274,6 +274,12 @@ export interface MochiWorkerOptions {
   queues: MochiQueueConfig[];
   /** The app's queue storage; may instead come from a `storage` declared on the descriptors. */
   storage?: MochiQueueStorage;
+  /**
+   * `'verify'` (default): a stored queue whose config differs from its declaration is a start() error — code is
+   * authoritative. `'sync'`: write the declared config to storage instead, logging each change. `MOCHI_QUEUE_SYNC=1`
+   * forces `'sync'` process-wide and wins over this option.
+   */
+  queueConfig?: 'verify' | 'sync';
 }
 
 export type MochiRouteValue = MochiPageConfig | MochiApiConfig | MochiWsConfig | MochiSseConfig | MochiFileConfig | BunRouteValue;
@@ -457,6 +463,12 @@ export interface MochiServeOptions {
    * declarations are a boot error.
    */
   queueStorage?: MochiQueueStorage;
+  /**
+   * `'verify'` (default): a stored queue whose config differs from its declaration is a boot error — code is
+   * authoritative. `'sync'`: write the declared config to storage instead, logging each change. `MOCHI_QUEUE_SYNC=1`
+   * forces `'sync'` process-wide and wins over this option.
+   */
+  queueConfig?: 'verify' | 'sync';
   fetch?: (req: Request, server: Server<undefined>) => Response | Promise<Response>;
   htmlShell?: string;
   /**


### PR DESCRIPTION
## Summary

Inverts queue-config authority, closing the follow-up to #316: **declared code is authoritative; storage is a cache of it.** One rule now covers every path — `Mochi.serve()`, `Mochi.worker()`, and standalone producers:

- **Not in storage** → create with the full declared config, `deadLetter` included.
- **In storage, matches** → continue.
- **In storage, differs** → throw at boot, naming the queue, each field, and both values, with ready-to-paste migration hints.

The per-path rules this replaces (serve's additive `updateQueue` re-sync, the worker's ensure-only link handling with two warning branches, the producer path stripping `deadLetter` entirely) are deleted. Boot order no longer decides whether a dead-letter link exists.

### `deadLetter` accepts a descriptor

```ts
export const dlq = Mochi.queue('plugin-info-dlq', { storage });
export const work = Mochi.queue('plugin-info', { process, storage, deadLetter: dlq });
```

A descriptor reference is self-sufficient: any process — including a lone enqueue script on fresh storage — ensures the target first, then creates the referrer with the link intact. The issue's producer-first repro now yields a linked queue with no migration and no warning. The string form stays accepted where the target is in the same array or already exists in storage; targets reached only via descriptor are ensured but not mounted.

### The migration lever: `queueConfig: 'sync'` / `MOCHI_QUEUE_SYNC=1`

Pure throw-on-mismatch would brick every intentional config change (the processes able to run the `updateQueue` migration are the ones refusing to boot). So both `Mochi.serve()` and `Mochi.worker()` take `queueConfig?: 'verify' | 'sync'` (default `'verify'`), and `MOCHI_QUEUE_SYNC=1` forces sync process-wide (standalone producers included), winning over the option. Sync runs the same comparison but repairs drift with a full-field `updateQueue` write and logs each changed field.

### Deliberate carve-outs

- **Bare declarations are existence-only.** `Mochi.queue(name, { storage })` with zero persisted options asserts the queue exists and skips comparison, keeping bare producer handles working. Any declaration with ≥1 persisted option is enforced on all stored fields (absent = the bun-boss default).
- **Removing a `deadLetter` is a config change like any other** (requires bun-boss ≥ 0.5.0, khromov/bun-boss#50): verify mode throws with a paste-ready `updateQueue(name, { deadLetter: null })` hint, and sync mode clears the stored link. The `Mochi.boss().deleteQueue()` reset recipe stays documented for wiping a queue outright.
- **Dead-letter loops cannot be created from scratch** (each target must exist before its referrer, and nothing calls `updateQueue` to add links after the fact); an existing loop that matches the declaration passes verification.

### Also included

Boot-time CSRF warning (the issue's footnote): when routes declare form `actions` and neither `proxy.origin` nor `proxy.hostHeader` is configured (and CSRF isn't disabled or overridden by a `csrf:check` filter), `Mochi.serve()` warns once at boot in both modes — previously the failure was a production-only per-request 403, invisible until deploy.

## Breaking changes

- A stored queue whose config differs from the declaration is now a boot error (previously: serve silently re-synced additively; worker/producer silently diverged). Existing deployments with drift throw on first boot after upgrading — the error message names the fix; `MOCHI_QUEUE_SYNC=1` on one deploy migrates in place.
- A worker whose string-form `deadLetter` target is neither declared nor in storage now throws (previously: warned and dropped the link).
- Declared dead-letter cycles among not-yet-created queues now throw (previously: serve could build them via the two-pass update; workers warned and dropped the links).

## Implementation notes

- `verifyOrCreateQueues()` in `queue.ts` is the single engine: closure over descriptor-form targets → topological order → `createQueue` (ON CONFLICT DO NOTHING, race-safe) → read back → normalized field-by-field compare (sqlite 0/1 booleans and string numerics normalize before comparison).
- The comparison's "absent = default" side comes from bun-boss 0.5.0's own `queueOptionDefaults` export (added in khromov/bun-boss#50 together with the clearable `deadLetter`, and pinned to real behavior by a test upstream) — nothing numeric is mirrored in Mochi, and `DEFAULT_EXPIRE_IN_SECONDS` derives from the same source. The dependency is bumped to `^0.5.0`.
- The engine is idempotent end-to-end, which let the old per-queue `registry.ensured` memo (and its adoption/stop/teardown bookkeeping) be deleted outright — a queue reached twice just re-verifies. The same closure walk is shared with the serve prelude, which now also catches descriptor-target self-references and conflicting duplicate declarations pre-bind.
- Docs: `115-queues.md` storage/producer/worker/dead-letter sections rewritten for the new contract (migration workflow, shared-descriptor guidance, reset recipe); `160-serve-options.md` notes the CSRF boot warning.

## Tests

New `queueConfigAuthority.test.ts` (mismatch/identical remount, sqlite boolean normalization, sync repair + env override, deadLetter removal — verify hint + sync clear, loop semantics, duplicate-declaration conflict), `serveAdoptsStandaloneMismatch.test.ts`, the issue's producer-first repro in `queueStandalone.test.ts`, inverted #316 tests in `queueWorker.test.ts` (throw + sync variants, descriptor auto-ensure), pglite mismatch coverage, serve descriptor-target ensured-not-mounted, and `csrfBootWarning` unit tests.
