### PR TITLE
feat: strip dev-only client code from island bundles with Bun feature() DCE

### DIFF
--- a/packages/docs/160-serve-options.md
+++ b/packages/docs/160-serve-options.md
@@ -7,6 +7,7 @@ description: 'Reference for every configuration option on Mochi.serve().'
 
 <script>
   import Callout from './_components/Callout.svelte';
+  import VersionNote from './_components/VersionNote.svelte';
 </script>
 
 ## Serve options
@@ -49,6 +50,7 @@ In production (`development: false`), prebuilt JS/CSS bundles served from `asset
 - `hostname` — interface to bind. Defaults to Bun's default (`0.0.0.0`).
 - `development` — enables live reload, debug bar, and dev error overlay. Default: `true`.
 - `liveReload` — enable the dev-mode live-reload WebSocket. Default: matches `development`. Set `false` to keep the debug bar but skip the socket.
+- `clientDebug` — keep the island runtime's verbose debug logging in the client bundle even in a production build. Default: `false`. See [Client debug logging](#client-debug-logging).
 - `shutdownTimeout` — grace period (ms) for in-flight requests on `SIGTERM`/`SIGINT`. Default: `5000` in production, `0` in development.
 - `routes` — `Record<string, MochiRouteValue>` of route paths to `Mochi.page` / `Mochi.api` / `Mochi.ws` / `Mochi.sse`.
 - `fetch` — `(req, server) => Response` fallback when no route matches. Default: built-in 404.
@@ -79,6 +81,25 @@ In production (`development: false`), prebuilt JS/CSS bundles served from `asset
 <Callout type="info">
 
 **Sync `assetPrefix` between build and runtime.** When using a prebuilt manifest, pass `assetPrefix` to the `build()` call (or `--asset-prefix`) so the baked-in URLs match. The manifest's URLs take precedence at runtime if the two disagree.
