### PR TITLE
docs: collapse duplicated isHydratable() section on environment-constants

### DIFF
--- a/packages/docs/80-environment-constants.md
+++ b/packages/docs/80-environment-constants.md
@@ -81,31 +81,7 @@ Inside `.svelte` components it is always `false` — components are compiled but
 
 ## Detecting hydration with `isHydratable()`
 
-`isHydratable()` returns `true` when the calling component — at any nesting depth — belongs to a subtree that will hydrate on this page load. See [Selective hydration](/docs/selective-hydration/#ishydratable) for the full semantics.
-
-For a unique per-instance id (for example, `<label for>`), use Svelte's native `$props.id()`.
-
-### Branching SSR-only behavior
-
-Use `isHydratable()` to do work only when the client won't take over rendering. A component that renders both as a hydrated island and as a plain SSR-only child can prepare a server-rendered fallback in the SSR-only case and skip it when the island will hydrate:
-
-```svelte
-<!-- file: src/lib/LiveCount.svelte -->
-<script lang="ts">
-  import { isHydratable } from 'mochi-framework';
-
-  let { count }: { count: number } = $props();
-
-  // The hydrated island renders a live control; plain SSR gets a static snapshot.
-  const interactive = isHydratable();
-</script>
-
-{#if interactive}
-  <button>{count}</button>
-{:else}
-  <span>{count}</span>
-{/if}
-```
+To branch on whether the client will take over rendering, use `isHydratable()`: it returns `true` when the calling component — at any nesting depth — belongs to a subtree that will hydrate on this page load. Unlike the constants above it is a runtime signal, not a build-time literal, so it lives with the hydration model rather than here. See [Selective hydration](/docs/selective-hydration/#ishydratable) for the full semantics and an example.
 
 <SeeItInAction
 demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "How the isomorphic URL helper works — one import that reads the request URL on the server and window.location on the client." }]}


### PR DESCRIPTION
## What

Follow-up to the deployment-page split (#321): a fan-out audit of the remaining ~57 docs pages for the same "content grafted onto an unrelated page" pattern. **56 pages were clean; this fixes the one finding.**

The [Environment constants](https://mochi.fast/docs/environment-constants/) page is scoped by its frontmatter to **build-time literal constants** — `isServer`, `isBrowser`, `isDev`, `isBuilding`. It carried a second co-equal top-level section re-documenting the **runtime** `isHydratable()` function, complete with its own worked example and a `$props.id()` tip — all of which already live on the [Selective hydration](https://mochi.fast/docs/selective-hydration/#ishydratable) page, which this section already linked to "for the full semantics."

### Why it was there

`isHydratable()`'s canonical home has always been Selective hydration. In #168 (`feat!: isHydratable() at any nesting depth…`) both pages were edited together; the environment-constants copy was trimmed but a partial-duplicate stub was left behind rather than removed.

## Change

- Collapse the section to a one-paragraph cross-reference that says what `isHydratable()` is, notes it's a runtime signal (not a build-time literal, distinguishing it from this page's constants), and links to Selective hydration for the full semantics + example.
- Drop the duplicated example and the redundant `$props.id()` tip (both already on Selective hydration).
- Keep the closing "See it in action" pointer to the Isomorphic URL demo — that demo is genuinely about `isServer`/`isBrowser`.

Net: −25 lines, one file. `bun run format` passes (no reformatting). Verified the page renders on the dev site.