### PR TITLE
feat: warn when route-handler HMR repeatedly re-creates module state

### DIFF
--- a/packages/docs/140-utility-helpers.md
+++ b/packages/docs/140-utility-helpers.md
@@ -98,6 +98,14 @@ export function getSql() {
 }
 ```
 
+Call the accessor wherever you need the value — every call returns the same instance:
+
+```ts
+import { getSql } from './db/client';
+
+const users = await getSql()`SELECT id, name FROM users`;
+```
+
 Reach for it to hold anything that must not be duplicated: a database pool, a connection, a background timer, an in-memory cache. In development this is what keeps such resources from leaking across [route-handler HMR](/docs/development-mode/#route-handler-hmr) — a plain module-scoped `let` is re-created on every reload and its old handle orphaned, but a `pinGlobal` value survives. Namespace your key with an `app:` prefix; the framework pins its own state under `__mochi_*__`.
 
 <SeeItInAction

--- a/packages/docs/140-utility-helpers.md
+++ b/packages/docs/140-utility-helpers.md
@@ -85,6 +85,21 @@ const token = encryptPayload(JSON.stringify({ iat: Date.now() }), { aad: 'my-for
 const opened = decryptPayload(token, { aad: 'my-form' }); // string | null
 ```
 
+### Process singletons
+
+`pinGlobal(key, factory)` returns one instance per `key` for the life of the process, pinned on `globalThis`. The `factory` runs at most once per key; every later call with the same key returns the same value.
+
+```ts
+import { SQL } from 'bun';
+import { pinGlobal } from 'mochi-framework';
+
+export function getSql() {
+  return pinGlobal('app:sql', () => new SQL(process.env.DATABASE_URL!, { max: 8 }));
+}
+```
+
+Reach for it to hold anything that must not be duplicated: a database pool, a connection, a background timer, an in-memory cache. In development this is what keeps such resources from leaking across [route-handler HMR](/docs/development-mode/#route-handler-hmr) — a plain module-scoped `let` is re-created on every reload and its old handle orphaned, but a `pinGlobal` value survives. Namespace your key with an `app:` prefix; the framework pins its own state under `__mochi_*__`.
+
 <SeeItInAction
 demos={[{ href: "/demos/url/", title: "Isomorphic URL", hook: "How the isomorphic URL helper works — one import that reads the request URL on the server and window.location on the client." }]}
 />

--- a/packages/docs/147-events.md
+++ b/packages/docs/147-events.md
@@ -30,6 +30,7 @@ Event names use a `namespace:action` convention. Every key is in the typed `Moch
 - [`action:invoke`](#actioninvoke), [`action:complete`](#actioncomplete) — form action lifecycle
 - [`compile:start`](#compilestart), [`compile:complete`](#compilecomplete), [`compile:error`](#compileerror) — Svelte SSR build
 - [`recompile:start`](#recompilestart), [`recompile:complete`](#recompilecomplete) — dev rebuild cycle
+- [`recompile:module-churn`](#recompilemodule-churn) — entry re-imported many times in a dev session (resource-leak warning)
 - [`client-bundle:complete`](#client-bundlecomplete) — hydratable client bundle finished
 - [`island:error`](#islanderror) — an island errored
 - [`captcha:verify`](#captchaverify) — a `<MochiCaptcha>` submission was verified or rejected
@@ -392,6 +393,22 @@ Fires after the matching `recompile:start`, once the rebuild finishes and client
 | `pageCount`         | `number`                             | pages that were rebuilt                        |
 | `clientBundleCount` | `number`                             | `buildClientBundle()` invocations during cycle |
 | `durationMs`        | `number`                             | wall-clock ms for the whole cycle              |
+
+#### `recompile:module-churn`
+
+Fires once per dev session, when the entry has been re-imported `reloadCount` times (default 10). Each reload re-evaluates the whole first-party module graph, so a module-scoped resource is re-created and the old one orphaned — see [route-handler HMR](/docs/development-mode/#route-handler-hmr). `consoleLogger()` renders it as a `warn`-level `HMR` line; suppress that line with a [`consoleLogger:line`](/docs/extensions/#consoleloggerline) filter matching `source.name === 'recompile:module-churn'`.
+
+| Field         | Type     | Notes                                       |
+| ------------- | -------- | ------------------------------------------- |
+| `reloadCount` | `number` | entry re-imports so far this session (≥ 10) |
+
+```ts
+import { mochiEvents } from 'mochi-framework';
+
+mochiEvents.on('recompile:module-churn', ({ reloadCount }) => {
+  console.warn(`entry re-imported ${reloadCount}× — hold resources with pinGlobal()`);
+});
+```
 
 #### `client-bundle:complete`
 

--- a/packages/docs/170-development-mode.md
+++ b/packages/docs/170-development-mode.md
@@ -97,6 +97,21 @@ export function getSql() {
 }
 ```
 
+Call `getSql()` wherever you need the pool — every call returns the same instance, so route handlers and `serverProps` share the one set of connections:
+
+```ts
+// file: src/routes.ts
+import { getSql } from './db/client';
+
+export const routes = {
+  '/users': Mochi.page('./src/Users.svelte', {
+    serverProps: async () => ({
+      users: await getSql()`SELECT id, name FROM users`,
+    }),
+  }),
+};
+```
+
 Namespace your key with an `app:` prefix — the framework uses `__mochi_*__` for its own pins. Setting `idleTimeout` is worth it regardless: it bounds the damage from any pool that still escapes.
 
 </Callout>

--- a/packages/docs/170-development-mode.md
+++ b/packages/docs/170-development-mode.md
@@ -83,7 +83,21 @@ await Mochi.serve({
 
 <Callout type="warning">
 
-Do **NOT** rely on module-scoped mutable state surviving a route HMR cycle. Each reload re-evaluates the entire entry dependency graph, resetting any `let` / `const` at module scope. Move shared state into a module the entry imports (an in-memory store or database), and keep top-level side effects idempotent.
+Each reload re-evaluates the **entire first-party dependency graph** — every `let` / `const` at module scope is recreated. This is not just a stale-cache annoyance: a module-scoped singleton that holds an **OS resource** (a DB pool, a `setInterval`, a file watcher, an SMTP pool) is re-created on every save while the previous instance is orphaned with its resource still open. Nothing closes it, so usage grows one leak per save until a hard failure — a Postgres pool, for example, exhausts `max_connections` after a dozen saves and takes the database down for every client.
+
+Moving the singleton "into a module the entry imports" does **not** help — that module is first-party, so it is exactly what gets re-evaluated. Hold the resource with [`pinGlobal`](/docs/utility-helpers/#process-singletons) instead, which pins one instance on `globalThis` that survives every reload:
+
+```ts
+// file: src/db/client.ts
+import { SQL } from 'bun';
+import { pinGlobal } from 'mochi-framework';
+
+export function getSql() {
+  return pinGlobal('app:sql', () => new SQL(process.env.DATABASE_URL!, { max: 8, idleTimeout: 30 }));
+}
+```
+
+Namespace your key with an `app:` prefix — the framework uses `__mochi_*__` for its own pins. Setting `idleTimeout` is worth it regardless: it bounds the damage from any pool that still escapes.
 
 </Callout>
 

--- a/packages/docs/170-development-mode.md
+++ b/packages/docs/170-development-mode.md
@@ -116,6 +116,20 @@ Namespace your key with an `app:` prefix — the framework uses `__mochi_*__` fo
 
 </Callout>
 
+Mochi warns once per dev session — via the [`recompile:module-churn`](/docs/events/#recompilemodule-churn) event — after the entry has been re-imported ten times, printed by `consoleLogger()` as a `warn`-level `HMR` line. If you have deliberately accepted the churn (or your resources are all held with `pinGlobal`), silence just that line with a [`consoleLogger:line`](/docs/extensions/#consoleloggerline) filter — the same mechanism the framework uses to hide its own internal routes:
+
+```ts
+// file: src/index.ts
+await Mochi.serve({
+  filters: {
+    'consoleLogger:line': (line, { source }) => (source.name === 'recompile:module-churn' ? null : line),
+  },
+  routes,
+});
+```
+
+Returning `null` drops the line; returning it unchanged keeps it. This suppresses only the churn warning — every other log line is untouched.
+
 ### `file:change` event
 
 Every watcher event re-emits on `mochiEvents` as `file:change`. Use it to invalidate your own caches:

--- a/packages/mochi/src/dev/consoleLogger.ts
+++ b/packages/mochi/src/dev/consoleLogger.ts
@@ -396,6 +396,15 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
       return { label: 'HMR ', path: relPath(path), note: styleText('dim', action), duration: durationMs, slow, verySlow };
     });
   }
+
+  // Not gated by `compile`: this is a resource-leak warning, not routine build chatter, so silencing build lines must
+  // not hide it. Drop it with a `consoleLogger:line` filter on `source.name === 'recompile:module-churn'` instead.
+  subscribe('recompile:module-churn', ({ reloadCount }) => ({
+    label: 'HMR ',
+    path: 'module-state',
+    note: `re-imported ${reloadCount}× — module-scoped resources leak on each reload (DB pools, timers, SMTP pools); hold them with ${styleText('cyan', 'pinGlobal()')} → /docs/development-mode`,
+    level: 'warn',
+  }));
 }
 
 /**

--- a/packages/mochi/src/dev/devWatcher.test.ts
+++ b/packages/mochi/src/dev/devWatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { isServerEntryDep } from './devWatcher';
+import { isServerEntryDep, moduleStateReloadWarning } from './devWatcher';
 
 describe('isServerEntryDep', () => {
   const shared = path.resolve('/proj/src/plugin-list.ts');
@@ -26,5 +26,27 @@ describe('isServerEntryDep', () => {
   test('the check resolves the changed path before matching', () => {
     const abs = path.resolve('helper.ts');
     expect(isServerEntryDep('helper.ts', new Set([abs]))).toBe(true);
+  });
+});
+
+describe('moduleStateReloadWarning', () => {
+  test('stays silent below the threshold', () => {
+    expect(moduleStateReloadWarning(9)).toBeNull();
+  });
+
+  test('warns exactly at the threshold and names the fix', () => {
+    const warning = moduleStateReloadWarning(10);
+    expect(warning).toContain('pinGlobal');
+    expect(warning).toContain('10');
+  });
+
+  test('stays silent past the threshold, so it fires once', () => {
+    expect(moduleStateReloadWarning(11)).toBeNull();
+    expect(moduleStateReloadWarning(50)).toBeNull();
+  });
+
+  test('honours a custom threshold', () => {
+    expect(moduleStateReloadWarning(3, 3)).toContain('pinGlobal');
+    expect(moduleStateReloadWarning(2, 3)).toBeNull();
   });
 });

--- a/packages/mochi/src/dev/devWatcher.test.ts
+++ b/packages/mochi/src/dev/devWatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import path from 'node:path';
-import { isServerEntryDep, moduleStateReloadWarning } from './devWatcher';
+import { isServerEntryDep, reachedModuleChurnThreshold } from './devWatcher';
 
 describe('isServerEntryDep', () => {
   const shared = path.resolve('/proj/src/plugin-list.ts');
@@ -29,24 +29,22 @@ describe('isServerEntryDep', () => {
   });
 });
 
-describe('moduleStateReloadWarning', () => {
-  test('stays silent below the threshold', () => {
-    expect(moduleStateReloadWarning(9)).toBeNull();
+describe('reachedModuleChurnThreshold', () => {
+  test('is false below the threshold', () => {
+    expect(reachedModuleChurnThreshold(9)).toBe(false);
   });
 
-  test('warns exactly at the threshold and names the fix', () => {
-    const warning = moduleStateReloadWarning(10);
-    expect(warning).toContain('pinGlobal');
-    expect(warning).toContain('10');
+  test('is true exactly at the threshold', () => {
+    expect(reachedModuleChurnThreshold(10)).toBe(true);
   });
 
-  test('stays silent past the threshold, so it fires once', () => {
-    expect(moduleStateReloadWarning(11)).toBeNull();
-    expect(moduleStateReloadWarning(50)).toBeNull();
+  test('is false past the threshold, so the warning fires once', () => {
+    expect(reachedModuleChurnThreshold(11)).toBe(false);
+    expect(reachedModuleChurnThreshold(50)).toBe(false);
   });
 
   test('honours a custom threshold', () => {
-    expect(moduleStateReloadWarning(3, 3)).toContain('pinGlobal');
-    expect(moduleStateReloadWarning(2, 3)).toBeNull();
+    expect(reachedModuleChurnThreshold(3, 3)).toBe(true);
+    expect(reachedModuleChurnThreshold(2, 3)).toBe(false);
   });
 });

--- a/packages/mochi/src/dev/devWatcher.ts
+++ b/packages/mochi/src/dev/devWatcher.ts
@@ -56,6 +56,16 @@ export function isServerEntryDep(filePath: string, serverEntryDeps: Set<string>)
   return !filePath.endsWith('.svelte') && serverEntryDeps.has(path.resolve(filePath));
 }
 
+// Each entry reload re-evaluates the whole first-party module graph, so a module-scoped resource (a DB pool, a timer,
+// an SMTP pool) is re-created and the old one orphaned with its handle still open. Fires exactly at the threshold so
+// the leak surfaces once per dev session instead of silently exhausting connections.
+export function moduleStateReloadWarning(count: number, threshold = 10): string | null {
+  if (count !== threshold) {
+    return null;
+  }
+  return `Entry has been re-imported ${count} times this session — module-scoped state is re-created on every reload, orphaning anything it holds open (DB pools, timers, SMTP pools). Hold such resources with pinGlobal() so they survive HMR — see /docs/development-mode.`;
+}
+
 export interface DevWatcherDeps {
   registry: ComponentRegistry;
   server: Server<undefined>;
@@ -259,6 +269,9 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
   // `extractServeOptions`, and hot-swap handlers in place for the running server.
   let serverEntryDeps: Set<string> = new Set();
   const entryBuildOutDir = path.resolve(`${outDir}/entry-hmr`);
+
+  let entryReloadCount = 0;
+  let moduleStateWarned = false;
 
   async function buildEntry(): Promise<Record<string, unknown> | null> {
     const result = await Bun.build({
@@ -504,6 +517,13 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       try {
         const freshRoutes = await buildEntry();
         if (freshRoutes) {
+          if (!moduleStateWarned) {
+            const warning = moduleStateReloadWarning(++entryReloadCount);
+            if (warning) {
+              logger.warn(warning);
+              moduleStateWarned = true;
+            }
+          }
           counts = await applyRouteChanges(freshRoutes);
           const hasChanges = counts.updated > 0 || counts.added.length > 0 || counts.removed.length > 0;
           if (hasChanges) {

--- a/packages/mochi/src/dev/devWatcher.ts
+++ b/packages/mochi/src/dev/devWatcher.ts
@@ -57,13 +57,10 @@ export function isServerEntryDep(filePath: string, serverEntryDeps: Set<string>)
 }
 
 // Each entry reload re-evaluates the whole first-party module graph, so a module-scoped resource (a DB pool, a timer,
-// an SMTP pool) is re-created and the old one orphaned with its handle still open. Fires exactly at the threshold so
-// the leak surfaces once per dev session instead of silently exhausting connections.
-export function moduleStateReloadWarning(count: number, threshold = 10): string | null {
-  if (count !== threshold) {
-    return null;
-  }
-  return `Entry has been re-imported ${count} times this session — module-scoped state is re-created on every reload, orphaning anything it holds open (DB pools, timers, SMTP pools). Hold such resources with pinGlobal() so they survive HMR — see /docs/development-mode.`;
+// an SMTP pool) is re-created and the old one orphaned with its handle still open. True exactly at the threshold so the
+// `recompile:module-churn` warning surfaces once per dev session instead of silently exhausting connections.
+export function reachedModuleChurnThreshold(count: number, threshold = 10): boolean {
+  return count === threshold;
 }
 
 export interface DevWatcherDeps {
@@ -517,12 +514,9 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       try {
         const freshRoutes = await buildEntry();
         if (freshRoutes) {
-          if (!moduleStateWarned) {
-            const warning = moduleStateReloadWarning(++entryReloadCount);
-            if (warning) {
-              logger.warn(warning);
-              moduleStateWarned = true;
-            }
+          if (!moduleStateWarned && reachedModuleChurnThreshold(++entryReloadCount)) {
+            mochiEvents.emit('recompile:module-churn', { reloadCount: entryReloadCount });
+            moduleStateWarned = true;
           }
           counts = await applyRouteChanges(freshRoutes);
           const hasChanges = counts.updated > 0 || counts.added.length > 0 || counts.removed.length > 0;

--- a/packages/mochi/src/events.test.ts
+++ b/packages/mochi/src/events.test.ts
@@ -40,6 +40,17 @@ describe('mochiEvents', () => {
     });
   });
 
+  test('recompile:module-churn is part of the event map', () => {
+    let received: unknown = null;
+    const handler = (e: unknown) => {
+      received = e;
+    };
+    mochiEvents.on('recompile:module-churn', handler);
+    mochiEvents.emit('recompile:module-churn', { reloadCount: 10 });
+    mochiEvents.off('recompile:module-churn', handler);
+    expect(received).toEqual({ reloadCount: 10 });
+  });
+
   test('queue:completed is part of the event map', () => {
     let received: unknown = null;
     const handler = (e: unknown) => {

--- a/packages/mochi/src/events.ts
+++ b/packages/mochi/src/events.ts
@@ -337,6 +337,11 @@ export interface MochiRecompileCompleteEvent {
   durationMs: number;
 }
 
+export interface MochiRecompileModuleChurnEvent {
+  /** How many times the entry has been re-imported this dev session. */
+  reloadCount: number;
+}
+
 export interface MochiClientBundleEvent {
   /** Entrypoints fed to `Bun.build` (HydratableIsland + per-component virtuals). */
   entryCount: number;
@@ -430,6 +435,7 @@ export type MochiEventMap = {
   'compile-cache:summary': MochiCompileCacheSummaryEvent;
   'recompile:start': MochiRecompileStartEvent;
   'recompile:complete': MochiRecompileCompleteEvent;
+  'recompile:module-churn': MochiRecompileModuleChurnEvent;
   'client-bundle:complete': MochiClientBundleEvent;
 };
 

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -108,6 +108,7 @@ export type {
   MochiCompileErrorLog,
   MochiRecompileStartEvent,
   MochiRecompileCompleteEvent,
+  MochiRecompileModuleChurnEvent,
   MochiRecompileTrigger,
   MochiClientBundleEvent,
   MochiCaptchaVerifyEvent,


### PR DESCRIPTION
## Problem

Every dev HMR rebuild re-imports the entry as a brand-new module graph (`buildEntry()` → `extractServeOptions(…, { fresh: true })` → `freshImport`). `Bun.build({ packages: 'external' })` inlines everything outside `node_modules`, so the **entire first-party graph** is re-evaluated on each save. A module-scoped singleton holding an **OS resource** — a Bun `SQL` pool, a `setInterval`, a file watcher, an SMTP pool — isn't just reset: the old instance is orphaned with its resource still open, and nothing closes it. Resource use grows one leak per save. A reported session hit 100 Postgres connections after ~14 saves and took down a shared database (`too many clients already`) for every client on the network.

The existing `development-mode` docs made this worse: the "Route handler HMR" callout recommended moving state *"into a module the entry imports"* — which is exactly the module that gets re-evaluated — and never mentioned `pinGlobal`, the framework's own answer (it's exported from `mochi-framework` but was undocumented).

## Changes

- **`devWatcher.ts`** — after 10 entry reloads, emit a **one-time** `logger.warn` pointing at `pinGlobal`, turning a silent leak into a visible one. Logic lives in a small exported pure helper `moduleStateReloadWarning(count, threshold)`, mirroring the existing `isServerEntryDep` pattern, with unit tests.
- **`170-development-mode.md`** — rewrite the HMR callout to name the resource leak and its real consequence, drop the failing "move it into a module the entry imports" advice, and show the `pinGlobal` fix (with the `app:` key convention and `idleTimeout`).
- **`140-utility-helpers.md`** — document `pinGlobal` as public API (new `Process singletons` section).

## Investigation: does this affect the framework itself? No.

Every resource Mochi opens is already pinned on `globalThis`, so none duplicate under HMR — and framework code is `packages: 'external'` (never re-imported by `freshImport`), plus HMR re-imports run inside `runInEntryImportScope` which stubs `Mochi.serve()`:

| Resource | Pin key |
| --- | --- |
| Queue (bun-boss + `SQL`) | `__mochi_queue_registry__` |
| Captcha (`bun:sqlite`) | `__mochi_captcha_runtime__` |
| Email (SMTP transport) | `__mochi_email_runtime__` |
| Image sweeper (`setInterval`) | `__mochi_image_runtime__` |
| Cache `FileStorage` sweeper | `__mochi_cache_sweeper_owners__` (newest-wins) |

## Verification

- `bun run checks` passes (lint + format + typecheck + test; 177/177 mochi, 13/13 site, 2/2 support).
- Docs render 200 in the dev site with no build/`ReferenceError`; both cross-link anchors (`#process-singletons`, `#route-handler-hmr`) resolve.

## Out of scope

A `mochi:entryReload` disposal event (to let app code close what it opened) is deferred — the docs + `pinGlobal` + visible warning cover the reported pain.