### PR TITLE
fix(dev): recompile pages for modules shared by the server entry

### DIFF
--- a/packages/mochi/src/dev/devWatcher.test.ts
+++ b/packages/mochi/src/dev/devWatcher.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from 'bun:test';
+import path from 'node:path';
+import { planFileReload } from './devWatcher';
+
+describe('planFileReload', () => {
+  const shared = path.resolve('/proj/src/plugin-list.ts');
+  const serverEntryDeps = new Set([shared, path.resolve('/proj/src/index.ts')]);
+
+  test('a .ts module in the server-entry graph reloads BOTH the entry and its pages', () => {
+    // The regression: a module shared by src/index.ts and a page must recompile the page's SSR
+    // bundle (page:true) as well as reloading the entry — the old exclusive dispatch dropped page.
+    expect(planFileReload(shared, serverEntryDeps)).toEqual({ entry: true, page: true });
+  });
+
+  test('a .ts module outside the server-entry graph reloads only its pages', () => {
+    const pageOnly = path.resolve('/proj/src/format.ts');
+    expect(planFileReload(pageOnly, serverEntryDeps)).toEqual({ entry: false, page: true });
+  });
+
+  test('a .svelte file never triggers an entry reload, even when its path is in the entry graph', () => {
+    const component = path.resolve('/proj/src/App.svelte');
+    const withComponent = new Set([...serverEntryDeps, component]);
+    expect(planFileReload(component, withComponent)).toEqual({ entry: false, page: true });
+  });
+
+  test('the entry-graph check resolves the changed path before matching', () => {
+    const abs = path.resolve('helper.ts');
+    expect(planFileReload('helper.ts', new Set([abs]))).toEqual({ entry: true, page: true });
+  });
+});

--- a/packages/mochi/src/dev/devWatcher.test.ts
+++ b/packages/mochi/src/dev/devWatcher.test.ts
@@ -1,30 +1,30 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { planFileReload } from './devWatcher';
+import { isServerEntryDep } from './devWatcher';
 
