### PR TITLE
fix(queue): configurable graceful queue-drain timeout on shutdown

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -115,7 +115,7 @@
         "@joint-ops/hitlimit-bun": "1.5.0",
         "@noble/ciphers": "2.2.0",
         "@noble/hashes": "2.2.0",
-        "bun-boss": "^0.5.0",
+        "bun-boss": "^0.5.1",
         "chokidar": "^5.0.0",
         "css-tree": "^3.2.1",
         "deepmerge": "^4.3.1",
@@ -689,7 +689,7 @@
 
     "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
 
-    "bun-boss": ["bun-boss@0.5.0", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-63Va9FnVg5oNOp/V6CJd7eGmGcS3fcsM1p4egHCAMBeiLt9gq2bIX0aL5/eoqozvqkTtHkyBRnPz2G3wmxG3vA=="],
+    "bun-boss": ["bun-boss@0.5.1", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-eRkLHfGx+cF1f2D5psluIfhq8oLnLSEBMukGXYdBfqnMAFUlvm+gkpNelg5w2plCen+r/OpE0Yfl1uLL0lGkXQ=="],
 
     "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
 

--- a/packages/docs/115-queues.md
+++ b/packages/docs/115-queues.md
@@ -311,7 +311,15 @@ When a queue's backlog crosses the warning threshold (`warningQueueSize`, defaul
 
 ### Shutdown
 
-Queues close gracefully on `SIGTERM`/`SIGINT`. In-flight jobs get up to 10 seconds to finish; a job still running after that is failed and follows its queue's retry policy from the store. For a worker process with an HTTP port (health checks, metrics), use `Mochi.serve({ queues })` with no `routes` — [`Mochi.worker()`](#standalone-workers) is the serverless alternative:
+Queues close gracefully on `SIGTERM`/`SIGINT`. In-flight jobs get up to `queueShutdownTimeout` (default 10 seconds) to finish; a job still running after that is failed and follows its queue's retry policy from the store. Raise it for handlers that legitimately run longer than 10s, so a job in flight at shutdown finishes instead of being re-run:
+
+```ts
+Mochi.serve({ queues, queueShutdownTimeout: 60_000 }); // or Mochi.worker({ queues, queueShutdownTimeout })
+```
+
+<VersionNote since="0.10.0" message="queueShutdownTimeout was added in 0.10.0; before it, the queue graceful-drain window was fixed at 10s." />
+
+It is distinct from `shutdownTimeout`, which bounds the HTTP-server drain. For a worker process with an HTTP port (health checks, metrics), use `Mochi.serve({ queues })` with no `routes` — [`Mochi.worker()`](#standalone-workers) is the serverless alternative:
 
 ```ts
 // worker.ts — run with `bun worker.ts`

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -106,7 +106,7 @@
     "@joint-ops/hitlimit-bun": "1.5.0",
     "@noble/ciphers": "2.2.0",
     "@noble/hashes": "2.2.0",
-    "bun-boss": "^0.5.0",
+    "bun-boss": "^0.5.1",
     "chokidar": "^5.0.0",
     "css-tree": "^3.2.1",
     "deepmerge": "^4.3.1",

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -251,7 +251,7 @@ export class Mochi {
    * handling is yours to wire (`Mochi.stop()` drains and closes the runtime).
    */
   static worker(options: MochiWorkerOptions): MochiWorker {
-    return createWorker(options.queues, options.storage, options.queueConfig);
+    return createWorker(options.queues, options.storage, options.queueConfig, options.queueShutdownTimeout);
   }
 
   /**
@@ -2005,7 +2005,7 @@ export class Mochi {
       if (declaredQueues.length > 0) {
         // kind 'serve' adopts a standalone producer runtime already connected to the same storage.
         await startQueueRuntime(queueStorage, { kind: 'serve' });
-        await mountQueues(declaredQueues, resolveQueueConfigMode(options.queueConfig));
+        await mountQueues(declaredQueues, resolveQueueConfigMode(options.queueConfig), options.queueShutdownTimeout);
       }
     } catch (err) {
       await closeAllQueueResources();

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -215,7 +215,11 @@ interface QueueRegistry {
   storage: MochiQueueStorage | null;
   /** In-flight standalone boot, so concurrent first-adds share one `start()`. */
   starting: Promise<void> | null;
+  /** Graceful drain budget (ms) for shutdown, from `queueShutdownTimeout`; see `closeAllQueueResources`. */
+  shutdownTimeout: number;
 }
+
+const DEFAULT_QUEUE_SHUTDOWN_TIMEOUT = 10_000;
 
 // Pinned so every duplicate bundled copy of this module shares one registry, since `closeAllQueueResources` must see
 // every resource to drain it whichever copy created it.
@@ -227,6 +231,7 @@ const registry = pinGlobal<QueueRegistry>('__mochi_queue_registry__', () => ({
   kind: null,
   storage: null,
   starting: null,
+  shutdownTimeout: DEFAULT_QUEUE_SHUTDOWN_TIMEOUT,
 }));
 
 export function storageEquals(a: MochiQueueStorage | null, b: MochiQueueStorage): boolean {
@@ -884,8 +889,9 @@ export function createQueueDescriptor<T = unknown, R = unknown>(name: string, co
  * Mount every queue declared in `Mochi.serve({ queues })` on the running boss: ensure each exists with its declared
  * config, then start a worker for each that has a processor.
  */
-export async function mountQueues(queues: MountableQueue[], mode: 'verify' | 'sync' = 'verify'): Promise<void> {
+export async function mountQueues(queues: MountableQueue[], mode: 'verify' | 'sync' = 'verify', shutdownTimeout: number = DEFAULT_QUEUE_SHUTDOWN_TIMEOUT): Promise<void> {
   const boss = requireBoss();
+  registry.shutdownTimeout = shutdownTimeout;
   await verifyOrCreateQueues(queues, 'Mochi.serve({ queues })', mode);
   // Only the declared array is registered — implicit descriptor-form deadLetter targets are ensured, not mounted.
   for (const config of queues) {
@@ -923,7 +929,12 @@ export interface MochiWorker {
 }
 
 /** Implements `Mochi.worker(options)` — see its JSDoc there. */
-export function createWorker(queues: MountableQueue[], storage?: MochiQueueStorage, queueConfig?: 'verify' | 'sync'): MochiWorker {
+export function createWorker(
+  queues: MountableQueue[],
+  storage?: MochiQueueStorage,
+  queueConfig?: 'verify' | 'sync',
+  shutdownTimeout: number = DEFAULT_QUEUE_SHUTDOWN_TIMEOUT,
+): MochiWorker {
   if (queues.length === 0) {
     throw new Error('Mochi.worker(): declare at least one queue.');
   }
@@ -981,6 +992,7 @@ export function createWorker(queues: MountableQueue[], storage?: MochiQueueStora
           );
         }
         const boss = requireBoss();
+        registry.shutdownTimeout = shutdownTimeout;
         await verifyOrCreateQueues(queues, 'Mochi.worker()', resolveQueueConfigMode(queueConfig));
         for (const q of queues) {
           if (!registry.byName.has(q.name)) {
@@ -1048,7 +1060,7 @@ export async function closeAllQueueResources(): Promise<void> {
   while (registry.starting) {
     await registry.starting.catch(() => {});
   }
-  const { boss, ownedSql } = registry;
+  const { boss, ownedSql, shutdownTimeout } = registry;
   // Cleared first so a fresh serve in this process (e.g. a test that restarts) can re-mount its queues even if a
   // close below fails.
   registry.boss = null;
@@ -1058,9 +1070,13 @@ export async function closeAllQueueResources(): Promise<void> {
   registry.starting = null;
   registry.byName.clear();
   registry.workIds.clear();
+  registry.shutdownTimeout = DEFAULT_QUEUE_SHUTDOWN_TIMEOUT;
   if (boss) {
     try {
-      await boss.stop({ graceful: true, timeout: 10_000 });
+      // bun-boss drains in-flight handlers within the graceful window and settles their cleanups before closing
+      // the store; a job still running when the window lapses is failed and follows its retry policy. Raising
+      // `queueShutdownTimeout` above the job duration lets it finish instead of being re-run.
+      await boss.stop({ graceful: true, timeout: shutdownTimeout });
     } catch (err) {
       logger.warn(`[queue] shutdown: ${err instanceof Error ? err.message : String(err)}`);
     }

--- a/packages/mochi/src/queueWorker.test.ts
+++ b/packages/mochi/src/queueWorker.test.ts
@@ -210,4 +210,72 @@ describe('Mochi.worker()', () => {
       warn.mockRestore();
     }
   }, 20_000);
+
+  test('drains an in-flight job on shutdown so it completes instead of being failed and re-run', async () => {
+    const file = path.join(dataDir, 'worker-drain.sqlite');
+    const processed: number[] = [];
+    const inFlight = deferred<void>();
+    const queue = Mochi.queue<{ n: number }>('drain-jobs', {
+      storage: { sqlite: file },
+      pollingIntervalSeconds: 0.5,
+      process: async (job: MochiJob<{ n: number }>) => {
+        processed.push(job.data.n);
+        inFlight.resolve();
+        // Still running when shutdown begins; the drain must wait for it to finish.
+        await Bun.sleep(600);
+      },
+    });
+
+    const jobId = await queue.add({ n: 1 });
+    const worker = Mochi.worker({ queues: [queue] });
+    await worker.start();
+    await inFlight.promise;
+
+    // The global teardown path (what Mochi.stop()/SIGINT run) gracefully drains in-flight jobs.
+    await closeAllQueueResources();
+    expect(processed).toEqual([1]);
+
+    // Re-open the same store: the job settled as completed, not left in retry for a future worker to re-run.
+    await startQueueRuntime({ sqlite: file });
+    expect((await getBoss().getJobById('drain-jobs', jobId!))?.state).toBe('completed');
+  }, 20_000);
+
+  test('queueShutdownTimeout bounds the drain: a job outlasting it is left for retry, not blocked on', async () => {
+    const file = path.join(dataDir, 'worker-drain-timeout.sqlite');
+    const inFlight = deferred<void>();
+    const queue = Mochi.queue<{ n: number }>('drain-timeout', {
+      storage: { sqlite: file },
+      pollingIntervalSeconds: 0.5,
+      process: async (_job: MochiJob<{ n: number }>) => {
+        inFlight.resolve();
+        await Bun.sleep(3000);
+      },
+    });
+
+    const jobId = await queue.add({ n: 1 });
+    const worker = Mochi.worker({ queues: [queue], queueShutdownTimeout: 500 });
+    await worker.start();
+    await inFlight.promise;
+
+    // The cut handler's late completion write (~3s) once queried the closed store and errored; bun-boss
+    // (>=0.5.1) settles the cleanup before closing, so capture logger.error across the drain window and
+    // assert it stays quiet — this also guards that the pinned bun-boss actually carries that fix.
+    const errs: string[] = [];
+    const err = spyOn(logger, 'error').mockImplementation((msg?: unknown) => {
+      errs.push(String(msg));
+    });
+    try {
+      const start = Date.now();
+      await closeAllQueueResources();
+      // Shutdown honors the 500ms budget instead of waiting out the 3s handler (default would be 10s).
+      expect(Date.now() - start).toBeLessThan(2000);
+      await Bun.sleep(2800);
+    } finally {
+      err.mockRestore();
+    }
+    expect(errs.filter((m) => /not opened|connection is not open|closed/i.test(m))).toEqual([]);
+
+    await startQueueRuntime({ sqlite: file });
+    expect((await getBoss().getJobById('drain-timeout', jobId!))?.state).not.toBe('completed');
+  }, 20_000);
 });

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -281,6 +281,12 @@ export interface MochiWorkerOptions {
    * forces `'sync'` process-wide and wins over this option.
    */
   queueConfig?: 'verify' | 'sync';
+  /**
+   * Grace period (ms) on shutdown for in-flight queue jobs to drain before the boss is stopped and the store closed.
+   * Default: `10000`. Raise it for handlers that legitimately run longer than 10s, so a job in flight at shutdown
+   * finishes and is not failed and re-run.
+   */
+  queueShutdownTimeout?: number;
 }
 
 export type MochiRouteValue = MochiPageConfig | MochiApiConfig | MochiWsConfig | MochiSseConfig | MochiFileConfig | BunRouteValue;
@@ -470,6 +476,12 @@ export interface MochiServeOptions {
    * forces `'sync'` process-wide and wins over this option.
    */
   queueConfig?: 'verify' | 'sync';
+  /**
+   * Grace period (ms) on shutdown for in-flight queue jobs to drain before the boss is stopped and the store closed.
+   * Default: `10000`. Distinct from `shutdownTimeout`, which bounds the HTTP server drain. Raise it for queues whose
+   * handlers legitimately run longer than 10s, so a job in flight at shutdown finishes and is not failed and re-run.
+   */
+  queueShutdownTimeout?: number;
   fetch?: (req: Request, server: Server<undefined>) => Response | Promise<Response>;
   htmlShell?: string;
   /**


### PR DESCRIPTION
Pairs with [khromov/bun-boss#52](https://github.com/khromov/bun-boss/pull/52), shipped in **bun-boss 0.5.1** (settle worker cleanups before closing the store on graceful stop). This PR bumps the `bun-boss` pin to `^0.5.1` and makes the queue graceful-drain window configurable.

## Problem

On shutdown of a `Mochi.worker()` / `Mochi.serve({ queues })` process with a job in flight, `closeAllQueueResources()` hardcoded `boss.stop({ graceful: true, timeout: 10_000 })`. A consumer whose handlers legitimately run longer than 10s had **every in-flight job failed and re-run on every restart**, with no way to raise the window. On the old bun-boss it also logged `Database connection is not opened` from the cut job's late completion write.

## Changes

- **Bump `bun-boss` to `^0.5.1`** — its `#doStop` now settles worker cleanups before closing the store, so a cut handler's late write no longer hits a closed connection.
- **`queueShutdownTimeout` option** on `Mochi.serve()` and `Mochi.worker()` (default `10_000`ms), distinct from `shutdownTimeout` (the HTTP-server drain). Threaded to the queue registry via `mountQueues()` / `createWorker()` and passed to `boss.stop()`. Raising it above the job duration lets a job in flight at shutdown finish instead of being re-run.

## Why timeout-only (no manual pre-drain)

An earlier revision also drained registered workers with `offWork({ wait: true })` before `boss.stop()`. Measured against bun-boss 0.5.1, that **reintroduced** the `Database connection is not opened` error for jobs exceeding the window: the raced `offWork` sets the worker to `stopping` outside bun-boss's `pendingOffWorkCleanups` tracking, so `settlePendingCleanups()` sees nothing to await and closes the store under the still-running handler. Letting bun-boss own the graceful drain (via a configurable `timeout`) is correct and simpler, so the manual pre-drain was dropped.

## Behavior (measured, sqlite, bun-boss 0.5.1)

| `queueShutdownTimeout` vs job | outcome |
|---|---|
| timeout > job duration | job **completes**, shutdown waits for it, no error |
| timeout < job duration | job left for **retry**, shutdown returns within the window, no error |

## Tests

`packages/mochi/src/queueWorker.test.ts`: (1) an in-flight job completes on shutdown instead of being re-run; (2) `queueShutdownTimeout` bounds the drain — a job outlasting it returns within the window, is left for retry, and logs **no** closed-store error (which also guards that the pinned bun-boss carries the cleanup fix). Full `bun run checks` green.

## Docs

`packages/docs/115-queues.md` Shutdown section documents `queueShutdownTimeout` with a `VersionNote since="0.10.0"`.