### PR TITLE
fix(site): force a full GC before generating the heap snapshot

### DIFF
--- a/memtest/README.md
+++ b/memtest/README.md
@@ -16,7 +16,8 @@ multi-day unattended run on a dedicated server.
    is exercised each pass.
 4. **Snapshot loop** — captures a **baseline snapshot immediately after readiness**,
    before any load is applied, then every `SNAPSHOT_INTERVAL_MS` downloads `/_heapsnapshot`
-   (`Bun.generateHeapSnapshot('v8')`) with **curl** to
+   (`Bun.gc(true)` + `Bun.generateHeapSnapshot('v8')`, so the dump measures live
+   memory rather than live-plus-garbage) with **curl** to
    `/snapshots/heap-<timestamp>.heapsnapshot`, then prunes to the newest
    `SNAPSHOT_KEEP` files. curl runs as a separate process so the large body
    streams to disk with constant memory and never contends with the load loop

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -161,6 +161,9 @@ export const routes: Record<string, MochiRouteValue> = {
   ...(HEAP_SNAPSHOTS_ENABLED
     ? {
         '/_heapsnapshot': Mochi.api(() => {
+          // Bun.generateHeapSnapshot() does not collect first, so without this the dump mixes live
+          // objects with uncollected garbage and every size read off it comes out high.
+          Bun.gc(true);
           const snapshot = Bun.generateHeapSnapshot('v8');
           const filename = `mochi-${Date.now()}.heapsnapshot`;
           return new Response(snapshot, {


### PR DESCRIPTION
## What

`/_heapsnapshot` now calls `Bun.gc(true)` before `Bun.generateHeapSnapshot('v8')`, so the dump measures live memory instead of live-plus-pending-garbage.

## Why

`Bun.generateHeapSnapshot('v8')` does not collect first. Verified with a standalone repro: allocate a 30 MB detached cycle, drop the reference, snapshot immediately — the 30 MB is still in the dump. An explicit `Bun.gc(true)` clears it.

```
HELD                     : total=30.10MB
DROPPED (no explicit gc) : total=30.23MB   <- garbage still present
AFTER Bun.gc(true)       : total=0.13MB
```

That matters for `memtest/`, which snapshots *while* its load loop is running — exactly when pending garbage is at its highest. Whether a given snapshot in the series includes a chunk of freshly-dropped garbage is otherwise down to where the allocator happened to be, and the offline leak analyzer has to diff through that noise.

## Measurements

Two A/B runs against `packages/site`, each: boot, replay all 128 sitemap URLs at 8-way concurrency, snapshot mid-flight.

| | no gc | with gc | delta |
|---|---|---|---|
| Run 1 | 131.08 MB / 369,838 nodes | 126.62 MB / 355,367 nodes | **−4.46 MB / −14,471** |
| Run 2 | 130.64 MB / 369,732 nodes | 126.09 MB / 355,088 nodes | **−4.55 MB / −14,644** |

Within-arm variance is ~0.5 MB, so the ~4.5 MB delta is roughly 10× the noise and reproduces cleanly.

Snapshot request latency is unchanged — 0.587s / 0.575s without, 0.585s / 0.593s with. The route is debug-only and already gated behind `HEAP_SNAPSHOTS_ENABLED`, so the synchronous collection costs nothing in normal operation.

Idle/lightly-loaded snapshots show no meaningful difference (120.54 MB vs 121.21 MB) — the win is specific to snapshotting under load, which is the harness's actual mode.

## Notes

`memtest/README.md` step 4 updated to describe the forced collection.

`bun run checks` fails at typecheck on this branch, but with 5 errors that reproduce identically on a clean `origin/main` (`Bun.XML` missing from `@types/bun` in `lib/docs.ts`/`feed.ts`/tests, and a `cron.ts` arity error) — none in files this PR touches. `lint:fix`/`format` are clean and `packages/site` tests pass 14/14.