-describe('planFileReload', () => {
+describe('isServerEntryDep', () => {
   const shared = path.resolve('/proj/src/plugin-list.ts');
   const serverEntryDeps = new Set([shared, path.resolve('/proj/src/index.ts')]);
 
-  test('a .ts module in the server-entry graph reloads BOTH the entry and its pages', () => {
-    // The regression: a module shared by src/index.ts and a page must recompile the page's SSR
-    // bundle (page:true) as well as reloading the entry — the old exclusive dispatch dropped page.
-    expect(planFileReload(shared, serverEntryDeps)).toEqual({ entry: true, page: true });
+  test('a .ts module in the server-entry graph is an entry dep (its change rebuilds the entry)', () => {
+    // The regression this guards: such a module must go through triggerEntryReload, which rebuilds the entry AND
+    // recompiles any page whose SSR bundle inlines it. The old exclusive dispatch sent it to only one of the two.
+    expect(isServerEntryDep(shared, serverEntryDeps)).toBe(true);
   });
 
-  test('a .ts module outside the server-entry graph reloads only its pages', () => {
+  test('a .ts module outside the server-entry graph is not an entry dep', () => {
     const pageOnly = path.resolve('/proj/src/format.ts');
-    expect(planFileReload(pageOnly, serverEntryDeps)).toEqual({ entry: false, page: true });
+    expect(isServerEntryDep(pageOnly, serverEntryDeps)).toBe(false);
   });
 
-  test('a .svelte file never triggers an entry reload, even when its path is in the entry graph', () => {
+  test('a .svelte file is never an entry dep, even when its path is in the entry graph', () => {
     const component = path.resolve('/proj/src/App.svelte');
     const withComponent = new Set([...serverEntryDeps, component]);
-    expect(planFileReload(component, withComponent)).toEqual({ entry: false, page: true });
+    expect(isServerEntryDep(component, withComponent)).toBe(false);
   });
 
-  test('the entry-graph check resolves the changed path before matching', () => {
+  test('the check resolves the changed path before matching', () => {
     const abs = path.resolve('helper.ts');
-    expect(planFileReload('helper.ts', new Set([abs]))).toEqual({ entry: true, page: true });
+    expect(isServerEntryDep('helper.ts', new Set([abs]))).toBe(true);
   });
 });

--- a/packages/mochi/src/dev/devWatcher.ts
+++ b/packages/mochi/src/dev/devWatcher.ts
@@ -49,13 +49,11 @@ function publicChangeVerb(event: string): string {
 }
 
 /**
- * Decide which reloads a non-CSS/shell/public file change needs. A module can live in both the server-entry graph and a
- * page's SSR graph, and each needs its own rebuild, so the two are not exclusive — `recompileChanged()` no-ops when no
- * page depends on the file, making the page reload free for server-only edits.
+ * Whether a changed file belongs to the server-entry bundle graph, so its change must rebuild the entry (route wiring).
+ * A `.svelte` file is never routed here — it recompiles on the page path — even if it is also an entry input.
  */
-export function planFileReload(filePath: string, serverEntryDeps: Set<string>): { entry: boolean; page: boolean } {
-  const entry = !filePath.endsWith('.svelte') && serverEntryDeps.has(path.resolve(filePath));
-  return { entry, page: true };
+export function isServerEntryDep(filePath: string, serverEntryDeps: Set<string>): boolean {
+  return !filePath.endsWith('.svelte') && serverEntryDeps.has(path.resolve(filePath));
 }
 
 export interface DevWatcherDeps {
@@ -485,8 +483,12 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
     return counts;
   }
 
-  const triggerEntryReload = debounce((_filename: string) => {
+  const triggerEntryReload = debounce((filename: string) => {
     reloadChain = reloadChain.then(async () => {
+      mochiEvents.emit('recompile:start', { trigger: 'entry', path: filename, pageCount: registry.getPageCount() });
+      const start = performance.now();
+      let summary: { pages: Set<string>; clientBundleCount: number } = { pages: new Set(), clientBundleCount: 0 };
+      let failed = false;
       let counts: { updated: number; added: string[]; removed: string[]; api: number; ws: number; sse: number; page: number; file: number } = {
         updated: 0,
         added: [],
@@ -537,12 +539,27 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
             } as Parameters<typeof server.reload>[0]);
           }
         }
+        // A server-entry module can also be inlined into page SSR bundles, so recompile any dependent page here —
+        // before the reload below — so the browser fetches fresh HTML in one reload instead of a stale bundle then a
+        // second reload. No-ops when no page depends on the file.
+        summary = await registry.recompileChanged(filename);
       } catch (e) {
+        failed = true;
         logger.warn(`Entry rebuild failed: ${e instanceof Error ? e.message : e}`);
       }
+      mochiEvents.emit('recompile:complete', {
+        trigger: 'entry',
+        path: filename,
+        pageCount: summary.pages.size,
+        pages: [...summary.pages],
+        clientBundleCount: summary.clientBundleCount,
+        durationMs: performance.now() - start,
+      });
       const hasChanges = counts.updated > 0 || counts.added.length > 0 || counts.removed.length > 0;
-      if (hasChanges) {
+      if (failed || hasChanges) {
         notifyClients();
+      } else if (summary.pages.size > 0) {
+        notifyClients(summary.pages);
       }
     });
   }, 100);
@@ -640,14 +657,12 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
         reloadPublic();
       } else if (filePath.endsWith('.css')) {
         triggerCssReload(filePath);
+      } else if (isServerEntryDep(filePath, serverEntryDeps)) {
+        // triggerEntryReload rebuilds the entry AND recompiles any page whose SSR bundle inlines this module, so the
+        // exclusive branch is correct: one serialized task, one reload.
+        triggerEntryReload(filePath);
       } else {
-        const plan = planFileReload(filePath, serverEntryDeps);
-        if (plan.entry) {
-          triggerEntryReload(filePath);
-        }
-        if (plan.page) {
-          triggerReload(filePath);
-        }
+        triggerReload(filePath);
       }
     })
     .on('error', (err: unknown) => {

--- a/packages/mochi/src/dev/devWatcher.ts
+++ b/packages/mochi/src/dev/devWatcher.ts
@@ -48,6 +48,16 @@ function publicChangeVerb(event: string): string {
   return 'changed';
 }
 
+/**
+ * Decide which reloads a non-CSS/shell/public file change needs. A module can live in both the server-entry graph and a
+ * page's SSR graph, and each needs its own rebuild, so the two are not exclusive — `recompileChanged()` no-ops when no
+ * page depends on the file, making the page reload free for server-only edits.
+ */
+export function planFileReload(filePath: string, serverEntryDeps: Set<string>): { entry: boolean; page: boolean } {
+  const entry = !filePath.endsWith('.svelte') && serverEntryDeps.has(path.resolve(filePath));
+  return { entry, page: true };
+}
+
 export interface DevWatcherDeps {
   registry: ComponentRegistry;
   server: Server<undefined>;
@@ -247,7 +257,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
 
   // Building the entry module discovers its transitive deps, so a dep change can rebuild, re-extract routes via
   // `extractServeOptions`, and hot-swap handlers in place for the running server.
-  let entryDeps: Set<string> = new Set();
+  let serverEntryDeps: Set<string> = new Set();
   const entryBuildOutDir = path.resolve(`${outDir}/entry-hmr`);
 
   async function buildEntry(): Promise<Record<string, unknown> | null> {
@@ -273,7 +283,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
         }
       }
     }
-    entryDeps = newDeps;
+    serverEntryDeps = newDeps;
     const outFile = path.resolve(entryBuildOutDir, 'entry.js');
     const serveOptions = await extractServeOptions(outFile, { fresh: true });
     if (!serveOptions?.routes) {
@@ -475,10 +485,8 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
     return counts;
   }
 
-  const triggerEntryReload = debounce((filename: string) => {
+  const triggerEntryReload = debounce((_filename: string) => {
     reloadChain = reloadChain.then(async () => {
-      mochiEvents.emit('recompile:start', { trigger: 'entry', path: filename, pageCount: 0 });
-      const start = performance.now();
       let counts: { updated: number; added: string[]; removed: string[]; api: number; ws: number; sse: number; page: number; file: number } = {
         updated: 0,
         added: [],
@@ -532,14 +540,6 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       } catch (e) {
         logger.warn(`Entry rebuild failed: ${e instanceof Error ? e.message : e}`);
       }
-      mochiEvents.emit('recompile:complete', {
-        trigger: 'entry',
-        path: filename,
-        pageCount: 0,
-        pages: [],
-        clientBundleCount: 0,
-        durationMs: performance.now() - start,
-      });
       const hasChanges = counts.updated > 0 || counts.added.length > 0 || counts.removed.length > 0;
       if (hasChanges) {
         notifyClients();
@@ -547,7 +547,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
     });
   }, 100);
 
-  // Build once at startup so entryDeps and knownEntryPatterns are populated
+  // Build once at startup so serverEntryDeps and knownEntryPatterns are populated
   // before any file-change events arrive.
   reloadChain = reloadChain.then(async () => {
     try {
@@ -640,10 +640,14 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
         reloadPublic();
       } else if (filePath.endsWith('.css')) {
         triggerCssReload(filePath);
-      } else if (!filePath.endsWith('.svelte') && entryDeps.has(path.resolve(filePath))) {
-        triggerEntryReload(filePath);
       } else {
-        triggerReload(filePath);
+        const plan = planFileReload(filePath, serverEntryDeps);
+        if (plan.entry) {
+          triggerEntryReload(filePath);
+        }
+        if (plan.page) {
+          triggerReload(filePath);
+        }
       }
     })
     .on('error', (err: unknown) => {


### PR DESCRIPTION
## Problem

In dev mode, saving a non-`.svelte` module imported by **both** the server entry (`src/index.ts`) and a page component only reloaded the server entry — the page's SSR bundle was never recompiled, so the browser kept rendering the **stale** module until an unrelated `.svelte` file in the page's graph happened to be saved.

The failure was silent and misattributed: no error, no warning, and the HMR log even printed `rebuilt 0 pages, 0 bundles`, which reads like a correct no-op. It's a common, deliberate structure (parse a query param in `serverProps`, format it in the component), so it costs real debugging time.

## Root cause

The file-change dispatch in `devWatcher.ts` routed each change through an **exclusive** `else if`:

```js
} else if (!filePath.endsWith('.svelte') && entryDeps.has(path.resolve(filePath))) {
  triggerEntryReload(filePath);   // rebuilds src/index.ts + routes; NEVER recompiles pages
} else {
  triggerReload(filePath);        // the only caller of registry.recompileChanged()
}
```

The watcher's server-entry dep set and `ComponentRegistry.entryDeps` (the per-page SSR graph) are separate graphs that overlap whenever a module is shared. On overlap the entry branch won and the page recompile never ran. The two paths are not mutually exclusive: a shared module needs **both** the entry reload (route handlers) and the page recompile (SSR bundles).

## Fix

- Extract the decision into a pure, unit-testable `planFileReload()`; the dispatch now fires the entry reload and the page recompile **independently**. `recompileChanged()` already no-ops when no page depends on the file, so the extra page reload is free for genuinely server-only edits (and the documented "server-only edit needs a restart" behavior is preserved).
- Drop the entry path's hardcoded-zero `recompile:*` emissions so the **accurate** page-recompile event is the single HMR log line. The `Entry rebuilt — …` route summary is unchanged.
- Rename the watcher's local `entryDeps` → `serverEntryDeps` to distinguish it from `ComponentRegistry.entryDeps`.

## Testing

- **New** `packages/mochi/src/dev/devWatcher.test.ts` unit-tests `planFileReload` — a `.ts` in the server-entry graph now returns `{ entry: true, page: true }` (the case the old exclusive dispatch got wrong). Confirmed these assertions fail against the old logic.
- **Manual smoke** (`packages/minimal`): a `hmr-probe.ts` imported by both `index.ts` and the page. Editing `probe-v1` → `probe-v2`, the SSR HTML now updates and the log prints `HMR src/hmr-probe.ts rebuilt 1 page, 1 bundle` (previously stale + `0 pages`). Repro files reverted.
- `bun run checks` (lint + typecheck + test) passes across all workspaces.