### PR TITLE
feat: include queued job count in large-backlog queue warning

### DIFF
--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -303,6 +303,8 @@ mochiEvents.on('queue:completed', ({ queue, jobId, duration }) => {
 
 `queue:completed` and `queue:failed` fire per attempt, as the processor settles — an immediate `Mochi.boss().findJobs()` from a listener may still see the job `active` for a beat. An `addBulk` emits `queue:added` per inserted job (flagged `bulk: true`) plus one `queue:addedBulk` summary — the console logger prints only the summary, so a 100k-job bulk add logs one line.
 
+When a queue's backlog crosses the warning threshold (`warningQueueSize`, default `10000`), Mochi logs a `[queue]` warning that names the offending queue and its current depth — e.g. `[queue] Warning: large queue backlog. Your queue should be reviewed (queue "emails" has 12345 jobs queued)`.
+
 ### Dev mode & hot reload
 
 `Mochi.serve({ queues })` starts the queue runtime once, so the dev route hot-reload watcher cannot spawn a duplicate consumer. The trade-off: **changes to a queue's `process` function or options do not hot-reload**. Restart the dev server to apply them.

--- a/packages/mochi/src/queue.test.ts
+++ b/packages/mochi/src/queue.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, afterEach, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync, existsSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
-import { startQueueRuntime, mountQueues, getQueue, getBoss, closeAllQueueResources, DEFAULT_EXPIRE_IN_SECONDS } from './queue';
+import { startQueueRuntime, mountQueues, getQueue, getBoss, closeAllQueueResources, formatQueueWarning, DEFAULT_EXPIRE_IN_SECONDS } from './queue';
 import type { MochiJob, MochiQueueStorage } from './queue';
 import { mochiEvents } from './events';
 import { initExtensions } from './extensions';
@@ -572,5 +572,37 @@ describe('Mochi queue', () => {
       { queue: name, jobId: solo! },
     ]);
     expect(bulks).toEqual([{ queue: name, count: 3, jobIds: ids }]);
+  });
+});
+
+describe('formatQueueWarning', () => {
+  test('folds the queued count and queue name into a large-backlog warning', () => {
+    const line = formatQueueWarning({
+      message: 'Warning: large queue backlog. Your queue should be reviewed',
+      data: { name: 'emails', queuedCount: 12345, warningQueueSize: 10000 },
+    });
+    expect(line).toBe('Warning: large queue backlog. Your queue should be reviewed (queue "emails" has 12345 jobs queued)');
+  });
+
+  test('coerces a string queuedCount (some drivers return integer columns as strings)', () => {
+    const line = formatQueueWarning({
+      message: 'Warning: large queue backlog. Your queue should be reviewed',
+      data: { name: 'emails', queuedCount: '42' as unknown as number },
+    });
+    expect(line).toContain('42 jobs queued');
+  });
+
+  test('singularizes a count of one', () => {
+    const line = formatQueueWarning({
+      message: 'Warning: large queue backlog. Your queue should be reviewed',
+      data: { name: 'emails', queuedCount: 1 },
+    });
+    expect(line).toContain('has 1 job queued');
+  });
+
+  test('passes warnings without queue-depth data through untouched', () => {
+    const message = 'Warning: slow query. Your queues and/or database server should be reviewed';
+    expect(formatQueueWarning({ message, data: { elapsed: 31, sql: 'select 1' } })).toBe(message);
+    expect(formatQueueWarning({ message, data: {} })).toBe(message);
   });
 });

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -1,7 +1,7 @@
 // The isolation boundary around bun-boss: the only module importing `bun-boss`, and the only one whose rewrite a
 // backend swap would need.
 import { BunBoss, fromBunSqlite, fromPglite, queueOptionDefaults } from 'bun-boss';
-import type { JobInsert, JobResult, JobWithMetadata, PGliteLike, SendOptions, UpdateQueueOptions, WorkOptions } from 'bun-boss';
+import type { JobInsert, JobResult, JobWithMetadata, PGliteLike, SendOptions, UpdateQueueOptions, WorkOptions, Warning } from 'bun-boss';
 import { SQL } from 'bun';
 import { mkdirSync } from 'node:fs';
 import path from 'node:path';
@@ -438,6 +438,19 @@ export async function startQueueRuntime(storage: MochiQueueStorage, opts?: { kin
   await registry.starting;
 }
 
+// bun-boss's large-backlog warning ("large queue backlog…") names the offending queue and its depth in
+// `warning.data`, but bakes neither into `warning.message`; fold the queued count in so the log line says
+// how big the backlog actually is. Other warnings (slow query, clock skew, notifier) carry no such fields
+// and pass through untouched.
+export function formatQueueWarning(warning: Warning): string {
+  const data = warning.data as { name?: unknown; queuedCount?: unknown };
+  const queuedCount = Number(data?.queuedCount);
+  if (typeof data?.name === 'string' && Number.isFinite(queuedCount)) {
+    return `${warning.message} (queue "${data.name}" has ${queuedCount} job${queuedCount === 1 ? '' : 's'} queued)`;
+  }
+  return warning.message;
+}
+
 async function bootQueueRuntime(storage: MochiQueueStorage, kind: 'serve' | 'standalone', enableSpies: boolean): Promise<void> {
   const spies = enableSpies ? { __test__enableSpies: true } : {};
   let boss: BunBoss;
@@ -462,7 +475,7 @@ async function bootQueueRuntime(storage: MochiQueueStorage, kind: 'serve' | 'sta
     mochiEvents.emit('queue:error', { error: error.message });
   });
   boss.on('warning', (warning) => {
-    logger.warn(`[queue] ${warning.message}`);
+    logger.warn(`[queue] ${formatQueueWarning(warning)}`);
   });
   try {
     await boss.start();


### PR DESCRIPTION
## What

When a queue's backlog crosses the warning threshold (`warningQueueSize`, default `10000`), bun-boss emits a `warning` event that Mochi forwarded to the log verbatim:

```
[queue] Warning: large queue backlog. Your queue should be reviewed
```

That line never said *how big* the backlog actually is. This adds the current queued-job count (and the offending queue's name) to the same message:

```
[queue] Warning: large queue backlog. Your queue should be reviewed (queue "emails" has 12345 jobs queued)
```

## How

bun-boss's large-backlog warning already carries the queue `name` and `queuedCount` in `warning.data` — it just doesn't bake them into `warning.message`. The new `formatQueueWarning()` helper (in `queue.ts`) folds those in when present.

The `warning` hook fires for other warnings too (slow query, clock skew, listen/notify fallback), none of which carry a `name`/`queuedCount` — those pass through untouched. The count is coerced with `Number()` since some drivers hand integer columns back as strings, and is singularized for a count of one.

## Tests

Added a `formatQueueWarning` unit suite in `queue.test.ts` covering the enriched line, string-coercion, singularization, and untouched pass-through for non-backlog warnings. Docs note added under Queues → Observability.

`bun run checks` is green.