+
+</Callout>
+
+### Client debug logging
+
+<VersionNote since="0.10.0" message="Before 0.10.0, island debug logging was gated only at runtime and still shipped in the client bundle." />
+
+The island runtime logs verbose diagnostics (hydration steps, component loads) at the `log`/`debug` level. In a production build these calls — and the argument objects they build — are eliminated from the client bundle at compile time via Bun's [`feature()`](https://bun.com/docs/bundler#features) flags, so they add no bytes and no per-island work. In development they stay on.
+
+To keep them in a production build while chasing a prod-only hydration bug, set `clientDebug: true`, or build with the `MOCHI_CLIENT_DEBUG=1` env var (which also reaches the ahead-of-time `mochi build`, which has no `serve()` options). Then raise the browser log level to see them:
+
+```ts
+import { setLogLevel } from 'mochi-framework';
+setLogLevel('debug'); // in the browser
+```
+
+<Callout type="info">
+
+`clientDebug` only affects which code is bundled — it does not change the log level. It is independent of `development`, so a fully production-compiled bundle can still carry the logging.
 
 </Callout>
 

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -441,6 +441,7 @@ export class Mochi {
     const warmupEnabled = resolveWarmupEnabled(options.warmup, development);
     const debugBarEnabled = development && (options.debugBar ?? true);
     const liveReloadEnabled = options.liveReload ?? development;
+    const clientDebug = development || (options.clientDebug ?? false) || process.env.MOCHI_CLIENT_DEBUG === '1';
     const middleware = options.handle;
     const protectionEnabled = options.protection?.enabled === true;
     const baseOutDir = options.outDir ?? './.mochi';
@@ -511,6 +512,7 @@ export class Mochi {
       registry = new ComponentRegistry({
         development,
         debugBar: options.debugBar,
+        clientDebug: options.clientDebug,
         outDir,
         assetPrefix: options.assetPrefix,
         svelteConfig,
@@ -627,8 +629,8 @@ export class Mochi {
 
     // Prod-with-manifest restores this from disk (baked by `build()`); otherwise
     // build it on demand. LiveReload is dev-only, so it's never prebuilt.
-    const serverIslandClientJs = registry.serverIslandClientJs ?? (await buildInlineWebComponent('./web-components/ServerIsland.ts'));
-    const liveReloadClientJs = liveReloadEnabled ? await buildInlineWebComponent('./web-components/LiveReload.ts') : '';
+    const serverIslandClientJs = registry.serverIslandClientJs ?? (await buildInlineWebComponent('./web-components/ServerIsland.ts', { debug: clientDebug }));
+    const liveReloadClientJs = liveReloadEnabled ? await buildInlineWebComponent('./web-components/LiveReload.ts', { debug: clientDebug }) : '';
 
     // Precompute request-invariant shell fragments once; `getTemplate` reads the
     // live `shellTemplate` so dev shell edits (reloadShell) are picked up.

--- a/packages/mochi/src/bun-bundle.d.ts
+++ b/packages/mochi/src/bun-bundle.d.ts
@@ -1,0 +1,11 @@
+// Restricts `feature()` (from `bun:bundle`) to the framework's known client-build flags, so a
+// typo like `feature('MOCH_DEBUG')` is a compile error. `@types/bun` already declares the module
+// and `feature` itself — this only augments its `Registry`.
+//
+// - MOCHI_DEBUG: verbose island debug logging; on in dev, stripped from prod client bundles.
+// - MOCHI_CLIENT: browser-build platform flag; strips server-only ANSI from the isomorphic logger.
+declare module 'bun:bundle' {
+  interface Registry {
+    features: 'MOCHI_DEBUG' | 'MOCHI_CLIENT';
+  }
+}

--- a/packages/mochi/src/cli/build.ts
+++ b/packages/mochi/src/cli/build.ts
@@ -49,6 +49,8 @@ export interface MochiBuildOptions {
   resources?: boolean;
   /** Mirror the value passed to `Mochi.serve({ protection })` so the interstitial page prebuilds into the manifest. Default: disabled. See `MochiServeOptions['protection']`. */
   protection?: MochiProtectionOptions;
+  /** Mirror the value passed to `Mochi.serve({ clientDebug })` so the prebuilt client bundle keeps `MOCHI_DEBUG` island logging. Default: `false`. `MOCHI_CLIENT_DEBUG=1` forces it on too. See `MochiServeOptions['clientDebug']`. */
+  clientDebug?: boolean;
 }
 
 type RouteKind = 'page' | 'api' | 'ws' | 'sse';
@@ -110,7 +112,8 @@ export async function build(options: MochiBuildOptions): Promise<void> {
     // Started now so it overlaps the compile phases, and awaited before the manifest. The `.catch(() => {})` guard only
     // marks a rejection handled in case compileAll throws first; the real error still surfaces at the trailing `await`.
     // `timed` wraps the work rather than that await, so the phase line reports real duration, not residual wait.
-    const serverIslandScriptPromise = timed('island-script', () => buildInlineWebComponent('./web-components/ServerIsland.ts'));
+    const serverIslandDebug = development || (options.clientDebug ?? false) || process.env.MOCHI_CLIENT_DEBUG === '1';
+    const serverIslandScriptPromise = timed('island-script', () => buildInlineWebComponent('./web-components/ServerIsland.ts', { debug: serverIslandDebug }));
     serverIslandScriptPromise.catch(() => {});
     // The runtime serves static files straight from publicDir in every mode, so all the build adds is proof that no
     // public file shadows a declared route and a deploy silently drops an asset. The runtime's own
@@ -139,6 +142,7 @@ export async function build(options: MochiBuildOptions): Promise<void> {
     const svelteConfig = await loadSvelteConfig(options.svelteConfigPath);
     const registry = new ComponentRegistry({
       development,
+      clientDebug: options.clientDebug,
       outDir,
       assetPrefix: options.assetPrefix,
       svelteConfig,

--- a/packages/mochi/src/cli/cli.ts
+++ b/packages/mochi/src/cli/cli.ts
@@ -182,6 +182,7 @@ async function main() {
     errorPage: serveOptions?.errorPage,
     resources: serveOptions?.build?.resources,
     protection: serveOptions?.protection,
+    clientDebug: serveOptions?.clientDebug,
     development: values.dev,
     outDir: values['out-dir'],
     // Fall back to the entry's own `publicDir` so the build validates the same

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -38,7 +38,7 @@ import { backendId, resolveSvelteCompiler, type MochiSvelteCompiler, type Svelte
 import { applyFilter } from '../extensions';
 import { decodeSourcePath, encodeSourcePath } from './manifestPaths';
 import { buildServerOnlyStubModule, scanServerOnlyExports } from './serverOnlyScan';
-import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
+import { CLIENT_BUILD_DEFINE, clientBuildFeatures, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 import { registerServerOnlyComponentStubs, SSR_ONLY_COMPONENT_NAMESPACE } from './serverOnlyComponents';
 import { cleanInputs, SERVER_ONLY_MODULE_NAMESPACE } from './bundleInputPaths';
 import { renderMochiEnvServer } from './virtualModuleTemplate';
@@ -295,6 +295,8 @@ export interface ComponentRegistryOptions {
   development?: boolean;
   /** Bundle and surface the dev-only debug-bar entry. Default: same as `development`. */
   debugBar?: boolean;
+  /** Keep `MOCHI_DEBUG`-gated island debug logging in the client bundle even in production. Default: `false`. */
+  clientDebug?: boolean;
   /** Directory for build artifacts (cwd-relative). Default: `./.mochi`. */
   outDir?: string;
   /** URL prefix for framework client assets (JS/CSS). Default: `/_mochi`. */
@@ -431,6 +433,8 @@ export class ComponentRegistry {
   /** Files `publicDir` held when this manifest was built; see `MochiManifest.publicFileCount`. 0 when not loaded from one. */
   publicFileCountAtBuild = 0;
   readonly debugBarEnabled: boolean;
+  /** Whether `MOCHI_DEBUG` is passed to the client build — on in dev, or forced in prod via the option / `MOCHI_CLIENT_DEBUG`. */
+  readonly clientDebug: boolean;
   readonly outDir: string;
   readonly assetPrefix: string;
   svelteConfig: MochiSvelteConfig;
@@ -459,6 +463,7 @@ export class ComponentRegistry {
   constructor(opts: ComponentRegistryOptions = {}) {
     this.development = opts.development ?? true;
     this.debugBarEnabled = this.development && (opts.debugBar ?? true);
+    this.clientDebug = this.development || (opts.clientDebug ?? false) || process.env.MOCHI_CLIENT_DEBUG === '1';
     // A relative outDir resolves against whoever's cwd asks, and compile and `toManifest()` ask at different moments, so
     // a `process.chdir()` in between would make every artifact look like it escaped the out-dir and bake absolute paths
     // into an otherwise relocatable build.
@@ -1258,6 +1263,7 @@ export class ComponentRegistry {
         NODE: 'false',
         ...CLIENT_BUILD_DEFINE,
       },
+      features: clientBuildFeatures(this.clientDebug),
       minify: true,
       splitting: true,
       naming: '[name]-[hash].[ext]',

--- a/packages/mochi/src/compiler/buildDebugBarBundle.ts
+++ b/packages/mochi/src/compiler/buildDebugBarBundle.ts
@@ -6,7 +6,7 @@
  */
 import path from 'node:path';
 import type { BunPlugin } from 'bun';
-import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
+import { CLIENT_BUILD_DEFINE, clientBuildFeatures, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 import { registerServerOnlyComponentStubs } from './serverOnlyComponents';
 import { registerEsmEnvStrip, registerMochiEnvClient, registerSvelteModuleLoader } from './clientBuildLoaders';
 import { mergeCompilerOptions } from './svelteConfig';
@@ -61,6 +61,8 @@ export async function buildDebugBarBundle(opts: { development: boolean; backend:
       NODE: 'false',
       ...CLIENT_BUILD_DEFINE,
     },
+    // The bar only builds in dev, so keep its debug logging.
+    features: clientBuildFeatures(true),
     minify: !diagnostic,
     naming: '[name]-[hash].[ext]',
     throw: false,

--- a/packages/mochi/src/compiler/buildInlineWebComponent.ts
+++ b/packages/mochi/src/compiler/buildInlineWebComponent.ts
@@ -4,19 +4,20 @@
  * resolved relative to `src/`, so callers pass paths like
  * `./web-components/ServerIsland.ts`.
  */
-import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
+import { CLIENT_BUILD_DEFINE, clientBuildFeatures, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 
 // This file lives in `src/compiler/`, so climb one level: resolving `relPath`
 // against `import.meta.url` would anchor callers' paths to `src/compiler/`.
 const SRC_URL = new URL('../', import.meta.url);
 
-export async function buildInlineWebComponent(relPath: string): Promise<string> {
+export async function buildInlineWebComponent(relPath: string, { debug = false }: { debug?: boolean } = {}): Promise<string> {
   const entry = Bun.fileURLToPath(new URL(relPath, SRC_URL));
   const result = await Bun.build({
     entrypoints: [entry],
     plugins: [serverOnlyModuleGuard],
     target: 'browser',
     define: { ...CLIENT_BUILD_DEFINE },
+    features: clientBuildFeatures(debug),
     minify: true,
     throw: false,
   });

--- a/packages/mochi/src/compiler/serverOnlyModuleGuard.ts
+++ b/packages/mochi/src/compiler/serverOnlyModuleGuard.ts
@@ -22,6 +22,14 @@ const SERVER_ONLY_MODULES = new Map<string, string>([
 /** Injected by every browser build so `utils/serverOnly.ts` can tell which bundle it landed in. */
 export const CLIENT_BUILD_DEFINE = { MOCHI_CLIENT: 'true' } as const;
 
+// `bun:bundle` feature flags for the three client (`target:'browser'`) builds — passed nowhere else,
+// so `feature('MOCHI_CLIENT')` degrades to `false` on the server (bundled SSR and unbundled dev),
+// keeping server-side ANSI logging intact. `MOCHI_DEBUG` gates verbose island logging; keep it off
+// in prod unless `debug` (dev, the `clientDebug` serve option, or `MOCHI_CLIENT_DEBUG=1`) is set.
+export function clientBuildFeatures(debug: boolean): ('MOCHI_CLIENT' | 'MOCHI_DEBUG')[] {
+  return debug ? ['MOCHI_CLIENT', 'MOCHI_DEBUG'] : ['MOCHI_CLIENT'];
+}
+
 // Narrow enough that the handler runs for a handful of specifiers per build; a
 // user file that happens to share one of these basenames falls through to normal
 // resolution below.

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -449,6 +449,12 @@ export interface MochiServeOptions {
    */
   liveReload?: boolean;
   /**
+   * Keep the `MOCHI_DEBUG`-gated island debug logging in the client bundle even in a production build, for diagnosing a
+   * prod-only hydration issue. Default: `false` (dev builds always keep it). The `MOCHI_CLIENT_DEBUG=1` env var forces it
+   * on too, and also reaches the ahead-of-time `mochi build` path, which has no serve options.
+   */
+  clientDebug?: boolean;
+  /**
    * Grace period (ms) on `SIGTERM`/`SIGINT` for in-flight requests to finish before connections are force-closed.
    * Default: `5000` in production, `0` in development, where `0` force-closes immediately. A non-forced `server.stop()`
    * never resolves while a WebSocket is open, so the forced fallback keeps one live-reload tab from wedging the process.

--- a/packages/mochi/src/utils/log.ts
+++ b/packages/mochi/src/utils/log.ts
@@ -1,3 +1,4 @@
+import { feature } from 'bun:bundle';
 import { pinGlobal } from './globalState';
 
 export type LogLevel = 'silent' | 'error' | 'warn' | 'info' | 'log' | 'debug';
@@ -15,10 +16,13 @@ const PREFIX = '[mochi]';
 
 // Inline ANSI escapes — log.ts is isomorphic (bundled for both server and
 // client), so it cannot import node:util whose browser polyfill lacks styleText.
-const red = (s: string) => `\x1b[31m${s}\x1b[39m`;
-const yellow = (s: string) => `\x1b[33m${s}\x1b[39m`;
-const green = (s: string) => `\x1b[32m${s}\x1b[39m`;
-const dim = (s: string) => `\x1b[2m${s}\x1b[22m`;
+// `feature('MOCHI_CLIENT')` is true only in the browser builds, where DevTools
+// consoles don't render escape codes, so each helper folds to a passthrough there
+// and keeps the escapes on the server (both bundled SSR and unbundled dev).
+const red = (s: string) => (feature('MOCHI_CLIENT') ? s : `\x1b[31m${s}\x1b[39m`);
+const yellow = (s: string) => (feature('MOCHI_CLIENT') ? s : `\x1b[33m${s}\x1b[39m`);
+const green = (s: string) => (feature('MOCHI_CLIENT') ? s : `\x1b[32m${s}\x1b[39m`);
+const dim = (s: string) => (feature('MOCHI_CLIENT') ? s : `\x1b[2m${s}\x1b[22m`);
 
 export const DEFAULT_LOG_LEVEL: LogLevel = 'warn';
 

--- a/packages/mochi/src/web-components/HydratableIsland.ts
+++ b/packages/mochi/src/web-components/HydratableIsland.ts
@@ -1,5 +1,6 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
+import { feature } from 'bun:bundle';
 import { hydrate, mount, unmount } from 'svelte';
 import type { Component } from 'svelte';
 import { parse as devalueParse } from 'devalue';
@@ -25,11 +26,13 @@ class HydratableIsland extends HTMLElement {
   connectedCallback() {
     const name = this.getAttribute('component-name');
     const hydrateOn = this.getAttribute('hydrate-on');
-    logger.log('connectedCallback', {
-      name,
-      hydrateOn,
-      attributes: [...this.attributes].map((a) => a.name + '=' + a.value),
-    });
+    if (feature('MOCHI_DEBUG')) {
+      logger.log('connectedCallback', {
+        name,
+        hydrateOn,
+        attributes: [...this.attributes].map((a) => a.name + '=' + a.value),
+      });
+    }
     if (this._hydrated) {
       return;
     }
@@ -80,13 +83,15 @@ class HydratableIsland extends HTMLElement {
     const componentUrl = this.getAttribute('component-url');
     const cssUrl = this.getAttribute('css-url');
 
-    logger.log('_doHydrate', {
-      name,
-      hasComponent: !!componentRegistry[name],
-      componentUrl,
-      cssUrl,
-      propsRaw,
-    });
+    if (feature('MOCHI_DEBUG')) {
+      logger.log('_doHydrate', {
+        name,
+        hasComponent: !!componentRegistry[name],
+        componentUrl,
+        cssUrl,
+        propsRaw,
+      });
+    }
 
     // Load deferred CSS if present (lazy islands) — once per URL
     if (cssUrl && !isLoadedCss(cssUrl)) {
@@ -103,7 +108,9 @@ class HydratableIsland extends HTMLElement {
 
     // Load the component's JS bundle (calls registerComponent on import)
     if (!componentRegistry[name] && componentUrl) {
-      logger.log('Loading component', name, componentUrl);
+      if (feature('MOCHI_DEBUG')) {
+        logger.log('Loading component', name, componentUrl);
+      }
       await import(componentUrl);
     }
 
@@ -165,7 +172,9 @@ class HydratableIsland extends HTMLElement {
       this._unmount = undefined;
       void unmount(instance);
     };
-    logger.log(clientOnly ? 'Mounted' : 'Hydrated', name);
+    if (feature('MOCHI_DEBUG')) {
+      logger.log(clientOnly ? 'Mounted' : 'Hydrated', name);
+    }
   }
 }
 

--- a/packages/mochi/src/web-components/HydratableIsland.ts
+++ b/packages/mochi/src/web-components/HydratableIsland.ts
@@ -4,7 +4,7 @@ import { feature } from 'bun:bundle';
 import { hydrate, mount, unmount } from 'svelte';
 import type { Component } from 'svelte';
 import { parse as devalueParse } from 'devalue';
-import { isDev, logger } from 'mochi-framework';
+import { logger } from 'mochi-framework';
 import './IslandFailure';
 import { islandFailureStub } from './islandFailureStub';
 import { observeVisible } from './sharedVisibilityObserver';
@@ -62,7 +62,7 @@ class HydratableIsland extends HTMLElement {
       // CSS load, or `hydrate()` itself before the boundary takes effect.
       const e = err instanceof Error ? err : new Error(String(err));
       logger.error(`Island "${name}" failed to hydrate:`, e);
-      this.innerHTML = islandFailureStub(name ?? '', isDev ? e.message : undefined);
+      this.innerHTML = islandFailureStub(name ?? '', feature('MOCHI_DEBUG') ? e.message : undefined);
     }
   }
 
@@ -146,7 +146,7 @@ class HydratableIsland extends HTMLElement {
     const transformError = (err: unknown): Error => {
       const e = err instanceof Error ? err : new Error(String(err));
       logger.error(`Island "${name}" runtime error:`, e);
-      const out = isDev ? e : new Error('Island error');
+      const out = feature('MOCHI_DEBUG') ? e : new Error('Island error');
       Object.defineProperty(out, 'message', {
         value: out.message,
         enumerable: true,

--- a/packages/mochi/src/web-components/ServerIsland.ts
+++ b/packages/mochi/src/web-components/ServerIsland.ts
@@ -1,6 +1,7 @@
 /// <reference lib="dom" />
 /// <reference lib="dom.iterable" />
 
+import { feature } from 'bun:bundle';
 import '../debug-bar/types';
 import { isReloadableIslandName, notifyDeferredIslandChange, registerDeferredIsland, unregisterDeferredIsland } from '../islands/deferInvalidation';
 
@@ -166,7 +167,7 @@ class ServerIsland extends HTMLElement {
         }
         const html = await response.text();
 
-        if (ll === 'log' || ll === 'debug') {
+        if (feature('MOCHI_DEBUG') && (ll === 'log' || ll === 'debug')) {
           console.log(`${tag} loaded (attempt ${attempt}, ${(html.length / 1024).toFixed(1)}kB, alsoHydrate=${alsoHydrate || 'none'})`);
         }
 


### PR DESCRIPTION
## What

Wires Bun's compile-time [`feature()`](https://bun.com/docs/bundler#features) API (`bun:bundle`) into the three `target:'browser'` builds so dev-only diagnostic code is eliminated from **production** frontend bundles — Svelte island runtimes, web components, and the isomorphic logger.

## Why

The island entries (`HydratableIsland.ts`, `ServerIsland.ts`) `import { isDev } from 'mochi-framework'`. Empirically, **Bun does not DCE an `if (isDev)` branch when `isDev` is an imported const**, even under `minify` — only the `DEV` *define* (free identifier) and same-module consts strip. So the verbose `logger.log(...)` diagnostics, their eagerly-constructed argument objects, and the server-only ANSI helpers shipped to every production island page. `feature()` strips reliably, and additionally decouples debug logging from dev-mode compilation.

| Mechanism (browser target, `minify:true`) | Dead branch removed? |
|---|---|
| `if (isDev)` where `isDev` is **imported** | **NO** |
| `if (DEV)` free identifier via `define` | yes |
| `if (feature('X'))` flag off | **yes** |

## How

Two client-only flags, passed **only** to the client builds (never the SSR build, so `feature()` is `false` server-side):

- **`MOCHI_DEBUG`** — verbose island debug logging. On in dev, stripped in prod. Force-on for a prod build via the new **`clientDebug`** serve option or **`MOCHI_CLIENT_DEBUG=1`** (which also reaches the AOT `mochi build`, which has no `serve()` options).
- **`MOCHI_CLIENT`** — always-on client platform flag; folds `log.ts`'s server-only ANSI helpers to passthroughs in the browser while keeping colors on the server (bundled SSR **and** unbundled dev — `feature()` degrades to `false` under `bun run`).

Shared `clientBuildFeatures(debug)` helper in `serverOnlyModuleGuard.ts` keeps all three client builds in lockstep. Wrapped call sites use `if (feature('X'))` / `if (feature('X') && cond)` (the required direct-condition form). ServerIsland's operational `console.warn`/`console.error`/`__mochi_warn` paths are left intact — only the debug success log is gated.

The two `isDev` error-masking ternaries in `HydratableIsland` are also switched to `feature('MOCHI_DEBUG')` so the dead branch is actually stripped (prod keeps only the masked `new Error('Island error')`; a forced-debug build keeps only the real error). Default behavior is unchanged (unmasked in dev, masked in prod); a `clientDebug` / `MOCHI_CLIENT_DEBUG=1` prod build now also surfaces real island error messages for troubleshooting.

## Bundle savings

Prod builds, `main` vs this branch. Deltas are the signal (chunk filenames are content-hashed and Bun's splitting distributes the runtime differently per app). Both artifacts load per page — the island chunk on any page with an island, the inline `server-island.js` in the HTML of any page using `mochi:defer` — so these are per-page-load, not one-time.

**`minimal`** (isolates the framework client code):

| Artifact | main | branch | Δ raw | Δ gzip |
|---|--:|--:|--:|--:|
| Island runtime chunk | 50,456 | 50,084 | −372 B (−0.7%) | −161 B (−0.9%) |
| Inline `server-island.js` | 3,847 | 3,716 | −131 B (−3.4%) | −65 B (−3.6%) |

**`site`** (73 pages, many islands):

| Artifact | main | branch | Δ raw | Δ gzip |
|---|--:|--:|--:|--:|
| Island runtime chunk | 16,510 | 16,159 | −351 B (−2.1%) | −142 B (−2.2%) |
| Inline `server-island.js` | 3,847 | 3,716 | −131 B (−3.4%) | −65 B (−3.6%) |

Byte savings are modest by design — the removed content is short diagnostic strings, four ANSI escape helpers, and the DCE'd masking branches. The bigger, non-byte win: the eager `logger.log` argument objects (e.g. `[...this.attributes].map(...)`) were **allocated on every island connect** in prod before the level check discarded them — now that work is gone entirely.

## Verification

- **DCE proof** — prod build of `minimal` + `site`: island chunk and prebuilt `server-island.js` carry no debug strings and no ANSI; `MOCHI_CLIENT_DEBUG=1` brings the `MOCHI_DEBUG` logging back (ANSI still stripped).
- **Server logging intact** — build/serve console still prints colored `[mochi]` lines.
- **Browser hydration** — `charts` demo on a prod build: all island scripts/chunks 200, multiple islands hydrate, **zero console errors/warnings**.
- **`bun run checks`** — green: 0 typecheck errors, all tests pass (mochi 177/177, demos 31/31, site 13/13, support, minimal, rsvelte).

Docs: new "Client debug logging" section + `clientDebug` option in `160-serve-options.md`, with a `VersionNote since="0.10.0"`.
