### PR TITLE
docs: split deployment page into Production builds and Deployment options

### DIFF
--- a/packages/docs/148-images.md
+++ b/packages/docs/148-images.md
@@ -110,7 +110,7 @@ Import a local image Vite-style and get an object with its served URL and intrin
 
 Supported formats: png, jpg, jpeg, webp, avif, gif. Put SVGs in your `public/` directory and reference them with a plain `<img src>`.
 
-Mochi copies the file to a content-hashed URL (`/_mochi/asset/<slug>-<hash>.<ext>`) and serves it from disk with a long-lived immutable cache in production. Transforms read the file from disk, so `<Image src={hero} size="…">` and `placeholder` work without an origin round-trip. Emitted copies live under `<outDir>/assets/` and [relocate with the build](/docs/deployment-options/#relocatable-builds).
+Mochi copies the file to a content-hashed URL (`/_mochi/asset/<slug>-<hash>.<ext>`) and serves it from disk with a long-lived immutable cache in production. Transforms read the file from disk, so `<Image src={hero} size="…">` and `placeholder` work without an origin round-trip. Emitted copies live under `<outDir>/assets/` and [relocate with the build](/docs/production-builds/#relocatable-builds).
 
 The `{ src, width, height, format }` shape is available as the exported `ImportedImage` type. Ambient module types come free through `mochi-framework/ambient`.
 

--- a/packages/docs/183-cli.md
+++ b/packages/docs/183-cli.md
@@ -77,7 +77,7 @@ After the tree, the build lists the **resources** it emitted — one row per [lo
 
 Silence the list with `Mochi.serve({ build: { resources: false } })`. The `build: done` summary still reports the asset count.
 
-The manifest stores all artifact paths relative to the out-dir, so the output is relocatable. Move or copy it and boot with `outDir` (or `manifest`) pointing at the new location. See [Deployment](/docs/deployment-options/).
+The manifest stores all artifact paths relative to the out-dir, so the output is relocatable. Move or copy it and boot with `outDir` (or `manifest`) pointing at the new location. See [Production builds](/docs/production-builds/#relocatable-builds).
 
 Static files are the exception: the build reads `--public-dir` only to reject a file that shadows a route, and copies nothing. The runtime serves that directory from disk, so it travels with your source. A `0 public file(s)` summary for an app with static assets means `--public-dir` points somewhere unexpected.
 

--- a/packages/docs/183-production-builds.md
+++ b/packages/docs/183-production-builds.md
@@ -1,0 +1,76 @@
+---
+title: 'Production builds'
+slug: production-builds
+description: 'How a Mochi build behaves in production: relocatable output and a persistent image cache.'
+---
+
+<script>
+import Callout from './_components/Callout.svelte';
+</script>
+
+# Production builds
+
+`mochi-framework build` writes a self-contained build to `.mochi/` (see the [CLI reference](/docs/cli/)). This page covers what that build gives you once it is deployed: it relocates cleanly from where you built it to where you run it, and its image cache can survive container restarts. For where to run it, see [Deployment options](/docs/deployment-options/); to containerize it, see [Building a Dockerfile](/docs/docker/).
+
+## Relocatable builds
+
+A manifest holds no absolute paths — artifacts are written relative to the out-dir, sources relative to the project root — so you can build in one place and run in another. Build in a CI stage, copy `.mochi/` into the final image, and point the runtime at wherever it landed:
+
+```ts
+Mochi.serve({ outDir: './.mochi' }); // default — or wherever you copied it
+```
+
+Paths resolve against the manifest's own directory, so pointing `manifest` at a relocated build works on its own:
+
+```ts
+Mochi.serve({ manifest: '/srv/app/build/manifest.json' });
+```
+
+<Callout type="warning">
+
+Five things still anchor a prebuilt app to its project:
+
+- **Build and serve from the same working directory.** Components are keyed relative to the project root, which both `mochi-framework build` and `Mochi.serve()` take to be the current working directory. Run both from the project root.
+- **Ship your `public/` directory.** Static files are never copied into the build. The runtime scans `publicDir` (default `./public`) at startup in production exactly as in development. A deploy that ships only `.mochi/` and `src/` 404s every static file.
+- **Keep the out-dir in the project tree.** The compiled SSR modules resolve `node_modules` from the out-dir's location.
+- **On-demand server islands need sources.** Islands missing from the manifest are compiled at request time from source paths recorded at build. Prebuilt islands relocate fine.
+- **Keep email templates in `src/emails/`.** A `Mochi.email({ component })` template is reachable only at send time, so the build walks that directory to find it. See [Svelte templates](/docs/email/#svelte-templates).
+
+</Callout>
+
+<Callout type="danger">
+
+The manifest records a schema version, and the runtime loads only the exact version it writes. Booting a build made by a different `mochi-framework` version throws at startup. Always run `mochi-framework build` with the same version you serve with.
+
+</Callout>
+
+## Persistent image cache
+
+Mochi's [image cache](/docs/images/) is written to disk under `cacheDir` (default `./.mochi/image-cache`). In a container that directory is recreated on every restart, so each redeploy starts with a cold cache and re-fetches and re-transforms every image. To keep the transformed bytes across restarts, point `cacheDir` at a dedicated path and mount a volume there:
+
+```ts
+Mochi.serve({
+  image: { cacheDir: process.env.MOCHI_IMAGE_CACHE_DIR /* , sizes: … */ },
+});
+```
+
+```yaml
+services:
+  site:
+    image: your-app
+    environment:
+      MOCHI_IMAGE_CACHE_DIR: /data/image-cache
+    volumes:
+      - image-cache:/data/image-cache
+
+volumes:
+  image-cache:
+```
+
+A plain `docker run -v image-cache:/data/image-cache your-app` mounts the same volume. Keep the mount off `./.mochi` — its build cache is rebuilt on every boot and must not persist. If the container runs as a non-root user, pre-create the directory owned by that user in your `Dockerfile` so the mounted volume is writable.
+
+<Callout type="info">
+
+Keep `MOCHI_KEY` stable across restarts. Image URLs are signed with a key derived from it, so a changed key invalidates already-minted links even though the cached bytes are still on disk.
+
+</Callout>

--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -12,74 +12,11 @@ import Callout from './_components/Callout.svelte';
 
 Mochi is a **serverful** application, so it does not run on every serverless host. That is what gives Mochi its features: built-in SQLite, in-memory cache, WebSockets, and Server-Sent Events. You can build complex, data-driven realtime apps with no extra dependency and no external cloud services.
 
-You can host Bun and Mochi at hundreds of hosts. Some popular options are below.
+You can host Bun and Mochi at hundreds of hosts. Some popular options are below. For how a build behaves once it is deployed — relocatable output, a persistent image cache — see [Production builds](/docs/production-builds/).
 
 <Callout type="info">
 
 None of the links below are affiliate links or endorsements.
-
-</Callout>
-
-## Relocatable builds
-
-A manifest holds no absolute paths — artifacts are written relative to the out-dir, sources relative to the project root — so you can build in one place and run in another. Build in a CI stage, copy `.mochi/` into the final image, and point the runtime at wherever it landed:
-
-```ts
-Mochi.serve({ outDir: './.mochi' }); // default — or wherever you copied it
-```
-
-Paths resolve against the manifest's own directory, so pointing `manifest` at a relocated build works on its own:
-
-```ts
-Mochi.serve({ manifest: '/srv/app/build/manifest.json' });
-```
-
-<Callout type="warning">
-
-Five things still anchor a prebuilt app to its project:
-
-- **Build and serve from the same working directory.** Components are keyed relative to the project root, which both `mochi-framework build` and `Mochi.serve()` take to be the current working directory. Run both from the project root.
-- **Ship your `public/` directory.** Static files are never copied into the build. The runtime scans `publicDir` (default `./public`) at startup in production exactly as in development. A deploy that ships only `.mochi/` and `src/` 404s every static file.
-- **Keep the out-dir in the project tree.** The compiled SSR modules resolve `node_modules` from the out-dir's location.
-- **On-demand server islands need sources.** Islands missing from the manifest are compiled at request time from source paths recorded at build. Prebuilt islands relocate fine.
-- **Keep email templates in `src/emails/`.** A `Mochi.email({ component })` template is reachable only at send time, so the build walks that directory to find it. See [Svelte templates](/docs/email/#svelte-templates).
-
-</Callout>
-
-<Callout type="danger">
-
-The manifest records a schema version, and the runtime loads only the exact version it writes. Booting a build made by a different `mochi-framework` version throws at startup. Always run `mochi-framework build` with the same version you serve with.
-
-</Callout>
-
-## Persistent image cache
-
-Mochi's [image cache](/docs/images/) is written to disk under `cacheDir` (default `./.mochi/image-cache`). In a container that directory is recreated on every restart, so each redeploy starts with a cold cache and re-fetches and re-transforms every image. To keep the transformed bytes across restarts, point `cacheDir` at a dedicated path and mount a volume there:
-
-```ts
-Mochi.serve({
-  image: { cacheDir: process.env.MOCHI_IMAGE_CACHE_DIR /* , sizes: … */ },
-});
-```
-
-```yaml
-services:
-  site:
-    image: your-app
-    environment:
-      MOCHI_IMAGE_CACHE_DIR: /data/image-cache
-    volumes:
-      - image-cache:/data/image-cache
-
-volumes:
-  image-cache:
-```
-
-A plain `docker run -v image-cache:/data/image-cache your-app` mounts the same volume. Keep the mount off `./.mochi` — its build cache is rebuilt on every boot and must not persist. If the container runs as a non-root user, pre-create the directory owned by that user in your `Dockerfile` so the mounted volume is writable.
-
-<Callout type="info">
-
-Keep `MOCHI_KEY` stable across restarts. Image URLs are signed with a key derived from it, so a changed key invalidates already-minted links even though the cached bytes are still on disk.
 
 </Callout>
 

--- a/packages/site/src/blog/2026-07-28-mochi-0-9-0.md
+++ b/packages/site/src/blog/2026-07-28-mochi-0-9-0.md
@@ -63,7 +63,7 @@ Mochi.serve({ manifest: '/srv/app/build/manifest.json' });
 
 <Callout type="danger">
 
-**Breaking change:** re-run `mochi-framework build` when you upgrade — the [manifest](/docs/deployment-options/#relocatable-builds) is now versioned, and an older build throws at startup.
+**Breaking change:** re-run `mochi-framework build` when you upgrade — the [manifest](/docs/production-builds/#relocatable-builds) is now versioned, and an older build throws at startup.
 
 </Callout>
 


### PR DESCRIPTION
## What

The [Deployment options](https://mochi.fast/docs/deployment-options/) page had become two topics in one:

- **Build/runtime mechanics** — *Relocatable builds* and *Persistent image cache*, i.e. how a build behaves once deployed.
- **Host directory** — PaaS / VPS / big cloud / self-hosted provider lists, i.e. where to run it.

### Why it merged

The page was born (#52) as a pure host directory. The two build sections were grafted onto the top of it later, each because a shipping feature needed docs and this was the nearest deployment-titled page:

- *Relocatable builds* — #170 (`feat!: relocatable build output`)
- *Persistent image cache* — #289 (`Persist site image cache to a mountable volume`)

## Change

- **New page** `183-production-builds.md` (slug `production-builds`) holds the two build sections, with a short intro linking to the CLI, Deployment options, and Docker pages.
- **`184-deployment.md`** is now a pure host list. Its slug/URL (`/docs/deployment-options/`) is **unchanged**; the removed sections are replaced by a single cross-link.
- Sidebar order is now **CLI reference → Production builds → Deployment options → Building a Dockerfile** (via the `183-` filename prefix; no other files renumbered).
- Redirected the three inbound links to the moved `#relocatable-builds` anchor: `183-cli.md`, `148-images.md`, and the published `0.9.0` blog post (URL only).

## Verification

Smoke-tested on the dev site: both pages render 200, headings split correctly, sidebar order is right, and every moved anchor resolves. `bun run format` passes (no reformatting needed). Nav/sitemap/llms.txt pick up the new page automatically.