### PR TITLE
refactor: reduce cyclomatic complexity of 46 functions below 15

### DIFF
--- a/.github/scripts/cli-regression-test.ts
+++ b/.github/scripts/cli-regression-test.ts
@@ -232,6 +232,49 @@ interface TemplateVariant {
   expectNoLintTooling: boolean;
 }
 
+type TemplateSteps = Record<'scaffold' | 'install' | 'test' | 'typecheck' | 'lint' | 'format' | 'omissions', StepResult>;
+
+// Assert an opt-out scaffold shipped no lint/format config files or scripts.
+function checkLintOmissions(scaffoldDir: string, label: string): StepResult {
+  const scripts = readScaffoldScripts(scaffoldDir);
+  const leftovers = [
+    ...['eslint.config.js', '.prettierrc', '.prettierignore'].filter((f) => existsSync(join(scaffoldDir, f))),
+    ...['lint', 'lint:fix', 'format', 'format:check'].filter((s) => scripts[s]).map((s) => `scripts.${s}`),
+  ];
+  const step: StepResult = {
+    name: 'omissions',
+    status: leftovers.length === 0 ? 'pass' : 'fail',
+    durationMs: null,
+    exitCode: null,
+    output: leftovers.length === 0 ? '' : `lint tooling present despite opt-out flags: ${leftovers.join(', ')}`,
+  };
+  console.log(`  [${label}]   omissions ${statusCell(step.status)}`);
+  return step;
+}
+
+async function runVerificationSteps(scaffoldDir: string, label: string, steps: TemplateSteps): Promise<void> {
+  console.log(`  [${label}] • test…`);
+  steps.test = toStep('test', await runCmd(['bun', 'run', 'test'], scaffoldDir));
+  console.log(`  [${label}]   ${statusCell(steps.test.status)} (${fmtDuration(steps.test.durationMs)})`);
+
+  console.log(`  [${label}] • typecheck…`);
+  steps.typecheck = toStep('typecheck', await runCmd(['bun', 'run', 'typecheck'], scaffoldDir));
+  console.log(`  [${label}]   ${statusCell(steps.typecheck.status)} (${fmtDuration(steps.typecheck.durationMs)})`);
+
+  // Lint tooling ships with create-mochi >=0.4.0 — older published CLIs scaffold without it, so these stay skipped.
+  const scripts = readScaffoldScripts(scaffoldDir);
+  if (scripts.lint) {
+    console.log(`  [${label}] • lint…`);
+    steps.lint = toStep('lint', await runCmd(['bun', 'run', 'lint'], scaffoldDir));
+    console.log(`  [${label}]   ${statusCell(steps.lint.status)} (${fmtDuration(steps.lint.durationMs)})`);
+  }
+  if (scripts['format:check']) {
+    console.log(`  [${label}] • format:check…`);
+    steps.format = toStep('format', await runCmd(['bun', 'run', 'format:check'], scaffoldDir));
+    console.log(`  [${label}]   ${statusCell(steps.format.status)} (${fmtDuration(steps.format.durationMs)})`);
+  }
+}
+
 async function runTemplate(template: TemplateId, id: string, variant?: TemplateVariant): Promise<TemplateResult> {
   const name = `mochi-test-${id}-${template}${variant?.suffix ?? ''}`;
   const scaffoldDir = join(TESTS_DIR, name);
@@ -263,19 +306,7 @@ async function runTemplate(template: TemplateId, id: string, variant?: TemplateV
     mochiVersion = extractMochiVersion(scaffold.stdout, scaffoldDir);
 
     if (variant?.expectNoLintTooling) {
-      const scripts = readScaffoldScripts(scaffoldDir);
-      const leftovers = [
-        ...['eslint.config.js', '.prettierrc', '.prettierignore'].filter((f) => existsSync(join(scaffoldDir, f))),
-        ...['lint', 'lint:fix', 'format', 'format:check'].filter((s) => scripts[s]).map((s) => `scripts.${s}`),
-      ];
-      steps.omissions = {
-        name: 'omissions',
-        status: leftovers.length === 0 ? 'pass' : 'fail',
-        durationMs: null,
-        exitCode: null,
-        output: leftovers.length === 0 ? '' : `lint tooling present despite opt-out flags: ${leftovers.join(', ')}`,
-      };
-      console.log(`  [${label}]   omissions ${statusCell(steps.omissions.status)}`);
+      steps.omissions = checkLintOmissions(scaffoldDir, label);
     }
 
     console.log(`  [${label}] • install…`);
@@ -285,29 +316,7 @@ async function runTemplate(template: TemplateId, id: string, variant?: TemplateV
 
     if (steps.install.status === 'pass') {
       mochiInstalledVersion = extractInstalledMochiVersion(scaffoldDir);
-
-      console.log(`  [${label}] • test…`);
-      const test = await runCmd(['bun', 'run', 'test'], scaffoldDir);
-      steps.test = toStep('test', test);
-      console.log(`  [${label}]   ${statusCell(steps.test.status)} (${fmtDuration(steps.test.durationMs)})`);
-
-      console.log(`  [${label}] • typecheck…`);
-      const tc = await runCmd(['bun', 'run', 'typecheck'], scaffoldDir);
-      steps.typecheck = toStep('typecheck', tc);
-      console.log(`  [${label}]   ${statusCell(steps.typecheck.status)} (${fmtDuration(steps.typecheck.durationMs)})`);
-
-      // Lint tooling ships with create-mochi >=0.4.0 — older published CLIs scaffold without it, so these stay skipped.
-      const scripts = readScaffoldScripts(scaffoldDir);
-      if (scripts.lint) {
-        console.log(`  [${label}] • lint…`);
-        steps.lint = toStep('lint', await runCmd(['bun', 'run', 'lint'], scaffoldDir));
-        console.log(`  [${label}]   ${statusCell(steps.lint.status)} (${fmtDuration(steps.lint.durationMs)})`);
-      }
-      if (scripts['format:check']) {
-        console.log(`  [${label}] • format:check…`);
-        steps.format = toStep('format', await runCmd(['bun', 'run', 'format:check'], scaffoldDir));
-        console.log(`  [${label}]   ${statusCell(steps.format.status)} (${fmtDuration(steps.format.durationMs)})`);
-      }
+      await runVerificationSteps(scaffoldDir, label, steps);
     }
   }
 

--- a/.github/scripts/loc-comment.ts
+++ b/.github/scripts/loc-comment.ts
@@ -25,11 +25,8 @@ function renderRow(name: string, mainLines: number, prLines: number, bold = fals
   return `| ${wrap(name)} | ${wrap(mainLines)} | ${wrap(prLines)} | ${wrap(delta(prLines - mainLines))} |`;
 }
 
-function renderPackageSection(name: string, mainReport: Report | undefined, prReport: Report | undefined, openByDefault: boolean): string[] {
-  const main = mainReport?.byCategory ?? {};
-  const pr = prReport?.byCategory ?? {};
+function diffCategories(main: Record<string, Counts>, pr: Record<string, Counts>): { changedRows: string[]; unchanged: { name: string; lines: number }[] } {
   const allCategories = new Set([...Object.keys(main), ...Object.keys(pr)]);
-
   const changedRows: string[] = [];
   const unchanged: { name: string; lines: number }[] = [];
   for (const category of allCategories) {
@@ -44,6 +41,11 @@ function renderPackageSection(name: string, mainReport: Report | undefined, prRe
     }
     changedRows.push(renderRow(`\`${category}\``, mainLines, prLines));
   }
+  return { changedRows, unchanged };
+}
+
+function renderPackageSection(name: string, mainReport: Report | undefined, prReport: Report | undefined, openByDefault: boolean): string[] {
+  const { changedRows, unchanged } = diffCategories(mainReport?.byCategory ?? {}, prReport?.byCategory ?? {});
   changedRows.push(renderRow('Total', mainReport?.totals.lines ?? 0, prReport?.totals.lines ?? 0, true));
 
   const table = ['| Category | main | PR | Δ |', '|---|---:|---:|---:|', ...changedRows];
@@ -102,22 +104,21 @@ function renderInstallSection(repo: string, runId: string): string[] {
   ];
 }
 
+function argValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  return idx !== -1 ? args[idx + 1] : undefined;
+}
+
 function main() {
   const args = process.argv.slice(2);
   const mainPath = args[0];
   const prPath = args[1];
-  const repoIdx = args.indexOf('--repo');
-  const repo = repoIdx !== -1 ? args[repoIdx + 1] : undefined;
-  const runIdIdx = args.indexOf('--run-id');
-  const runId = runIdIdx !== -1 ? args[runIdIdx + 1] : undefined;
-  const depIdx = args.indexOf('--dep-report');
-  const depReportPath = depIdx !== -1 ? args[depIdx + 1] : undefined;
-  const changedIdx = args.indexOf('--changed-paths');
-  const changedPathsPath = changedIdx !== -1 ? args[changedIdx + 1] : undefined;
-  const auditIdx = args.indexOf('--audit');
-  const auditPath = auditIdx !== -1 ? args[auditIdx + 1] : undefined;
-  const licensesIdx = args.indexOf('--licenses');
-  const licensesPath = licensesIdx !== -1 ? args[licensesIdx + 1] : undefined;
+  const repo = argValue(args, '--repo');
+  const runId = argValue(args, '--run-id');
+  const depReportPath = argValue(args, '--dep-report');
+  const changedPathsPath = argValue(args, '--changed-paths');
+  const auditPath = argValue(args, '--audit');
+  const licensesPath = argValue(args, '--licenses');
 
   if (!mainPath || !prPath) {
     console.error('Usage: bun loc-comment.ts <main.json> <pr.json> [--repo <owner/repo> --run-id <id>]');

--- a/packages/mochi/scripts/dep-report.ts
+++ b/packages/mochi/scripts/dep-report.ts
@@ -45,13 +45,6 @@ function loadInstalledFromLock(): Set<string> {
   return installed;
 }
 
-/**
- * Bun's isolated install layout is `node_modules/.bun/<name>@<version>/node_modules/<name>/package.json`.
- * Scan the store once and index by package name (first hit wins on duplicates,
- * which is good enough for a counts report). For non-Bun installs (npm/pnpm hoisted)
- * fall back to scanning `node_modules/<name>/package.json` directly.
- */
-// Scan each glob under `cwd`, indexing every readable package.json by name (first hit wins).
 async function scanPackagesInto(index: Map<string, IndexEntry>, cwd: string, globs: Bun.Glob[]): Promise<void> {
   for (const glob of globs) {
     for await (const rel of glob.scan({ cwd })) {
@@ -68,6 +61,12 @@ async function scanPackagesInto(index: Map<string, IndexEntry>, cwd: string, glo
   }
 }
 
+/**
+ * Bun's isolated install layout is `node_modules/.bun/<name>@<version>/node_modules/<name>/package.json`.
+ * Scan the store once and index by package name (first hit wins on duplicates,
+ * which is good enough for a counts report). For non-Bun installs (npm/pnpm hoisted)
+ * fall back to scanning `node_modules/<name>/package.json` directly.
+ */
 async function indexPackages(): Promise<Map<string, IndexEntry>> {
   const index = new Map<string, IndexEntry>();
   // Scoped packages live one folder deeper (`<store>/<flat>/node_modules/@scope/<name>/`), so we need both glob depths.

--- a/packages/mochi/scripts/dep-report.ts
+++ b/packages/mochi/scripts/dep-report.ts
@@ -51,64 +51,37 @@ function loadInstalledFromLock(): Set<string> {
  * which is good enough for a counts report). For non-Bun installs (npm/pnpm hoisted)
  * fall back to scanning `node_modules/<name>/package.json` directly.
  */
-async function indexPackages(): Promise<Map<string, IndexEntry>> {
-  const index = new Map<string, IndexEntry>();
-  // Scoped packages live one folder deeper (`<store>/<flat>/node_modules/@scope/<name>/`),
-  // so we need both glob depths.
-  const globs = [
-    new Bun.Glob('*/node_modules/*/package.json'), // unscoped
-    new Bun.Glob('*/node_modules/@*/*/package.json'), // scoped
-  ];
-  if (existsSync(BUN_STORE)) {
-    for (const glob of globs) {
-      for await (const rel of glob.scan({ cwd: BUN_STORE })) {
-        const full = join(BUN_STORE, rel);
-        try {
-          const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
-          if (pkg.name && !index.has(pkg.name)) {
-            index.set(pkg.name, { pkg, dir: dirname(full) });
-          }
-        } catch {
-          // Skip unreadable/invalid package.json files
+// Scan each glob under `cwd`, indexing every readable package.json by name (first hit wins).
+async function scanPackagesInto(index: Map<string, IndexEntry>, cwd: string, globs: Bun.Glob[]): Promise<void> {
+  for (const glob of globs) {
+    for await (const rel of glob.scan({ cwd })) {
+      const full = join(cwd, rel);
+      try {
+        const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
+        if (pkg.name && !index.has(pkg.name)) {
+          index.set(pkg.name, { pkg, dir: dirname(full) });
         }
+      } catch {
+        // Skip unreadable/invalid package.json files
       }
     }
   }
+}
+
+async function indexPackages(): Promise<Map<string, IndexEntry>> {
+  const index = new Map<string, IndexEntry>();
+  // Scoped packages live one folder deeper (`<store>/<flat>/node_modules/@scope/<name>/`), so we need both glob depths.
+  if (existsSync(BUN_STORE)) {
+    await scanPackagesInto(index, BUN_STORE, [new Bun.Glob('*/node_modules/*/package.json'), new Bun.Glob('*/node_modules/@*/*/package.json')]);
+  }
   // Fallback: top-level node_modules for any non-isolated installs.
-  const topGlobs = [
-    new Bun.Glob('*/package.json'), // unscoped
-    new Bun.Glob('@*/*/package.json'), // scoped
-  ];
   const topNodeModules = join(REPO_ROOT, 'node_modules');
   if (existsSync(topNodeModules)) {
-    for (const glob of topGlobs) {
-      for await (const rel of glob.scan({ cwd: topNodeModules })) {
-        const full = join(topNodeModules, rel);
-        try {
-          const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
-          if (pkg.name && !index.has(pkg.name)) {
-            index.set(pkg.name, { pkg, dir: dirname(full) });
-          }
-        } catch {
-          // skip
-        }
-      }
-    }
+    await scanPackagesInto(index, topNodeModules, [new Bun.Glob('*/package.json'), new Bun.Glob('@*/*/package.json')]);
   }
   // Workspace packages (`packages/*`) resolve locally rather than into node_modules,
   // so deps satisfied by an override (e.g. the msgpackr-extract stub) are only sizable here.
-  const wsGlob = new Bun.Glob('packages/*/package.json');
-  for await (const rel of wsGlob.scan({ cwd: REPO_ROOT })) {
-    const full = join(REPO_ROOT, rel);
-    try {
-      const pkg = JSON.parse(readFileSync(full, 'utf8')) as PkgJson;
-      if (pkg.name && !index.has(pkg.name)) {
-        index.set(pkg.name, { pkg, dir: dirname(full) });
-      }
-    } catch {
-      // skip
-    }
-  }
+  await scanPackagesInto(index, REPO_ROOT, [new Bun.Glob('packages/*/package.json')]);
   return index;
 }
 

--- a/packages/mochi/scripts/leak/analyze.ts
+++ b/packages/mochi/scripts/leak/analyze.ts
@@ -79,21 +79,25 @@ export type VerdictInput = {
   latencyCreepPct: number; // (last-window p95 / first-window p95 - 1) * 100
 };
 
+// A GC dip is any sample whose RSS fell below its predecessor — evidence the heap is being reclaimed under load.
+function hasGcDip(samples: RssSample[]): boolean {
+  for (let i = 1; i < samples.length; i++) {
+    const cur = samples[i];
+    const prev = samples[i - 1];
+    if (cur && prev && cur.rssKb < prev.rssKb) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function judge(input: VerdictInput): VerdictDetail {
   const reg = leastSquares(input.workloadSamples);
   const slopeMbPerMin = reg.slopeMbPerMin;
   const r2 = reg.r2;
   const deltaMb = (input.finalRssKb - input.baselineRssKb) / 1024;
 
-  let hadGcDip = false;
-  for (let i = 1; i < input.workloadSamples.length; i++) {
-    const cur = input.workloadSamples[i];
-    const prev = input.workloadSamples[i - 1];
-    if (cur && prev && cur.rssKb < prev.rssKb) {
-      hadGcDip = true;
-      break;
-    }
-  }
+  const hadGcDip = hasGcDip(input.workloadSamples);
 
   const reasons: string[] = [];
   const severity: Record<Verdict, number> = { pass: 0, warn: 1, fail: 2 };

--- a/packages/mochi/scripts/leak/analyze.ts
+++ b/packages/mochi/scripts/leak/analyze.ts
@@ -79,7 +79,6 @@ export type VerdictInput = {
   latencyCreepPct: number; // (last-window p95 / first-window p95 - 1) * 100
 };
 
-// A GC dip is any sample whose RSS fell below its predecessor — evidence the heap is being reclaimed under load.
 function hasGcDip(samples: RssSample[]): boolean {
   for (let i = 1; i < samples.length; i++) {
     const cur = samples[i];

--- a/packages/mochi/scripts/leak/loadGen.ts
+++ b/packages/mochi/scripts/leak/loadGen.ts
@@ -21,6 +21,18 @@ export type LoadStats = {
   endedAt: number;
 };
 
+function recordStatusClass(routeStats: RouteStats, status: number): void {
+  if (status >= 200 && status < 300) {
+    routeStats.status2xx++;
+  } else if (status >= 300 && status < 400) {
+    routeStats.status3xx++;
+  } else if (status >= 400 && status < 500) {
+    routeStats.status4xx++;
+  } else if (status >= 500) {
+    routeStats.status5xx++;
+  }
+}
+
 function emptyStats(name: string): RouteStats {
   return {
     name,
@@ -109,16 +121,7 @@ export async function startLoad(opts: StartLoadOpts): Promise<LoadStats> {
         const dt = performance.now() - t0;
         routeStats.count++;
         routeStats.samples.push({ t: tWall, latencyMs: dt, status: res.status });
-        const s = res.status;
-        if (s >= 200 && s < 300) {
-          routeStats.status2xx++;
-        } else if (s >= 300 && s < 400) {
-          routeStats.status3xx++;
-        } else if (s >= 400 && s < 500) {
-          routeStats.status4xx++;
-        } else if (s >= 500) {
-          routeStats.status5xx++;
-        }
+        recordStatusClass(routeStats, res.status);
         stats.totalRequests++;
       } catch (err) {
         if ((err as { name?: string })?.name === 'AbortError') {

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -170,6 +170,161 @@ function jsonForHtml(value: unknown): string {
   return JSON.stringify(value).replace(/</g, '\\u003c');
 }
 
+function buildDebugHeadScripts(
+  debugBarEnabled: boolean,
+  liveReloadEnabled: boolean,
+  opts?: { debugInfo?: DebugBarData; pageEntry?: string },
+): { debugInfoScript: string; pageEntryScript: string } {
+  const debugInfoScript = debugBarEnabled && opts?.debugInfo ? `<script>window.__mochi_debug=${jsonForHtml(opts.debugInfo)}</script>` : '';
+  const pageEntryScript = liveReloadEnabled && opts?.pageEntry ? `<script>window.__mochi_page_entry=${jsonForHtml(opts.pageEntry)}</script>` : '';
+  return { debugInfoScript, pageEntryScript };
+}
+
+function buildShellScripts(
+  bootstrapUrl: string | null | undefined,
+  hasServerIslands: boolean,
+  serverIslandScript: string,
+  debugBarUrl: string | null | undefined,
+  assetPrefixJson: string,
+  liveReloadTail: string,
+): string {
+  return (
+    (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
+    (hasServerIslands ? serverIslandScript : '') +
+    (debugBarUrl ? `<script type="module" src="${debugBarUrl}"></script><script>window.__mochi_asset_prefix=${assetPrefixJson}</script>` : '') +
+    liveReloadTail
+  );
+}
+
+// Reject before initMochiConfig pins the process singleton, so a bad `bun` passthrough fails fast without wedging it.
+function assertValidBunOverrides(options: MochiServeOptions): void {
+  if (options.bun && typeof options.bun === 'object') {
+    for (const key of FRAMEWORK_OWNED_BUN_KEYS) {
+      if (key in options.bun) {
+        throw new Error(`Mochi.serve({ bun }): "${key}" is owned by the framework and cannot be overridden. Use the top-level Mochi.serve() option instead.`);
+      }
+    }
+  }
+}
+
+function assertValidQueueNames(declaredQueues: NonNullable<MochiServeOptions['queues']>): void {
+  const queueNames = new Set<string>();
+  for (const config of declaredQueues) {
+    if (!isMochiQueue(config)) {
+      throw new Error(`Mochi.serve({ queues }): every element must be a descriptor created with Mochi.queue(name, …).`);
+    }
+    if (typeof config.name !== 'string' || !/^[\w.\-/]+$/.test(config.name)) {
+      throw new Error(`Mochi.serve({ queues }): "${config.name}" is not a valid queue name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
+    }
+    if (config.name.startsWith('cron-')) {
+      throw new Error(`Mochi.serve({ queues }): "${config.name}" uses the reserved "cron-" prefix — that namespace is for scheduled jobs (Mochi.cron). Rename the queue.`);
+    }
+    if (queueNames.has(config.name)) {
+      throw new Error(`Mochi.serve({ queues }): two queues are named "${config.name}". Queue names must be unique.`);
+    }
+    queueNames.add(config.name);
+    // Descriptor form is self-sufficient — the target is ensured on its own; only a bare name needs the array.
+    const deadLetter = config.options?.deadLetter;
+    if (typeof deadLetter === 'string' && !declaredQueues.some((q) => q.name === deadLetter)) {
+      throw new Error(
+        `Mochi.serve({ queues }): "${config.name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues array. Declare it there, or pass its descriptor (deadLetter: Mochi.queue("${deadLetter}", …)) so it is ensured on its own.`,
+      );
+    }
+  }
+}
+
+function detectDeclaredQueueStorage(declaredQueues: NonNullable<MochiServeOptions['queues']>): { name: string; storage: MochiQueueStorage } | undefined {
+  let declaredStorage: { name: string; storage: MochiQueueStorage } | undefined;
+  for (const { name, storage } of collectQueueClosure(declaredQueues, 'Mochi.serve({ queues })')) {
+    if (storage === undefined) {
+      continue;
+    }
+    if (declaredStorage && !storageEquals(declaredStorage.storage, storage)) {
+      throw new Error(`Mochi.serve({ queues }): "${name}" and "${declaredStorage.name}" declare different storages — an app has one queue storage.`);
+    }
+    declaredStorage ??= { name, storage };
+  }
+  return declaredStorage;
+}
+
+// An app has one queue storage: declared on the descriptors (deadLetter targets included), app-wide via queueStorage, or both when they agree.
+function resolveQueueStorage(declaredQueues: NonNullable<MochiServeOptions['queues']>, options: MochiServeOptions): MochiQueueStorage {
+  const declaredStorage = detectDeclaredQueueStorage(declaredQueues);
+  if (options.queueStorage !== undefined && declaredStorage && !storageEquals(declaredStorage.storage, options.queueStorage)) {
+    throw new Error(
+      `Mochi.serve({ queueStorage }): "${declaredStorage.name}" declares a different storage — an app has one queue storage. Align the two declarations, or drop one.`,
+    );
+  }
+  const queueStorage = options.queueStorage ?? declaredStorage?.storage ?? 'memory';
+  if (!isValidQueueStorage(queueStorage)) {
+    throw new Error(`Mochi.serve({ queueStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
+  }
+  if (options.queueStorage !== undefined && declaredQueues.length === 0) {
+    logger.warn(`Mochi.serve({ queueStorage }) has no effect without a non-empty queues array — the queue runtime only starts when queues are declared.`);
+  }
+  if (declaredQueues.length > 0) {
+    // Fail before the config singleton pins and the server binds — rejecting this deep in the boot would wedge the process.
+    assertNoConflictingStandaloneRuntime(queueStorage);
+  }
+  return queueStorage;
+}
+
+// Validate the queue declarations, resolve the single app-wide storage, and fail before the config singleton pins.
+function resolveQueueConfig(options: MochiServeOptions): { declaredQueues: NonNullable<MochiServeOptions['queues']>; queueStorage: MochiQueueStorage } {
+  const declaredQueues = options.queues ?? [];
+  assertValidQueueNames(declaredQueues);
+  const queueStorage = resolveQueueStorage(declaredQueues, options);
+  return { declaredQueues, queueStorage };
+}
+
+// Validate the cron declarations and resolve their storage; same fail-fast rule as the queue config.
+function resolveCronConfig(options: MochiServeOptions): { declaredCron: NonNullable<MochiServeOptions['cron']>; cronStorage: MochiQueueStorage } {
+  const declaredCron = options.cron ?? [];
+  const cronNames = new Set<string>();
+  for (const job of declaredCron) {
+    if (!isMochiCron(job)) {
+      throw new Error(`Mochi.serve({ cron }): every element must be a descriptor created with Mochi.cron(name, schedule, …).`);
+    }
+    if (typeof job.name !== 'string' || !/^[\w.\-/]+$/.test(job.name)) {
+      throw new Error(`Mochi.serve({ cron }): "${job.name}" is not a valid cron job name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
+    }
+    if (cronNames.has(job.name)) {
+      throw new Error(`Mochi.serve({ cron }): two cron jobs are named "${job.name}". Cron job names must be unique.`);
+    }
+    cronNames.add(job.name);
+  }
+  // Independent of queueStorage: cron always runs on its own bun-boss instance, defaulting to in-process memory.
+  const cronStorage = options.cronStorage ?? 'memory';
+  if (declaredCron.length > 0 && !isValidQueueStorage(cronStorage)) {
+    throw new Error(`Mochi.serve({ cronStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
+  }
+  return { declaredCron, cronStorage };
+}
+
+function assertServerPropsShape(resolved: Record<string, unknown>, pattern: string, hasActions: boolean): void {
+  if (isFormFail(resolved) || isFormSuccess(resolved)) {
+    throw new Error(
+      `[mochi] Route "${pattern}" serverProps returned ${isFormFail(resolved) ? 'fail()' : 'success()'} — those are form-action results. ` +
+        `serverProps may return props or redirect(status, location).`,
+    );
+  }
+  if (hasActions && 'form' in resolved) {
+    throw new Error(`[mochi] Route "${pattern}" has form actions and also returns a prop named "form". ` + `"form" is reserved for the form action result — rename your prop.`);
+  }
+}
+
+function fillShellParts(parts: ShellPart[], head: string, css: string, body: string, script: string): string {
+  let out = '';
+  for (const part of parts) {
+    if ('text' in part) {
+      out += part.text;
+    } else {
+      out += part.slot === 'head' ? head : part.slot === 'css' ? css : part.slot === 'body' ? body : script;
+    }
+  }
+  return out;
+}
+
 /**
  * `createShellRenderer` bakes the static `window.__mochi_debug` fields into the cached body, so per-request headers and cookies have to be appended
  * afterwards for cache hits to stay accurate. The trailing script is synchronous so it lands before the deferred debug-bar module runs `onMount`.
@@ -348,116 +503,22 @@ export class Mochi {
       const fontPreloads = fontPreload ? result.fontPreloadUrls.slice(0, FONT_PRELOAD_MAX).map(fontPreloadTag).join('\n') : '';
       const cssLinks = (fontPreloads ? `${fontPreloads}\n` : '') + result.cssUrls.map(cssLinkTag).join('\n');
       const debugBarUrl = registry.getDebugBarUrl();
-      const debugInfoScript = registry.debugBarEnabled && opts?.debugInfo ? `<script>window.__mochi_debug=${jsonForHtml(opts.debugInfo)}</script>` : '';
-      const pageEntryScript = liveReloadClientJs && opts?.pageEntry ? `<script>window.__mochi_page_entry=${jsonForHtml(opts.pageEntry)}</script>` : '';
+      const { debugInfoScript, pageEntryScript } = buildDebugHeadScripts(registry.debugBarEnabled, Boolean(liveReloadClientJs), opts);
 
       const head = logLevelScript + warnShim + speculationRulesScript + result.head;
       const css = cssStylePrefix + cssLinks;
       const body = result.body + debugInfoScript + pageEntryScript + toolbarDiv;
-      const script =
-        (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
-        (result.hasServerIslands ? serverIslandScript : '') +
-        (debugBarUrl ? `<script type="module" src="${debugBarUrl}"></script><script>window.__mochi_asset_prefix=${assetPrefixJson}</script>` : '') +
-        liveReloadTail;
+      const script = buildShellScripts(bootstrapUrl, result.hasServerIslands, serverIslandScript, debugBarUrl, assetPrefixJson, liveReloadTail);
 
-      let out = '';
-      for (const part of parts) {
-        if ('text' in part) {
-          out += part.text;
-        } else {
-          out += part.slot === 'head' ? head : part.slot === 'css' ? css : part.slot === 'body' ? body : script;
-        }
-      }
-      return out;
+      return fillShellParts(parts, head, css, body, script);
     };
   }
 
   static async serve(options: MochiServeOptions): Promise<Server<undefined>> {
-    // Reject before initMochiConfig pins the process singleton, so a bad `bun` passthrough fails fast without wedging it.
-    if (options.bun && typeof options.bun === 'object') {
-      for (const key of FRAMEWORK_OWNED_BUN_KEYS) {
-        if (key in options.bun) {
-          throw new Error(`Mochi.serve({ bun }): "${key}" is owned by the framework and cannot be overridden. Use the top-level Mochi.serve() option instead.`);
-        }
-      }
-    }
-
-    // Same fail-fast rule for the queue declarations: a bad descriptor, duplicate name, deadLetter, or storage shape rejects here.
-    const declaredQueues = options.queues ?? [];
-    const queueNames = new Set<string>();
-    for (const config of declaredQueues) {
-      if (!isMochiQueue(config)) {
-        throw new Error(`Mochi.serve({ queues }): every element must be a descriptor created with Mochi.queue(name, …).`);
-      }
-      if (typeof config.name !== 'string' || !/^[\w.\-/]+$/.test(config.name)) {
-        throw new Error(`Mochi.serve({ queues }): "${config.name}" is not a valid queue name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
-      }
-      if (config.name.startsWith('cron-')) {
-        throw new Error(`Mochi.serve({ queues }): "${config.name}" uses the reserved "cron-" prefix — that namespace is for scheduled jobs (Mochi.cron). Rename the queue.`);
-      }
-      if (queueNames.has(config.name)) {
-        throw new Error(`Mochi.serve({ queues }): two queues are named "${config.name}". Queue names must be unique.`);
-      }
-      queueNames.add(config.name);
-      // Descriptor form is self-sufficient — the target is ensured on its own; only a bare name needs the array.
-      // Self-references and conflicting duplicates are caught by the closure walk below.
-      const deadLetter = config.options?.deadLetter;
-      if (typeof deadLetter === 'string' && !declaredQueues.some((q) => q.name === deadLetter)) {
-        throw new Error(
-          `Mochi.serve({ queues }): "${config.name}" names "${deadLetter}" as its deadLetter queue, but no queue with that name is declared in the same queues array. Declare it there, or pass its descriptor (deadLetter: Mochi.queue("${deadLetter}", …)) so it is ensured on its own.`,
-        );
-      }
-    }
-    // An app has one queue storage: declared on the descriptors (deadLetter targets included), app-wide via
-    // queueStorage, or both when they agree.
-    let declaredStorage: { name: string; storage: MochiQueueStorage } | undefined;
-    for (const { name, storage } of collectQueueClosure(declaredQueues, 'Mochi.serve({ queues })')) {
-      if (storage === undefined) {
-        continue;
-      }
-      if (declaredStorage && !storageEquals(declaredStorage.storage, storage)) {
-        throw new Error(`Mochi.serve({ queues }): "${name}" and "${declaredStorage.name}" declare different storages — an app has one queue storage.`);
-      }
-      declaredStorage ??= { name, storage };
-    }
-    if (options.queueStorage !== undefined && declaredStorage && !storageEquals(declaredStorage.storage, options.queueStorage)) {
-      throw new Error(
-        `Mochi.serve({ queueStorage }): "${declaredStorage.name}" declares a different storage — an app has one queue storage. Align the two declarations, or drop one.`,
-      );
-    }
-    const queueStorage = options.queueStorage ?? declaredStorage?.storage ?? 'memory';
-    if (!isValidQueueStorage(queueStorage)) {
-      throw new Error(`Mochi.serve({ queueStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
-    }
-    if (options.queueStorage !== undefined && declaredQueues.length === 0) {
-      logger.warn(`Mochi.serve({ queueStorage }) has no effect without a non-empty queues array — the queue runtime only starts when queues are declared.`);
-    }
-    if (declaredQueues.length > 0) {
-      // Fail before the config singleton pins and the server binds — rejecting this deep in the boot would wedge the process.
-      assertNoConflictingStandaloneRuntime(queueStorage);
-    }
-
-    // Same fail-fast rule for cron: a bad descriptor or duplicate name rejects before the config singleton pins and
-    // the socket binds, so a typo can never leave a half-scheduled server listening.
-    const declaredCron = options.cron ?? [];
-    const cronNames = new Set<string>();
-    for (const job of declaredCron) {
-      if (!isMochiCron(job)) {
-        throw new Error(`Mochi.serve({ cron }): every element must be a descriptor created with Mochi.cron(name, schedule, …).`);
-      }
-      if (typeof job.name !== 'string' || !/^[\w.\-/]+$/.test(job.name)) {
-        throw new Error(`Mochi.serve({ cron }): "${job.name}" is not a valid cron job name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
-      }
-      if (cronNames.has(job.name)) {
-        throw new Error(`Mochi.serve({ cron }): two cron jobs are named "${job.name}". Cron job names must be unique.`);
-      }
-      cronNames.add(job.name);
-    }
-    // Independent of queueStorage: cron always runs on its own bun-boss instance, defaulting to in-process memory.
-    const cronStorage = options.cronStorage ?? 'memory';
-    if (declaredCron.length > 0 && !isValidQueueStorage(cronStorage)) {
-      throw new Error(`Mochi.serve({ cronStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
-    }
+    assertValidBunOverrides(options);
+    // Fail-fast validation before initMochiConfig pins the process singleton and the socket binds.
+    const { declaredQueues, queueStorage } = resolveQueueConfig(options);
+    const { declaredCron, cronStorage } = resolveCronConfig(options);
 
     // Same fail-fast rule: an unmountable prefix rejects here rather than 404ing at runtime.
     const staticDirMounts = options.staticDirs ? resolveStaticDirs(options.staticDirs, normalizeAssetPrefix(options.assetPrefix)) : [];
@@ -867,59 +928,57 @@ export class Mochi {
           await registry.compile(componentPath);
         }
 
+        const resolvePageProps = async (req: Request, ctx: MochiRequestContext): Promise<{ redirect: Response } | { props: Record<string, unknown> }> => {
+          const liveServerProps = pageConfigMap ? pageConfigMap.get(pattern)?.serverProps : serverProps;
+          const resolved = isServerPropsResolver(liveServerProps) ? ((await liveServerProps(req, ctx.params)) ?? {}) : (liveServerProps ?? {});
+          if (isRedirect(resolved)) {
+            return { redirect: new Response(null, { status: resolved.status, headers: { Location: resolved.location } }) };
+          }
+          const liveActions = pageConfigMap ? pageConfigMap.get(pattern)?.actions : actions;
+          assertServerPropsShape(resolved, pattern, Boolean(liveActions));
+          const formProp = ctx.form ?? null;
+          return { props: formProp === null ? resolved : { ...resolved, form: formProp } };
+        };
+
+        const augmentDebugBarData = (result: RenderResult, ctx: MochiRequestContext, ssrStart: number): void => {
+          if (!result.debugBarData) {
+            return;
+          }
+          result.debugBarData.ssrDurationMs = Math.round((performance.now() - ssrStart) * 100) / 100;
+          if (ctx.requestCache) {
+            const { hits, misses, map, perKey } = ctx.requestCache;
+            result.debugBarData.requestCache = {
+              hits,
+              misses,
+              entries: map.size,
+              keys: [...perKey].map(([key, t]) => ({ key, hits: t.hits, misses: t.misses })),
+            };
+          }
+          if (result.hasServerIslands) {
+            const serverIslandSize = new TextEncoder().encode(serverIslandClientJs).length;
+            (result.debugBarData.bundles ??= []).push({
+              url: '(inline)',
+              label: 'Server island runtime',
+              sizeBytes: serverIslandSize,
+              kind: 'bootstrap',
+              inputs: [],
+            });
+          }
+        };
+
         const renderComponent = async (req: Request, ctx: MochiRequestContext, resolveOpts: MochiResolveOptions | undefined, statusOverride?: number): Promise<Response> => {
           const compileErrors = registry.getErrors();
           if (compileErrors.length > 0) {
             throw new MochiHttpError(500, formatCompileErrors(compileErrors));
           }
-          const liveServerProps = pageConfigMap ? pageConfigMap.get(pattern)?.serverProps : serverProps;
-          const resolved = isServerPropsResolver(liveServerProps) ? ((await liveServerProps(req, ctx.params)) ?? {}) : (liveServerProps ?? {});
-          if (isRedirect(resolved)) {
-            const redirectResponse = new Response(null, {
-              status: resolved.status,
-              headers: { Location: resolved.location },
-            });
-            return applyResolveOptions(redirectResponse, resolveOpts);
+          const propsResult = await resolvePageProps(req, ctx);
+          if ('redirect' in propsResult) {
+            return applyResolveOptions(propsResult.redirect, resolveOpts);
           }
-          if (isFormFail(resolved) || isFormSuccess(resolved)) {
-            throw new Error(
-              `[mochi] Route "${pattern}" serverProps returned ${isFormFail(resolved) ? 'fail()' : 'success()'} — those are form-action results. ` +
-                `serverProps may return props or redirect(status, location).`,
-            );
-          }
-          const baseProps = resolved;
-          const liveActions = pageConfigMap ? pageConfigMap.get(pattern)?.actions : actions;
-          if (liveActions && 'form' in baseProps) {
-            throw new Error(
-              `[mochi] Route "${pattern}" has form actions and also returns a prop named "form". ` + `"form" is reserved for the form action result — rename your prop.`,
-            );
-          }
-          const formProp = ctx.form ?? null;
-          const resolvedProps = formProp === null ? baseProps : { ...baseProps, form: formProp };
+          const resolvedProps = propsResult.props;
           const ssrStart = performance.now();
           const result = await registry.renderComponent(componentPath, resolvedProps);
-          if (result.debugBarData) {
-            result.debugBarData.ssrDurationMs = Math.round((performance.now() - ssrStart) * 100) / 100;
-            if (ctx.requestCache) {
-              const { hits, misses, map, perKey } = ctx.requestCache;
-              result.debugBarData.requestCache = {
-                hits,
-                misses,
-                entries: map.size,
-                keys: [...perKey].map(([key, t]) => ({ key, hits: t.hits, misses: t.misses })),
-              };
-            }
-            if (result.hasServerIslands) {
-              const serverIslandSize = new TextEncoder().encode(serverIslandClientJs).length;
-              (result.debugBarData.bundles ??= []).push({
-                url: '(inline)',
-                label: 'Server island runtime',
-                sizeBytes: serverIslandSize,
-                kind: 'bootstrap',
-                inputs: [],
-              });
-            }
-          }
+          augmentDebugBarData(result, ctx, ssrStart);
           const html = renderShell(result, {
             debugInfo: result.debugBarData ? { ...result.debugBarData, liveReloadEnabled, ...serverDebugInfo } : undefined,
             pageEntry: liveReloadEnabled ? path.resolve(componentPath) : undefined,
@@ -1015,6 +1074,60 @@ export class Mochi {
                 mochiEvents.emit('action:complete', payload);
               };
 
+              const finalizeActionResult = async (result: MochiFormActionResult, actionName: string): Promise<Response> => {
+                if (result instanceof Response) {
+                  emitActionComplete(actionName, 'success', result.status);
+                  return applyResolveOptions(result, resolveOpts);
+                }
+                if (isRedirect(result)) {
+                  emitActionComplete(actionName, 'redirect', result.status);
+                  if (enhanced) {
+                    return jsonRedirect(result.status, result.location);
+                  }
+                  const redirectResponse = new Response(null, {
+                    status: result.status,
+                    headers: { Location: result.location },
+                  });
+                  return applyResolveOptions(redirectResponse, resolveOpts);
+                }
+                try {
+                  if (isFormFail(result)) {
+                    if (enhanced) {
+                      emitActionComplete(actionName, 'fail', result.status);
+                      return jsonFailure(result.status, result.data);
+                    }
+                    ctx.form = {
+                      ok: false,
+                      action: actionName,
+                      status: result.status,
+                      data: result.data,
+                    };
+                    emitActionComplete(actionName, 'fail', result.status);
+                    return await renderComponent(req, ctx, resolveOpts, result.status);
+                  }
+                  if (enhanced) {
+                    emitActionComplete(actionName, 'success');
+                    if (result === undefined || result === null) {
+                      return jsonSuccess(undefined, { emptyResult: true });
+                    }
+                    return jsonSuccess(isFormSuccess(result) ? result.data : {});
+                  }
+                  const data = isFormSuccess(result) ? result.data : {};
+                  ctx.form = { ok: true, action: actionName, data };
+                  emitActionComplete(actionName, 'success');
+                  return await renderComponent(req, ctx, resolveOpts);
+                } catch (err) {
+                  if (enhanced) {
+                    const response = await handleEnhancedError(err, event);
+                    emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
+                    return response;
+                  }
+                  const response = await routeErrorResponse(req, event, resolveOpts, err);
+                  emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
+                  return response;
+                }
+              };
+
               const livePostActions = pageConfigMap ? pageConfigMap.get(pattern)?.actions : actions;
               if (!livePostActions) {
                 return new Response('Method Not Allowed', { status: 405 });
@@ -1098,57 +1211,7 @@ export class Mochi {
                 return response;
               }
 
-              if (result instanceof Response) {
-                emitActionComplete(actionName, 'success', result.status);
-                return applyResolveOptions(result, resolveOpts);
-              }
-              if (isRedirect(result)) {
-                emitActionComplete(actionName, 'redirect', result.status);
-                if (enhanced) {
-                  return jsonRedirect(result.status, result.location);
-                }
-                const redirectResponse = new Response(null, {
-                  status: result.status,
-                  headers: { Location: result.location },
-                });
-                return applyResolveOptions(redirectResponse, resolveOpts);
-              }
-              try {
-                if (isFormFail(result)) {
-                  if (enhanced) {
-                    emitActionComplete(actionName, 'fail', result.status);
-                    return jsonFailure(result.status, result.data);
-                  }
-                  ctx.form = {
-                    ok: false,
-                    action: actionName,
-                    status: result.status,
-                    data: result.data,
-                  };
-                  emitActionComplete(actionName, 'fail', result.status);
-                  return await renderComponent(req, ctx, resolveOpts, result.status);
-                }
-                if (enhanced) {
-                  emitActionComplete(actionName, 'success');
-                  if (result === undefined || result === null) {
-                    return jsonSuccess(undefined, { emptyResult: true });
-                  }
-                  return jsonSuccess(isFormSuccess(result) ? result.data : {});
-                }
-                const data = isFormSuccess(result) ? result.data : {};
-                ctx.form = { ok: true, action: actionName, data };
-                emitActionComplete(actionName, 'success');
-                return await renderComponent(req, ctx, resolveOpts);
-              } catch (err) {
-                if (enhanced) {
-                  const response = await handleEnhancedError(err, event);
-                  emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
-                  return response;
-                }
-                const response = await routeErrorResponse(req, event, resolveOpts, err);
-                emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
-                return response;
-              }
+              return finalizeActionResult(result, actionName);
             });
 
           return {
@@ -1575,6 +1638,43 @@ export class Mochi {
         ctx.islandInline = { budget: applyFilter('serverIsland:inlineBudget', DEFAULT_INLINE_BUDGET, { componentName, request: req }) };
       }
 
+      const finalizeIslandBody = (result: RenderResult): string => {
+        let body = result.body;
+
+        if (isAlsoHydrateMode(hydrateMode)) {
+          const componentUrl = registry.getComponentEntryUrl(componentName);
+          const serializedProps = devalueStringify(props);
+
+          let hydrateAttrs = `component-name="${componentName}"`;
+          if (Object.keys(props as Record<string, unknown>).length > 0) {
+            hydrateAttrs += ` props="${escapeHtmlAttr(serializedProps)}"`;
+          }
+          if (componentUrl) {
+            hydrateAttrs += ` component-url="${componentUrl}"`;
+          }
+
+          body = `<mochi-hydratable-island ${hydrateAttrs}>${body}</mochi-hydratable-island>`;
+        }
+
+        // Appended whenever the rendered subtree carries hydratables — the also-hydrate island itself, plain
+        // mochi:hydrate children, or inlined also-hydrate islands — so the fragment self-hydrates even on a page that
+        // shipped no bootstrap of its own; duplicate module scripts are no-ops by src.
+        const bootstrapUrl = result.bootstrapUrl ?? (isAlsoHydrateMode(hydrateMode) ? registry.getIslandBootstrapUrl() : null);
+        if (bootstrapUrl) {
+          body += `<script type="module" src="${bootstrapUrl}"></script>`;
+        }
+
+        // CSS for islands rendered only inside this deferred content is gated out of the page `<head>`, so its `<link>`
+        // tags are prepended here along with side-effect CSS imports; browsers honour a `<link>` assigned via `innerHTML`.
+        // The island's own scoped CSS is excluded, since the wrapper's `css-url` attribute already loads it.
+        const ownCss = registry.getComponentCssUrl(componentPath);
+        const extraCss = result.cssUrls.filter((url) => url !== ownCss);
+        if (extraCss.length > 0) {
+          body = extraCss.map(cssLinkTag).join('') + body;
+        }
+        return body;
+      };
+
       return requestContext.run(ctx, async () => {
         // A miss here means the build's eager discovery (see build.ts) didn't
         // find this island; `compileAll` warns about any manifest miss, so the
@@ -1622,39 +1722,7 @@ export class Mochi {
           });
         }
 
-        let body = result.body;
-
-        if (isAlsoHydrateMode(hydrateMode)) {
-          const componentUrl = registry.getComponentEntryUrl(componentName);
-          const serializedProps = devalueStringify(props);
-
-          let hydrateAttrs = `component-name="${componentName}"`;
-          if (Object.keys(props as Record<string, unknown>).length > 0) {
-            hydrateAttrs += ` props="${escapeHtmlAttr(serializedProps)}"`;
-          }
-          if (componentUrl) {
-            hydrateAttrs += ` component-url="${componentUrl}"`;
-          }
-
-          body = `<mochi-hydratable-island ${hydrateAttrs}>${body}</mochi-hydratable-island>`;
-        }
-
-        // Appended whenever the rendered subtree carries hydratables — the also-hydrate island itself, plain
-        // mochi:hydrate children, or inlined also-hydrate islands — so the fragment self-hydrates even on a page that
-        // shipped no bootstrap of its own; duplicate module scripts are no-ops by src.
-        const bootstrapUrl = result.bootstrapUrl ?? (isAlsoHydrateMode(hydrateMode) ? registry.getIslandBootstrapUrl() : null);
-        if (bootstrapUrl) {
-          body += `<script type="module" src="${bootstrapUrl}"></script>`;
-        }
-
-        // CSS for islands rendered only inside this deferred content is gated out of the page `<head>`, so its `<link>`
-        // tags are prepended here along with side-effect CSS imports; browsers honour a `<link>` assigned via `innerHTML`.
-        // The island's own scoped CSS is excluded, since the wrapper's `css-url` attribute already loads it.
-        const ownCss = registry.getComponentCssUrl(componentPath);
-        const extraCss = result.cssUrls.filter((url) => url !== ownCss);
-        if (extraCss.length > 0) {
-          body = extraCss.map(cssLinkTag).join('') + body;
-        }
+        const body = finalizeIslandBody(result);
 
         return new Response(body, {
           headers: {

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -44,6 +44,7 @@ import type {
   MochiWsConfig,
   MochiWsHandlers,
   MochiWsData,
+  AlsoHydrateMode,
 } from './types';
 import { isFormFail, isFormSuccess, isRedirect } from './runtime/forms';
 import { isEnhanceRequest, jsonError, jsonFailure, jsonRedirect, jsonSuccess } from './runtime/formsJson';
@@ -91,6 +92,7 @@ import {
   startCronRuntime,
   stopCronRuntime,
   CRON_JITTER_MS,
+  QUEUE_NAME_RE,
 } from './queue';
 import { pinGlobal } from './utils/globalState';
 import { resetStartupMilestones } from './lifecycle';
@@ -180,22 +182,6 @@ function buildDebugHeadScripts(
   return { debugInfoScript, pageEntryScript };
 }
 
-function buildShellScripts(
-  bootstrapUrl: string | null | undefined,
-  hasServerIslands: boolean,
-  serverIslandScript: string,
-  debugBarUrl: string | null | undefined,
-  assetPrefixJson: string,
-  liveReloadTail: string,
-): string {
-  return (
-    (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
-    (hasServerIslands ? serverIslandScript : '') +
-    (debugBarUrl ? `<script type="module" src="${debugBarUrl}"></script><script>window.__mochi_asset_prefix=${assetPrefixJson}</script>` : '') +
-    liveReloadTail
-  );
-}
-
 // Reject before initMochiConfig pins the process singleton, so a bad `bun` passthrough fails fast without wedging it.
 function assertValidBunOverrides(options: MochiServeOptions): void {
   if (options.bun && typeof options.bun === 'object') {
@@ -207,22 +193,27 @@ function assertValidBunOverrides(options: MochiServeOptions): void {
   }
 }
 
+// The charset rule is queue.ts's QUEUE_NAME_RE, so serve-time validation can never drift from what ensureQueue accepts.
+function assertUniqueValidName(scope: 'queues' | 'cron', noun: 'queue' | 'cron job', name: unknown, seen: Set<string>): asserts name is string {
+  if (typeof name !== 'string' || !QUEUE_NAME_RE.test(name)) {
+    throw new Error(`Mochi.serve({ ${scope} }): "${String(name)}" is not a valid ${noun} name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
+  }
+  if (seen.has(name)) {
+    throw new Error(`Mochi.serve({ ${scope} }): two ${noun}s are named "${name}". ${noun.charAt(0).toUpperCase() + noun.slice(1)} names must be unique.`);
+  }
+  seen.add(name);
+}
+
 function assertValidQueueNames(declaredQueues: NonNullable<MochiServeOptions['queues']>): void {
   const queueNames = new Set<string>();
   for (const config of declaredQueues) {
     if (!isMochiQueue(config)) {
       throw new Error(`Mochi.serve({ queues }): every element must be a descriptor created with Mochi.queue(name, …).`);
     }
-    if (typeof config.name !== 'string' || !/^[\w.\-/]+$/.test(config.name)) {
-      throw new Error(`Mochi.serve({ queues }): "${config.name}" is not a valid queue name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
-    }
+    assertUniqueValidName('queues', 'queue', config.name, queueNames);
     if (config.name.startsWith('cron-')) {
       throw new Error(`Mochi.serve({ queues }): "${config.name}" uses the reserved "cron-" prefix — that namespace is for scheduled jobs (Mochi.cron). Rename the queue.`);
     }
-    if (queueNames.has(config.name)) {
-      throw new Error(`Mochi.serve({ queues }): two queues are named "${config.name}". Queue names must be unique.`);
-    }
-    queueNames.add(config.name);
     // Descriptor form is self-sufficient — the target is ensured on its own; only a bare name needs the array.
     const deadLetter = config.options?.deadLetter;
     if (typeof deadLetter === 'string' && !declaredQueues.some((q) => q.name === deadLetter)) {
@@ -285,13 +276,7 @@ function resolveCronConfig(options: MochiServeOptions): { declaredCron: NonNulla
     if (!isMochiCron(job)) {
       throw new Error(`Mochi.serve({ cron }): every element must be a descriptor created with Mochi.cron(name, schedule, …).`);
     }
-    if (typeof job.name !== 'string' || !/^[\w.\-/]+$/.test(job.name)) {
-      throw new Error(`Mochi.serve({ cron }): "${job.name}" is not a valid cron job name. Names may only contain letters, digits, underscores, dots, dashes, and slashes.`);
-    }
-    if (cronNames.has(job.name)) {
-      throw new Error(`Mochi.serve({ cron }): two cron jobs are named "${job.name}". Cron job names must be unique.`);
-    }
-    cronNames.add(job.name);
+    assertUniqueValidName('cron', 'cron job', job.name, cronNames);
   }
   // Independent of queueStorage: cron always runs on its own bun-boss instance, defaulting to in-process memory.
   const cronStorage = options.cronStorage ?? 'memory';
@@ -313,14 +298,10 @@ function assertServerPropsShape(resolved: Record<string, unknown>, pattern: stri
   }
 }
 
-function fillShellParts(parts: ShellPart[], head: string, css: string, body: string, script: string): string {
+function fillShellParts(parts: ShellPart[], slots: { head: string; css: string; body: string; script: string }): string {
   let out = '';
   for (const part of parts) {
-    if ('text' in part) {
-      out += part.text;
-    } else {
-      out += part.slot === 'head' ? head : part.slot === 'css' ? css : part.slot === 'body' ? body : script;
-    }
+    out += 'text' in part ? part.text : slots[part.slot];
   }
   return out;
 }
@@ -350,6 +331,50 @@ async function appendDebugTail(response: Response, ctx: MochiRequestContext, dev
     statusText: response.statusText,
     headers: response.headers,
   });
+}
+
+// Wraps a server island's rendered body for the wire: the also-hydrate wrapper element, the self-hydration bootstrap
+// script, and `<link>`s for CSS first seen inside this deferred content.
+function finalizeIslandBody(
+  result: RenderResult,
+  island: { hydrateMode: AlsoHydrateMode | null; componentName: string; componentPath: string; props: Record<string, unknown> },
+  registry: ComponentRegistry,
+): string {
+  const { hydrateMode, componentName, componentPath, props } = island;
+  let body = result.body;
+
+  if (hydrateMode !== null) {
+    const componentUrl = registry.getComponentEntryUrl(componentName);
+    const serializedProps = devalueStringify(props);
+
+    let hydrateAttrs = `component-name="${componentName}"`;
+    if (Object.keys(props).length > 0) {
+      hydrateAttrs += ` props="${escapeHtmlAttr(serializedProps)}"`;
+    }
+    if (componentUrl) {
+      hydrateAttrs += ` component-url="${componentUrl}"`;
+    }
+
+    body = `<mochi-hydratable-island ${hydrateAttrs}>${body}</mochi-hydratable-island>`;
+  }
+
+  // Appended whenever the rendered subtree carries hydratables — the also-hydrate island itself, plain
+  // mochi:hydrate children, or inlined also-hydrate islands — so the fragment self-hydrates even on a page that
+  // shipped no bootstrap of its own; duplicate module scripts are no-ops by src.
+  const bootstrapUrl = result.bootstrapUrl ?? (hydrateMode !== null ? registry.getIslandBootstrapUrl() : null);
+  if (bootstrapUrl) {
+    body += `<script type="module" src="${bootstrapUrl}"></script>`;
+  }
+
+  // CSS for islands rendered only inside this deferred content is gated out of the page `<head>`, so its `<link>`
+  // tags are prepended here along with side-effect CSS imports; browsers honour a `<link>` assigned via `innerHTML`.
+  // The island's own scoped CSS is excluded, since the wrapper's `css-url` attribute already loads it.
+  const ownCss = registry.getComponentCssUrl(componentPath);
+  const extraCss = result.cssUrls.filter((url) => url !== ownCss);
+  if (extraCss.length > 0) {
+    body = extraCss.map(cssLinkTag).join('') + body;
+  }
+  return body;
 }
 
 export class Mochi {
@@ -508,9 +533,13 @@ export class Mochi {
       const head = logLevelScript + warnShim + speculationRulesScript + result.head;
       const css = cssStylePrefix + cssLinks;
       const body = result.body + debugInfoScript + pageEntryScript + toolbarDiv;
-      const script = buildShellScripts(bootstrapUrl, result.hasServerIslands, serverIslandScript, debugBarUrl, assetPrefixJson, liveReloadTail);
+      const script =
+        (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
+        (result.hasServerIslands ? serverIslandScript : '') +
+        (debugBarUrl ? `<script type="module" src="${debugBarUrl}"></script><script>window.__mochi_asset_prefix=${assetPrefixJson}</script>` : '') +
+        liveReloadTail;
 
-      return fillShellParts(parts, head, css, body, script);
+      return fillShellParts(parts, { head, css, body, script });
     };
   }
 
@@ -990,6 +1019,74 @@ export class Mochi {
           return applyResolveOptions(response, resolveOpts);
         };
 
+        // Registration-scoped (not per-request) so each form POST reuses one finalizer; the per-request state arrives
+        // as explicit parameters instead of a capture web.
+        const finalizeActionResult = async (
+          result: MochiFormActionResult,
+          state: {
+            actionName: string;
+            enhanced: boolean;
+            ctx: MochiRequestContext;
+            req: Request;
+            event: MochiEvent;
+            resolveOpts: MochiResolveOptions | undefined;
+            emitActionComplete: (actionName: string, result: MochiActionResult, status?: number) => void;
+          },
+        ): Promise<Response> => {
+          const { actionName, enhanced, ctx, req, event, resolveOpts, emitActionComplete } = state;
+          if (result instanceof Response) {
+            emitActionComplete(actionName, 'success', result.status);
+            return applyResolveOptions(result, resolveOpts);
+          }
+          if (isRedirect(result)) {
+            emitActionComplete(actionName, 'redirect', result.status);
+            if (enhanced) {
+              return jsonRedirect(result.status, result.location);
+            }
+            const redirectResponse = new Response(null, {
+              status: result.status,
+              headers: { Location: result.location },
+            });
+            return applyResolveOptions(redirectResponse, resolveOpts);
+          }
+          try {
+            if (isFormFail(result)) {
+              if (enhanced) {
+                emitActionComplete(actionName, 'fail', result.status);
+                return jsonFailure(result.status, result.data);
+              }
+              ctx.form = {
+                ok: false,
+                action: actionName,
+                status: result.status,
+                data: result.data,
+              };
+              emitActionComplete(actionName, 'fail', result.status);
+              return await renderComponent(req, ctx, resolveOpts, result.status);
+            }
+            if (enhanced) {
+              emitActionComplete(actionName, 'success');
+              if (result === undefined || result === null) {
+                return jsonSuccess(undefined, { emptyResult: true });
+              }
+              return jsonSuccess(isFormSuccess(result) ? result.data : {});
+            }
+            const data = isFormSuccess(result) ? result.data : {};
+            ctx.form = { ok: true, action: actionName, data };
+            emitActionComplete(actionName, 'success');
+            return await renderComponent(req, ctx, resolveOpts);
+          } catch (err) {
+            if (enhanced) {
+              const response = await handleEnhancedError(err, event);
+              emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
+              return response;
+            }
+            const response = await routeErrorResponse(req, event, resolveOpts, err);
+            emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
+            return response;
+          }
+        };
+
         const wrapRequest = async (
           req: Request,
           server: Server<undefined>,
@@ -1072,60 +1169,6 @@ export class Mochi {
                   payload.status = status;
                 }
                 mochiEvents.emit('action:complete', payload);
-              };
-
-              const finalizeActionResult = async (result: MochiFormActionResult, actionName: string): Promise<Response> => {
-                if (result instanceof Response) {
-                  emitActionComplete(actionName, 'success', result.status);
-                  return applyResolveOptions(result, resolveOpts);
-                }
-                if (isRedirect(result)) {
-                  emitActionComplete(actionName, 'redirect', result.status);
-                  if (enhanced) {
-                    return jsonRedirect(result.status, result.location);
-                  }
-                  const redirectResponse = new Response(null, {
-                    status: result.status,
-                    headers: { Location: result.location },
-                  });
-                  return applyResolveOptions(redirectResponse, resolveOpts);
-                }
-                try {
-                  if (isFormFail(result)) {
-                    if (enhanced) {
-                      emitActionComplete(actionName, 'fail', result.status);
-                      return jsonFailure(result.status, result.data);
-                    }
-                    ctx.form = {
-                      ok: false,
-                      action: actionName,
-                      status: result.status,
-                      data: result.data,
-                    };
-                    emitActionComplete(actionName, 'fail', result.status);
-                    return await renderComponent(req, ctx, resolveOpts, result.status);
-                  }
-                  if (enhanced) {
-                    emitActionComplete(actionName, 'success');
-                    if (result === undefined || result === null) {
-                      return jsonSuccess(undefined, { emptyResult: true });
-                    }
-                    return jsonSuccess(isFormSuccess(result) ? result.data : {});
-                  }
-                  const data = isFormSuccess(result) ? result.data : {};
-                  ctx.form = { ok: true, action: actionName, data };
-                  emitActionComplete(actionName, 'success');
-                  return await renderComponent(req, ctx, resolveOpts);
-                } catch (err) {
-                  if (enhanced) {
-                    const response = await handleEnhancedError(err, event);
-                    emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
-                    return response;
-                  }
-                  const response = await routeErrorResponse(req, event, resolveOpts, err);
-                  emitError('action', ctx.requestId, req, ctx.url, response.status, err, actionName);
-                  return response;
-                }
               };
 
               const livePostActions = pageConfigMap ? pageConfigMap.get(pattern)?.actions : actions;
@@ -1211,7 +1254,7 @@ export class Mochi {
                 return response;
               }
 
-              return finalizeActionResult(result, actionName);
+              return finalizeActionResult(result, { actionName, enhanced, ctx, req, event, resolveOpts, emitActionComplete });
             });
 
           return {
@@ -1638,43 +1681,6 @@ export class Mochi {
         ctx.islandInline = { budget: applyFilter('serverIsland:inlineBudget', DEFAULT_INLINE_BUDGET, { componentName, request: req }) };
       }
 
-      const finalizeIslandBody = (result: RenderResult): string => {
-        let body = result.body;
-
-        if (isAlsoHydrateMode(hydrateMode)) {
-          const componentUrl = registry.getComponentEntryUrl(componentName);
-          const serializedProps = devalueStringify(props);
-
-          let hydrateAttrs = `component-name="${componentName}"`;
-          if (Object.keys(props as Record<string, unknown>).length > 0) {
-            hydrateAttrs += ` props="${escapeHtmlAttr(serializedProps)}"`;
-          }
-          if (componentUrl) {
-            hydrateAttrs += ` component-url="${componentUrl}"`;
-          }
-
-          body = `<mochi-hydratable-island ${hydrateAttrs}>${body}</mochi-hydratable-island>`;
-        }
-
-        // Appended whenever the rendered subtree carries hydratables — the also-hydrate island itself, plain
-        // mochi:hydrate children, or inlined also-hydrate islands — so the fragment self-hydrates even on a page that
-        // shipped no bootstrap of its own; duplicate module scripts are no-ops by src.
-        const bootstrapUrl = result.bootstrapUrl ?? (isAlsoHydrateMode(hydrateMode) ? registry.getIslandBootstrapUrl() : null);
-        if (bootstrapUrl) {
-          body += `<script type="module" src="${bootstrapUrl}"></script>`;
-        }
-
-        // CSS for islands rendered only inside this deferred content is gated out of the page `<head>`, so its `<link>`
-        // tags are prepended here along with side-effect CSS imports; browsers honour a `<link>` assigned via `innerHTML`.
-        // The island's own scoped CSS is excluded, since the wrapper's `css-url` attribute already loads it.
-        const ownCss = registry.getComponentCssUrl(componentPath);
-        const extraCss = result.cssUrls.filter((url) => url !== ownCss);
-        if (extraCss.length > 0) {
-          body = extraCss.map(cssLinkTag).join('') + body;
-        }
-        return body;
-      };
-
       return requestContext.run(ctx, async () => {
         // A miss here means the build's eager discovery (see build.ts) didn't
         // find this island; `compileAll` warns about any manifest miss, so the
@@ -1722,7 +1728,7 @@ export class Mochi {
           });
         }
 
-        const body = finalizeIslandBody(result);
+        const body = finalizeIslandBody(result, { hydrateMode, componentName, componentPath, props: props as Record<string, unknown> }, registry);
 
         return new Response(body, {
           headers: {

--- a/packages/mochi/src/captcha/captcha.ts
+++ b/packages/mochi/src/captcha/captcha.ts
@@ -5,7 +5,7 @@ import { mochiEvents } from '../events';
 import type { MochiCaptchaReason } from '../events';
 import { getCaptchaRuntime } from './config';
 import { CAPTCHA_AAD, deriveChain, powInput, leadingZeroBits } from './pow';
-import type { CaptchaResult, NonceStore } from './types';
+import type { CaptchaResult } from './types';
 
 // The chain and proof-of-work are re-derived here with node:crypto while the widget uses the sync JS implementation in
 // pow.ts. Keeping the two independent lets pow.test.ts assert they agree, checking the JS digest against a known-good
@@ -51,16 +51,10 @@ export function mintCaptcha(options?: { bits?: number; solveBudgetMs?: number })
   return { token, bits, solveBudgetMs };
 }
 
-/**
- * Verify the `captcha_token` / `captcha_pow` fields `<MochiCaptcha />` adds to the form, consuming the one-time nonce on
- * success unless `consume: false`, where you call {@link consumeCaptcha} once the submission is committed. A failure
- * carries a ready-to-render `error` plus a `reason` for your own copy — see {@link CaptchaFailureReason} for why
- * `reason` is deliberately coarse. `minAgeMs` overrides the configured timing floor for this call alone — for flows with
- * nothing to fill in (protection mode's auto-solve submits the instant the proof-of-work lands); being explicit and
- * per-call, it also bypasses the app-wide `captcha:minAgeMs` filter. `minBits` refuses tokens minted below a difficulty
- * floor — without it, any endpoint minting easier tokens (a low-bits form captcha) devalues a harder one's proof.
- */
-function parseCaptchaClaims(opened: string): { iat: number; nonce: string; bits: number } | null {
+function parseCaptchaClaims(opened: string | null): { iat: number; nonce: string; bits: number } | null {
+  if (opened === null) {
+    return null;
+  }
   try {
     const parsed = JSON.parse(opened) as { iat?: unknown; nonce?: unknown; bits?: unknown };
     if (typeof parsed.iat !== 'number' || typeof parsed.nonce !== 'string' || typeof parsed.bits !== 'number') {
@@ -79,10 +73,6 @@ function captchaPowSatisfies(token: string, pow: string, bits: number): boolean 
   return leadingZeroBits(createHash('sha256').update(powInput(challenge, pow)).digest()) >= bits;
 }
 
-async function captchaReplayRejected(store: NonceStore, consume: boolean | undefined, nonce: string, expiresAt: number): Promise<boolean> {
-  return consume !== false && !(await store.consume(nonce, expiresAt));
-}
-
 function resolveCaptchaMinAgeMs(override: number | undefined, resolvedMin: number, limitMs: number, bits: number, ageMs: number): number {
   const minAgeMs = override ?? applyFilter('captcha:minAgeMs', resolvedMin, { bits, ageMs, limitMs });
   if (!Number.isFinite(minAgeMs) || minAgeMs < 0 || minAgeMs >= limitMs) {
@@ -91,15 +81,19 @@ function resolveCaptchaMinAgeMs(override: number | undefined, resolvedMin: numbe
   return minAgeMs;
 }
 
+/**
+ * Verify the `captcha_token` / `captcha_pow` fields `<MochiCaptcha />` adds to the form, consuming the one-time nonce on
+ * success unless `consume: false`, where you call {@link consumeCaptcha} once the submission is committed. A failure
+ * carries a ready-to-render `error` plus a `reason` for your own copy — see {@link CaptchaFailureReason} for why
+ * `reason` is deliberately coarse. `minAgeMs` overrides the configured timing floor for this call alone — for flows with
+ * nothing to fill in (protection mode's auto-solve submits the instant the proof-of-work lands); being explicit and
+ * per-call, it also bypasses the app-wide `captcha:minAgeMs` filter. `minBits` refuses tokens minted below a difficulty
+ * floor — without it, any endpoint minting easier tokens (a low-bits form captcha) devalues a harder one's proof.
+ */
 export async function verifyCaptcha(formData: FormData, options?: { consume?: boolean; minAgeMs?: number; minBits?: number }): Promise<CaptchaResult> {
   const token = String(formData.get('captcha_token') ?? '');
   const pow = String(formData.get('captcha_pow') ?? '');
-  const opened = token ? decryptPayload(token, { aad: CAPTCHA_AAD }) : null;
-  if (opened === null) {
-    return reject('malformed');
-  }
-
-  const claims = parseCaptchaClaims(opened);
+  const claims = parseCaptchaClaims(token ? decryptPayload(token, { aad: CAPTCHA_AAD }) : null);
   if (claims === null) {
     return reject('malformed');
   }
@@ -132,7 +126,7 @@ export async function verifyCaptcha(formData: FormData, options?: { consume?: bo
   // Tracks the acceptance bound rather than `maxAgeMs`: a token accepted inside the drift pad would otherwise carry an
   // already-past expiry, and both stores prune on `expiresAt < now`, sweeping the nonce back out so the token replays.
   const expiresAt = iat + limitMs;
-  if (await captchaReplayRejected(store, options?.consume, nonce, expiresAt)) {
+  if (options?.consume !== false && !(await store.consume(nonce, expiresAt))) {
     return reject('replay', { bits, ageMs });
   }
   mochiEvents.emit('captcha:verify', { ok: true, reason: 'ok', bits, ageMs });

--- a/packages/mochi/src/captcha/captcha.ts
+++ b/packages/mochi/src/captcha/captcha.ts
@@ -5,7 +5,7 @@ import { mochiEvents } from '../events';
 import type { MochiCaptchaReason } from '../events';
 import { getCaptchaRuntime } from './config';
 import { CAPTCHA_AAD, deriveChain, powInput, leadingZeroBits } from './pow';
-import type { CaptchaResult } from './types';
+import type { CaptchaResult, NonceStore } from './types';
 
 // The chain and proof-of-work are re-derived here with node:crypto while the widget uses the sync JS implementation in
 // pow.ts. Keeping the two independent lets pow.test.ts assert they agree, checking the JS digest against a known-good
@@ -60,6 +60,37 @@ export function mintCaptcha(options?: { bits?: number; solveBudgetMs?: number })
  * per-call, it also bypasses the app-wide `captcha:minAgeMs` filter. `minBits` refuses tokens minted below a difficulty
  * floor — without it, any endpoint minting easier tokens (a low-bits form captcha) devalues a harder one's proof.
  */
+function parseCaptchaClaims(opened: string): { iat: number; nonce: string; bits: number } | null {
+  try {
+    const parsed = JSON.parse(opened) as { iat?: unknown; nonce?: unknown; bits?: unknown };
+    if (typeof parsed.iat !== 'number' || typeof parsed.nonce !== 'string' || typeof parsed.bits !== 'number') {
+      return null;
+    }
+    return { iat: parsed.iat, nonce: parsed.nonce, bits: parsed.bits };
+  } catch {
+    return null;
+  }
+}
+
+// Re-derive the slide-step chain from the raw token: the widget only reaches the final link by actually running the
+// progression, so a PoW over the token itself (skipping the chain) fails here.
+function captchaPowSatisfies(token: string, pow: string, bits: number): boolean {
+  const challenge = deriveChain(token, nodeHashHex);
+  return leadingZeroBits(createHash('sha256').update(powInput(challenge, pow)).digest()) >= bits;
+}
+
+async function captchaReplayRejected(store: NonceStore, consume: boolean | undefined, nonce: string, expiresAt: number): Promise<boolean> {
+  return consume !== false && !(await store.consume(nonce, expiresAt));
+}
+
+function resolveCaptchaMinAgeMs(override: number | undefined, resolvedMin: number, limitMs: number, bits: number, ageMs: number): number {
+  const minAgeMs = override ?? applyFilter('captcha:minAgeMs', resolvedMin, { bits, ageMs, limitMs });
+  if (!Number.isFinite(minAgeMs) || minAgeMs < 0 || minAgeMs >= limitMs) {
+    throw new Error(`Captcha: the captcha:minAgeMs filter returned ${minAgeMs}; expected a non-negative number below ${limitMs}, or every token is rejected`);
+  }
+  return minAgeMs;
+}
+
 export async function verifyCaptcha(formData: FormData, options?: { consume?: boolean; minAgeMs?: number; minBits?: number }): Promise<CaptchaResult> {
   const token = String(formData.get('captcha_token') ?? '');
   const pow = String(formData.get('captcha_pow') ?? '');
@@ -68,18 +99,11 @@ export async function verifyCaptcha(formData: FormData, options?: { consume?: bo
     return reject('malformed');
   }
 
-  let iat: number;
-  let nonce: string;
-  let bits: number;
-  try {
-    const parsed = JSON.parse(opened) as { iat?: unknown; nonce?: unknown; bits?: unknown };
-    if (typeof parsed.iat !== 'number' || typeof parsed.nonce !== 'string' || typeof parsed.bits !== 'number') {
-      return reject('malformed');
-    }
-    ({ iat, nonce, bits } = parsed as { iat: number; nonce: string; bits: number });
-  } catch {
+  const claims = parseCaptchaClaims(opened);
+  if (claims === null) {
     return reject('malformed');
   }
+  const { iat, nonce, bits } = claims;
 
   if (options?.minBits !== undefined && bits < options.minBits) {
     return reject('bad-pow', { bits });
@@ -92,10 +116,7 @@ export async function verifyCaptcha(formData: FormData, options?: { consume?: bo
   // different machines, so the allowance widens the expiry bound alone. Padding the floor would mean subtracting from
   // it, and any allowance wider than `minAgeMs` would delete the too-fast check rather than soften it.
   const limitMs = resolved.maxAgeMs + resolved.driftAllowanceMs;
-  const minAgeMs = options?.minAgeMs ?? applyFilter('captcha:minAgeMs', resolved.minAgeMs, { bits, ageMs, limitMs });
-  if (!Number.isFinite(minAgeMs) || minAgeMs < 0 || minAgeMs >= limitMs) {
-    throw new Error(`Captcha: the captcha:minAgeMs filter returned ${minAgeMs}; expected a non-negative number below ${limitMs}, or every token is rejected`);
-  }
+  const minAgeMs = resolveCaptchaMinAgeMs(options?.minAgeMs, resolved.minAgeMs, limitMs, bits, ageMs);
 
   if (ageMs < minAgeMs) {
     return reject('too-fast', { bits, ageMs });
@@ -104,18 +125,14 @@ export async function verifyCaptcha(formData: FormData, options?: { consume?: bo
     return reject('expired', { bits, ageMs });
   }
 
-  // Re-derive the slide-step chain from the raw token: the widget only reaches
-  // the final link by actually running the progression, so a PoW over the token
-  // itself (skipping the chain) fails here.
-  const challenge = deriveChain(token, nodeHashHex);
-  if (leadingZeroBits(createHash('sha256').update(powInput(challenge, pow)).digest()) < bits) {
+  if (!captchaPowSatisfies(token, pow, bits)) {
     return reject('bad-pow', { bits, ageMs });
   }
 
   // Tracks the acceptance bound rather than `maxAgeMs`: a token accepted inside the drift pad would otherwise carry an
   // already-past expiry, and both stores prune on `expiresAt < now`, sweeping the nonce back out so the token replays.
   const expiresAt = iat + limitMs;
-  if (options?.consume !== false && !(await store.consume(nonce, expiresAt))) {
+  if (await captchaReplayRejected(store, options?.consume, nonce, expiresAt)) {
     return reject('replay', { bits, ageMs });
   }
   mochiEvents.emit('captcha:verify', { ok: true, reason: 'ok', bits, ageMs });

--- a/packages/mochi/src/cli/build.ts
+++ b/packages/mochi/src/cli/build.ts
@@ -94,12 +94,7 @@ export async function build(options: MochiBuildOptions): Promise<void> {
   mochiEvents.on('client-bundle:complete', onClientBundle);
   mochiEvents.on('compile:complete', onCompileComplete);
   try {
-    const development = options.development ?? false;
-    const baseOutDir = options.outDir ?? './.mochi';
-    // Mirror the dev/prod split in Mochi.serve(): a `--dev` build nests under
-    // `dev/` so it can't clobber the production manifest at the root.
-    const outDir = development ? path.join(baseOutDir, 'dev') : baseOutDir;
-    const publicDir = options.publicDir ?? './public';
+    const { development, outDir, publicDir } = resolveBuildDirs(options);
 
     // Clean previous build artifacts
     rmSync(outDir, { recursive: true, force: true });
@@ -163,21 +158,10 @@ export async function build(options: MochiBuildOptions): Promise<void> {
     if (options.protection?.enabled === true) {
       ssrEntrypoints.push(options.protection.page ?? PROTECTION_SHELL_COMPONENT);
     }
-    const allRoutes: RouteEntry[] = [];
-
-    for (const [pattern, handler] of Object.entries(options.routes)) {
-      if (isMochiPage(handler)) {
-        allRoutes.push({ pattern, kind: 'page', componentPath: handler.componentPath });
-        ssrEntrypoints.push(handler.componentPath);
-        compiledPages.push(pattern);
-      } else if (isMochiApi(handler)) {
-        allRoutes.push({ pattern, kind: 'api' });
-      } else if (isMochiWs(handler)) {
-        allRoutes.push({ pattern, kind: 'ws' });
-      } else if (isMochiSse(handler)) {
-        allRoutes.push({ pattern, kind: 'sse' });
-      }
-    }
+    const classified = classifyRoutes(options.routes);
+    const allRoutes = classified.allRoutes;
+    ssrEntrypoints.push(...classified.pagePaths);
+    compiledPages.push(...classified.compiledPages);
 
     // Email templates are reachable only through `Mochi.email({ component })` at runtime, so no import graph leads here
     // from a route. Walking the conventional directory is what keeps them out of a cold compile on the first send.
@@ -203,29 +187,7 @@ export async function build(options: MochiBuildOptions): Promise<void> {
       return { file, ...stats };
     });
 
-    // Until the build compiled these, an island in an email template surfaced only as a render-time throw on the first
-    // send. Now that they're in the bundle it would also emit client JS no email client can run, so fail here instead.
-    // Mirrors renderStatic()'s hydratable guard, which is import-graph based and fires regardless of props.
-    const emailWithIslands = emailStats.filter((s) => s.hydratableCount > 0).map((s) => s.file);
-    if (emailWithIslands.length > 0) {
-      throw new Error(
-        `[mochi:build] Email templates can't contain islands:\n` +
-          emailWithIslands.map((f) => `  - ${f}`).join('\n') +
-          `\nmochi:hydrate* / mochi:clientOnly need client JS, which an email can't run — render the content inline instead.`,
-      );
-    }
-
-    // Stricter than renderStatic()'s own server-island guard, which is post-render and greps the output for the
-    // placeholder, so it lets through a `mochi:defer` behind a branch that never renders. The import graph catches that
-    // one too — an email template has no business referencing a server island at all.
-    const emailWithServerIslands = emailStats.filter((s) => s.serverIslandCount > 0).map((s) => s.file);
-    if (emailWithServerIslands.length > 0) {
-      throw new Error(
-        `[mochi:build] Email templates can't contain server islands:\n` +
-          emailWithServerIslands.map((f) => `  - ${f}`).join('\n') +
-          `\nmochi:defer* loads over a follow-up request an email can't make — render the content inline instead.`,
-      );
-    }
+    assertNoEmailIslands(emailStats);
 
     // Precompiling `mochi:defer` islands as standalone SSR modules keeps the production runtime off the compile path,
     // which the first fetch of each deferred island would otherwise trigger. Discovery is eager because a
@@ -301,6 +263,59 @@ export async function build(options: MochiBuildOptions): Promise<void> {
   } finally {
     mochiEvents.off('client-bundle:complete', onClientBundle);
     mochiEvents.off('compile:complete', onCompileComplete);
+  }
+}
+
+function resolveBuildDirs(options: MochiBuildOptions): { development: boolean; outDir: string; publicDir: string } {
+  const development = options.development ?? false;
+  const baseOutDir = options.outDir ?? './.mochi';
+  // Mirror the dev/prod split in Mochi.serve(): a `--dev` build nests under `dev/` so it can't clobber the production manifest at the root.
+  const outDir = development ? path.join(baseOutDir, 'dev') : baseOutDir;
+  const publicDir = options.publicDir ?? './public';
+  return { development, outDir, publicDir };
+}
+
+function classifyRoutes(routes: MochiBuildOptions['routes']): { allRoutes: RouteEntry[]; pagePaths: string[]; compiledPages: string[] } {
+  const allRoutes: RouteEntry[] = [];
+  const pagePaths: string[] = [];
+  const compiledPages: string[] = [];
+  for (const [pattern, handler] of Object.entries(routes)) {
+    if (isMochiPage(handler)) {
+      allRoutes.push({ pattern, kind: 'page', componentPath: handler.componentPath });
+      pagePaths.push(handler.componentPath);
+      compiledPages.push(pattern);
+    } else if (isMochiApi(handler)) {
+      allRoutes.push({ pattern, kind: 'api' });
+    } else if (isMochiWs(handler)) {
+      allRoutes.push({ pattern, kind: 'ws' });
+    } else if (isMochiSse(handler)) {
+      allRoutes.push({ pattern, kind: 'sse' });
+    }
+  }
+  return { allRoutes, pagePaths, compiledPages };
+}
+
+function assertNoEmailIslands(emailStats: { file: string; hydratableCount: number; serverIslandCount: number }[]): void {
+  // Until the build compiled these, an island in an email template surfaced only as a render-time throw on the first
+  // send. Now that they're in the bundle it would also emit client JS no email client can run, so fail here instead.
+  const emailWithIslands = emailStats.filter((s) => s.hydratableCount > 0).map((s) => s.file);
+  if (emailWithIslands.length > 0) {
+    throw new Error(
+      `[mochi:build] Email templates can't contain islands:\n` +
+        emailWithIslands.map((f) => `  - ${f}`).join('\n') +
+        `\nmochi:hydrate* / mochi:clientOnly need client JS, which an email can't run — render the content inline instead.`,
+    );
+  }
+
+  // Stricter than renderStatic()'s own server-island guard: the import graph catches a `mochi:defer` behind a branch
+  // that never renders — an email template has no business referencing a server island at all.
+  const emailWithServerIslands = emailStats.filter((s) => s.serverIslandCount > 0).map((s) => s.file);
+  if (emailWithServerIslands.length > 0) {
+    throw new Error(
+      `[mochi:build] Email templates can't contain server islands:\n` +
+        emailWithServerIslands.map((f) => `  - ${f}`).join('\n') +
+        `\nmochi:defer* loads over a follow-up request an email can't make — render the content inline instead.`,
+    );
   }
 }
 
@@ -449,6 +464,11 @@ function printBuildTree({ routes, errorPage, emails, islands, assetPrefix, stats
     }
   }
 
+  const legendEntries = buildLegendEntries(routeRows, emails.length > 0, islandRows);
+  console.log(`\n  ${legendEntries.join(styleText('dim', '  ·  '))}`);
+}
+
+function buildLegendEntries(routeRows: { kind: RouteKind; hyd: number | null }[], hasEmails: boolean, islandRows: { hyd: number | null }[]): string[] {
   const legendEntries: string[] = [];
   if (routeRows.some((r) => r.kind === 'page' && r.hyd != null && r.hyd > 0)) {
     legendEntries.push(`${styleText('green', '●')} page with islands`);
@@ -466,7 +486,7 @@ function printBuildTree({ routes, errorPage, emails, islands, assetPrefix, stats
     legendEntries.push(`${styleText('green', '→')} sse`);
   }
   legendEntries.push(`${styleText('yellow', '⚠')} error page`);
-  if (emails.length > 0) {
+  if (hasEmails) {
     legendEntries.push(`${styleText('cyan', '✉')} email template`);
   }
   if (islandRows.some((r) => r.hyd != null && r.hyd > 0)) {
@@ -475,5 +495,5 @@ function printBuildTree({ routes, errorPage, emails, islands, assetPrefix, stats
   if (islandRows.some((r) => r.hyd === null || r.hyd === 0)) {
     legendEntries.push(`${styleText('magenta', '○')} server island`);
   }
-  console.log(`\n  ${legendEntries.join(styleText('dim', '  ·  '))}`);
+  return legendEntries;
 }

--- a/packages/mochi/src/cli/cli.ts
+++ b/packages/mochi/src/cli/cli.ts
@@ -3,6 +3,7 @@ import { parseArgs } from 'node:util';
 import path from 'node:path';
 import { existsSync } from 'node:fs';
 import { build } from './build';
+import type { MochiBuildOptions } from './build';
 import { closeAllQueueResources } from '../queue';
 import { extractServeOptions } from './extractServeOptions';
 import { updateSkill, SKILL_TARGETS, SKILL_DESTS, DEFAULT_SKILL_TARGET, type SkillTarget } from './updateSkill';
@@ -102,6 +103,27 @@ async function runGenerateKey(force: boolean) {
   }
 }
 
+type BuildCliValues = { dev?: boolean; 'out-dir'?: string; 'public-dir'?: string; 'asset-prefix'?: string };
+
+function toBuildOptions(routes: MochiBuildOptions['routes'], serveOptions: Awaited<ReturnType<typeof extractServeOptions>>, values: BuildCliValues): MochiBuildOptions {
+  return {
+    routes,
+    markdown: serveOptions?.markdown,
+    svelteCompiler: serveOptions?.svelteCompiler,
+    optimize: serveOptions && 'optimize' in serveOptions ? serveOptions.optimize : undefined,
+    barrelWarnings: serveOptions?.barrelWarnings,
+    fonts: serveOptions?.fonts,
+    errorPage: serveOptions?.errorPage,
+    resources: serveOptions?.build?.resources,
+    protection: serveOptions?.protection,
+    development: values.dev,
+    outDir: values['out-dir'],
+    // Fall back to the entry's own `publicDir` so the build validates the same directory the server will scan — an explicit flag still overrides it.
+    publicDir: values['public-dir'] ?? serveOptions?.publicDir,
+    assetPrefix: values['asset-prefix'],
+  };
+}
+
 async function main() {
   const { values, positionals } = parseArgs({
     args: Bun.argv.slice(2),
@@ -172,23 +194,7 @@ async function main() {
     process.exit(1);
   }
 
-  await build({
-    routes,
-    markdown: serveOptions?.markdown,
-    svelteCompiler: serveOptions?.svelteCompiler,
-    optimize: serveOptions && 'optimize' in serveOptions ? serveOptions.optimize : undefined,
-    barrelWarnings: serveOptions?.barrelWarnings,
-    fonts: serveOptions?.fonts,
-    errorPage: serveOptions?.errorPage,
-    resources: serveOptions?.build?.resources,
-    protection: serveOptions?.protection,
-    development: values.dev,
-    outDir: values['out-dir'],
-    // Fall back to the entry's own `publicDir` so the build validates the same
-    // directory the server will scan — an explicit flag still overrides it.
-    publicDir: values['public-dir'] ?? serveOptions?.publicDir,
-    assetPrefix: values['asset-prefix'],
-  });
+  await build(toBuildOptions(routes, serveOptions, values));
 
   // Extracting serve options imports the user's entry for real; if anything started the queue runtime, its
   // maintenance timers keep the event loop alive and hang this one-shot build. Drain and exit.

--- a/packages/mochi/src/cli/testing.ts
+++ b/packages/mochi/src/cli/testing.ts
@@ -437,23 +437,27 @@ export async function runTests(options: RunTestsOptions = {}): Promise<void> {
   );
   reportWedges(results);
   if (failed.length > 0) {
-    // Re-print each failure at the very end: with files streaming out of order
-    // across workers, the error text that matters is buried thousands of lines up.
-    console.log('Failed:');
-    for (const r of failed) {
-      console.log(`\n  ✗ ${r.file}${r.wedged ? ' (finished, never exited)' : r.killed ? ' (timed out)' : ''}`);
-      const { failures, fallback } = extractFailures(r);
-      const body = failures.flatMap((f) => (f.name ? [`(fail) ${f.name}`, ...f.detail] : f.detail)).concat(fallback ?? []);
-      if (body.length === 0) {
-        console.log('    (no output captured before the process was killed)');
-      }
-      for (const line of body.slice(0, MAX_FILE_LINES)) {
-        console.log(line.trim() ? `    ${line}` : '');
-      }
-      if (body.length > MAX_FILE_LINES) {
-        console.log(`    … (truncated, ${body.length - MAX_FILE_LINES} more lines — see this file's output above)`);
-      }
-    }
+    printRunFailures(failed);
     process.exit(1);
+  }
+}
+
+function printRunFailures(failed: FileResult[]): void {
+  // Re-print each failure at the very end: with files streaming out of order across workers, the error text that
+  // matters is buried thousands of lines up.
+  console.log('Failed:');
+  for (const r of failed) {
+    console.log(`\n  ✗ ${r.file}${r.wedged ? ' (finished, never exited)' : r.killed ? ' (timed out)' : ''}`);
+    const { failures, fallback } = extractFailures(r);
+    const body = failures.flatMap((f) => (f.name ? [`(fail) ${f.name}`, ...f.detail] : f.detail)).concat(fallback ?? []);
+    if (body.length === 0) {
+      console.log('    (no output captured before the process was killed)');
+    }
+    for (const line of body.slice(0, MAX_FILE_LINES)) {
+      console.log(line.trim() ? `    ${line}` : '');
+    }
+    if (body.length > MAX_FILE_LINES) {
+      console.log(`    … (truncated, ${body.length - MAX_FILE_LINES} more lines — see this file's output above)`);
+    }
   }
 }

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -347,8 +347,20 @@ function indexHydratables(hydratables: HydratableComponent[]): {
   };
 }
 
-type BuildOutputsMeta = Record<string, { entryPoint?: string; inputs: Record<string, unknown>; imports?: { path: string }[]; bytes?: number }>;
 type ClientBuildMetafile = NonNullable<Awaited<ReturnType<typeof Bun.build>>['metafile']>;
+type BuildOutputsMeta = ClientBuildMetafile['outputs'];
+
+// Everything one compile batch accumulates in the build plugin's onLoad hooks and consumes after the build. Passed as
+// one object so the structurally-identical hydratable/server-island maps can never be transposed between call sites.
+interface CompileBatch {
+  cssMap: Map<string, string>;
+  importedCssPaths: Set<string>;
+  allHydratables: HydratableComponent[];
+  allServerIslands: ServerIslandComponent[];
+  fileHydratables: Map<string, HydratableComponent[]>;
+  fileServerIslands: Map<string, ServerIslandComponent[]>;
+  filePreprocessErrors: Map<string, PreprocessIslandError[]>;
+}
 
 export class ComponentRegistry {
   private compiledComponents: Map<
@@ -551,14 +563,13 @@ export class ComponentRegistry {
     if (exclude.length === 0) {
       return 0;
     }
-    const cwd = process.cwd();
     const globs = exclude.map((p) => new Bun.Glob(p));
     let excluded = 0;
     // Snapshot the keys: the loop deletes from `shaken` while iterating it.
     // oxlint-disable-next-line no-useless-spread
     for (const id of [...shaken.keys()]) {
       // Glob patterns are written with forward slashes, so match against POSIX-ified paths or Windows never excludes anything.
-      const rel = toPosixPath(path.relative(cwd, id));
+      const rel = relForDisplay(id);
       // Excluded files compile from original source. Safe regardless: the whole-app scan still covered them as call sites of other components.
       if (globs.some((g) => g.match(rel) || g.match(toPosixPath(id)))) {
         shaken.delete(id);
@@ -659,15 +670,18 @@ export class ComponentRegistry {
     }
     const compileStart = performance.now();
 
-    const cssMap = new Map<string, string>();
-    const importedCssPaths = new Set<string>();
-    const allHydratables: HydratableComponent[] = [];
-    const allServerIslands: ServerIslandComponent[] = [];
+    const batch: CompileBatch = {
+      cssMap: new Map(),
+      importedCssPaths: new Set(),
+      allHydratables: [],
+      allServerIslands: [],
+      fileHydratables: new Map(),
+      fileServerIslands: new Map(),
+      filePreprocessErrors: new Map(),
+    };
+    const { cssMap, importedCssPaths, allHydratables, allServerIslands, fileHydratables, fileServerIslands, filePreprocessErrors } = batch;
     const preprocessCacheStats = createPreprocessCacheStats();
     const compileCacheStats = createCompileCacheStats();
-    const fileHydratables = new Map<string, HydratableComponent[]>();
-    const fileServerIslands = new Map<string, ServerIslandComponent[]>();
-    const filePreprocessErrors = new Map<string, PreprocessIslandError[]>();
     const development = this.development;
     const userCompilerOptions = this.svelteConfig.compilerOptions ?? {};
     const backend = await resolveSvelteCompiler(this.svelteCompiler);
@@ -823,11 +837,11 @@ export class ComponentRegistry {
       throw: false,
     });
 
-    this.recordPreprocessErrors(filePreprocessErrors, fileHydratables, fileServerIslands);
+    this.recordPreprocessErrors(batch);
 
     this.warnOnBarrelImports(result.metafile);
 
-    this.detectNestedIslandErrors(fileHydratables, fileServerIslands, allHydratables);
+    this.detectNestedIslandErrors(batch);
 
     if (!result.success) {
       const message = `Svelte SSR build failed:\n${formatBuildMessages(result.logs)}`;
@@ -841,14 +855,15 @@ export class ComponentRegistry {
       throw new Error(message);
     }
 
-    await this.registerCompiledEntries(todo, result.metafile?.outputs ?? {}, compileOutDir, fileHydratables, fileServerIslands, cssMap, importedCssPaths, compileStart);
+    await this.registerCompiledEntries(todo, result.metafile?.outputs ?? {}, compileOutDir, batch, compileStart);
 
     mochiEvents.emit('compile:batch-complete', {
       count: todo.length,
       durationMs: performance.now() - compileStart,
     });
 
-    emitCompileCacheSummaries(preprocessCacheStats, compileCacheStats);
+    emitCacheSummary('preprocess-cache:summary', preprocessCacheStats);
+    emitCacheSummary('compile-cache:summary', compileCacheStats);
 
     await this.writeComponentCss(cssMap);
 
@@ -885,11 +900,8 @@ export class ComponentRegistry {
   // a fixed mistake keeps 500-ing every page until a restart and an unfixed one is duplicated on every save. Runs BEFORE
   // the `result.success` throw on purpose: the hydration maps come from the svelte `onLoad`, which fires for every entry
   // before Bun resolves transitive JS deps, so a later bundler failure must not swallow a structural error already detected.
-  private recordPreprocessErrors(
-    filePreprocessErrors: Map<string, PreprocessIslandError[]>,
-    fileHydratables: Map<string, HydratableComponent[]>,
-    fileServerIslands: Map<string, ServerIslandComponent[]>,
-  ): void {
+  private recordPreprocessErrors(batch: CompileBatch): void {
+    const { filePreprocessErrors, fileHydratables, fileServerIslands } = batch;
     this.errors = this.errors.filter(
       (e) =>
         !(e.kind === 'nested-hydration' && fileHydratables.has(e.parentPath)) &&
@@ -919,11 +931,8 @@ export class ComponentRegistry {
 
   // Detect nested hydration and server-islands-inside-hydratables — both one file deep: a hydratable subtree can't
   // contain another hydratable directive or a server island, which the client can't render on hydration.
-  private detectNestedIslandErrors(
-    fileHydratables: Map<string, HydratableComponent[]>,
-    fileServerIslands: Map<string, ServerIslandComponent[]>,
-    allHydratables: HydratableComponent[],
-  ): void {
+  private detectNestedIslandErrors(batch: CompileBatch): void {
+    const { fileHydratables, fileServerIslands, allHydratables } = batch;
     const hydratablePaths = new Set(allHydratables.map((h) => h.resolvedPath));
     for (const [filePath, children] of fileHydratables) {
       if (hydratablePaths.has(filePath) && children.length > 0) {
@@ -937,6 +946,9 @@ export class ComponentRegistry {
       }
     }
 
+    // A server island inside a hydratable subtree can never work: client bundles skip the island preprocessor, so on
+    // hydration the client renders the raw child where SSR emitted a placeholder (observed: HYDRATION_ERROR + client
+    // remount wiping the island). Same one-file-deep limitation as the nested-hydration guard above.
     for (const [filePath, children] of fileServerIslands) {
       if (hydratablePaths.has(filePath) && children.length > 0) {
         const parent = allHydratables.find((h) => h.resolvedPath === filePath)!;
@@ -954,16 +966,8 @@ export class ComponentRegistry {
   // hydratables/CSS/server-islands, and dev-watcher dep tracking. `outputs[outKey].inputs` is the flat record of every
   // source file that fed a chunk — stable to compare against `cssMap`/`importedCssPaths`, unlike the importer-relative
   // `inputs[].imports[].path`.
-  private async registerCompiledEntries(
-    todo: string[],
-    outputsMeta: BuildOutputsMeta,
-    compileOutDir: string,
-    fileHydratables: Map<string, HydratableComponent[]>,
-    fileServerIslands: Map<string, ServerIslandComponent[]>,
-    cssMap: Map<string, string>,
-    importedCssPaths: Set<string>,
-    compileStart: number,
-  ): Promise<void> {
+  private async registerCompiledEntries(todo: string[], outputsMeta: BuildOutputsMeta, compileOutDir: string, batch: CompileBatch, compileStart: number): Promise<void> {
+    const { fileHydratables, fileServerIslands, cssMap, importedCssPaths } = batch;
     const entryToOutKey = new Map<string, string>();
     for (const [outKey, outMeta] of Object.entries(outputsMeta)) {
       if (outMeta.entryPoint) {
@@ -1295,14 +1299,7 @@ export class ComponentRegistry {
       durationMs: performance.now() - bundleStart,
     });
 
-    const compileCacheFiles = compileCacheStats.hits + compileCacheStats.misses;
-    if (compileCacheFiles > 0) {
-      mochiEvents.emit('compile-cache:summary', {
-        hits: compileCacheStats.hits,
-        misses: compileCacheStats.misses,
-        files: compileCacheFiles,
-      });
-    }
+    emitCacheSummary('compile-cache:summary', compileCacheStats);
   }
 
   // Map each client-build entry-point output back to its component (or the bootstrap) via metafile.entryPoint, avoiding
@@ -1549,7 +1546,7 @@ export class ComponentRegistry {
 
     const debugBarData = this.buildRenderDebugBarData(ctx, hydratables.length > 0, renderedIslandNames);
 
-    const { cssUrls, fontPreloadUrls } = this.collectRenderCssUrls(entryKey, cssComponents, islandPaths, hydratablesByPath, lazyIslandPaths, renderedIslandNames);
+    const { cssUrls, fontPreloadUrls } = this.collectRenderCssUrls({ entryKey, cssComponents, islandPaths, hydratablesByPath, lazyIslandPaths, renderedIslandNames });
 
     // Collapse the doubled-marker Svelte SSR bug (`$state` arrays + `{@attach}`); only island wrappers can carry it,
     // so island-free renders skip the scan.
@@ -1559,7 +1556,7 @@ export class ComponentRegistry {
       body: normalized,
       head: shouldStrip ? stripHydrationMarkers(headStr) : headStr,
       cssUrls,
-      fontPreloadUrls: [...fontPreloadUrls],
+      fontPreloadUrls,
       // Gated on wrappers actually present in the output — the entry's compile-time hydratables may all sit in branches
       // this render never took.
       bootstrapUrl: renderedIslandNames.size > 0 ? this.islandBootstrapUrl : null,
@@ -1570,14 +1567,21 @@ export class ComponentRegistry {
 
   // Scoped CSS URLs for this render: each component's own stylesheet, minus lazy islands and islands that didn't render,
   // plus the side-effect CSS imports reachable from the entry and their font preloads.
-  private collectRenderCssUrls(
-    entryKey: string,
-    cssComponents: Set<string>,
-    islandPaths: Set<string>,
-    hydratablesByPath: Map<string, HydratableComponent[]>,
-    lazyIslandPaths: Set<string>,
-    renderedIslandNames: Set<string>,
-  ): { cssUrls: string[]; fontPreloadUrls: string[] } {
+  private collectRenderCssUrls({
+    entryKey,
+    cssComponents,
+    islandPaths,
+    hydratablesByPath,
+    lazyIslandPaths,
+    renderedIslandNames,
+  }: {
+    entryKey: string;
+    cssComponents: Set<string>;
+    islandPaths: Set<string>;
+    hydratablesByPath: Map<string, HydratableComponent[]>;
+    lazyIslandPaths: Set<string>;
+    renderedIslandNames: Set<string>;
+  }): { cssUrls: string[]; fontPreloadUrls: string[] } {
     const cssUrls: string[] = [];
     for (const componentPath of cssComponents) {
       const cssUrl = this.cssFileUrls.get(componentPath);
@@ -2555,7 +2559,6 @@ function resolveExportedComponent(mod: { default: any } & Record<string, any>, e
   return component;
 }
 
-// One virtual client entry per island: import the component (default or named) and register it under its island key.
 function buildIslandEntrypoints(
   unique: Map<string, HydratableComponent>,
   hydratableIslandPath: string,
@@ -2577,14 +2580,10 @@ function buildIslandEntrypoints(
   return { entrypoints, filesMap };
 }
 
-function emitCompileCacheSummaries(preprocessCacheStats: { hits: number; misses: number }, compileCacheStats: { hits: number; misses: number }): void {
-  const files = preprocessCacheStats.hits + preprocessCacheStats.misses;
+function emitCacheSummary(event: 'preprocess-cache:summary' | 'compile-cache:summary', stats: { hits: number; misses: number }): void {
+  const files = stats.hits + stats.misses;
   if (files > 0) {
-    mochiEvents.emit('preprocess-cache:summary', { hits: preprocessCacheStats.hits, misses: preprocessCacheStats.misses, files });
-  }
-  const compileCacheFiles = compileCacheStats.hits + compileCacheStats.misses;
-  if (compileCacheFiles > 0) {
-    mochiEvents.emit('compile-cache:summary', { hits: compileCacheStats.hits, misses: compileCacheStats.misses, files: compileCacheFiles });
+    mochiEvents.emit(event, { hits: stats.hits, misses: stats.misses, files });
   }
 }
 

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -29,6 +29,7 @@ import {
   fontChangedSinceResolved,
   fontContentHash,
   substituteFontUrls,
+  type SurvivingFont,
 } from './cssFontAssets';
 import { type HydratableComponent, type PreprocessIslandError, type ServerIslandComponent } from './svelteAstPreprocess';
 import { cachedPreprocessHydratable, createPreprocessCacheStats } from './preprocessCache';
@@ -119,24 +120,27 @@ function createMarkdownLoader(opts: {
 }) {
   const highlight = opts.markdown.highlight;
   const fingerprint = compileFingerprint(opts.userCompilerOptions, opts.development, backendId(opts.backend));
+  // A hit replays the side effects the miss path would have produced (hydration metadata, scoped CSS) and skips mdsvex
+  // and the svelte compile.
+  const replayCachedMarkdown = (cached: NonNullable<ReturnType<typeof opts.compileCache.get>>, filePath: string) => {
+    if (opts.hydration) {
+      opts.hydration.fileHydratables.set(filePath, cached.hydratables);
+      opts.hydration.allHydratables.push(...cached.hydratables);
+      opts.hydration.allServerIslands.push(...cached.serverIslands);
+      opts.hydration.filePreprocessErrors.set(filePath, cached.preprocessErrors);
+    }
+    if (opts.target === 'server' && cached.css && opts.cssMap) {
+      opts.cssMap.set(filePath, cached.css);
+    }
+    return { contents: cached.js, loader: 'js' as const };
+  };
   return async (args: { path: string }) => {
     const raw = await Bun.file(args.path).text();
-    // A hit replays the side effects the miss path would have produced (hydration metadata, scoped CSS) and skips mdsvex
-    // and the svelte compile. Keying on raw source assumes mdsvex and the user preprocessors are pure in
-    // (source, filename), the standard Vite/SvelteKit contract: a plugin reading a sibling `.json` won't re-run until
-    // this file's own bytes change.
+    // Keying on raw source assumes mdsvex and the user preprocessors are pure in (source, filename), the standard
+    // Vite/SvelteKit contract: a plugin reading a sibling `.json` won't re-run until this file's own bytes change.
     const cached = opts.compileCache.get(opts.target, args.path, raw, fingerprint, opts.compileCacheStats);
     if (cached) {
-      if (opts.hydration) {
-        opts.hydration.fileHydratables.set(args.path, cached.hydratables);
-        opts.hydration.allHydratables.push(...cached.hydratables);
-        opts.hydration.allServerIslands.push(...cached.serverIslands);
-        opts.hydration.filePreprocessErrors.set(args.path, cached.preprocessErrors);
-      }
-      if (opts.target === 'server' && cached.css && opts.cssMap) {
-        opts.cssMap.set(args.path, cached.css);
-      }
-      return { contents: cached.js, loader: 'js' as const };
+      return replayCachedMarkdown(cached, args.path);
     }
     // mdsvex's `compile` declares a nested-Promise return type, so we accept
     // `unknown` at the type level and await + validate at runtime. `await`
@@ -343,6 +347,9 @@ function indexHydratables(hydratables: HydratableComponent[]): {
   };
 }
 
+type BuildOutputsMeta = Record<string, { entryPoint?: string; inputs: Record<string, unknown>; imports?: { path: string }[]; bytes?: number }>;
+type ClientBuildMetafile = NonNullable<Awaited<ReturnType<typeof Bun.build>>['metafile']>;
+
 export class ComponentRegistry {
   private compiledComponents: Map<
     string,
@@ -470,11 +477,19 @@ export class ComponentRegistry {
     this.optimize = opts.optimize ?? false;
     this.fontInlineThreshold = opts.fonts?.inlineThreshold ?? 4096;
     this.fontDropLegacyWoff = opts.fonts?.dropLegacyWoff ?? true;
-    const bw = opts.barrelWarnings;
-    this.barrelWarningsEnabled = bw !== false;
-    this.barrelIgnore = new Set(typeof bw === 'object' ? (bw.ignore ?? []) : []);
-    this.barrelMinBytes = (typeof bw === 'object' ? bw.minBytes : undefined) ?? 50 * 1024;
+    const barrel = ComponentRegistry.resolveBarrelWarnings(opts.barrelWarnings);
+    this.barrelWarningsEnabled = barrel.enabled;
+    this.barrelIgnore = barrel.ignore;
+    this.barrelMinBytes = barrel.minBytes;
     this.barrelBuffering = opts.bufferBarrelWarnings ?? false;
+  }
+
+  private static resolveBarrelWarnings(bw: ComponentRegistryOptions['barrelWarnings']): { enabled: boolean; ignore: Set<string>; minBytes: number } {
+    return {
+      enabled: bw !== false,
+      ignore: new Set(typeof bw === 'object' ? (bw.ignore ?? []) : []),
+      minBytes: (typeof bw === 'object' ? bw.minBytes : undefined) ?? 50 * 1024,
+    };
   }
 
   /**
@@ -503,25 +518,7 @@ export class ComponentRegistry {
       if (shaken.size === 0) {
         logger.warn(`svelte-shaker: no .svelte components found under ${appRoot}; nothing to shake`);
       }
-      const cwd = process.cwd();
-      const exclude = typeof opt === 'object' ? (opt.exclude ?? []) : [];
-      let excluded = 0;
-      if (exclude.length > 0) {
-        const globs = exclude.map((p) => new Bun.Glob(p));
-        // Snapshot the keys: the loop deletes from `shaken` while iterating it.
-        // oxlint-disable-next-line no-useless-spread
-        for (const id of [...shaken.keys()]) {
-          // Glob patterns are written with forward slashes, so match against
-          // POSIX-ified paths or Windows never excludes anything.
-          const rel = toPosixPath(path.relative(cwd, id));
-          // Excluded files compile from original source. Safe regardless: the
-          // whole-app scan still covered them as call sites of other components.
-          if (globs.some((g) => g.match(rel) || g.match(toPosixPath(id)))) {
-            shaken.delete(id);
-            excluded++;
-          }
-        }
-      }
+      const excluded = ComponentRegistry.applyShakeExclusions(shaken, opt);
       this.shakenSources = shaken;
 
       // The shake map holds every in-scope component, returning untouched ones verbatim, so its size is the scan count.
@@ -546,6 +543,29 @@ export class ComponentRegistry {
       logger.error(e);
       this.shakenSources = new Map();
     }
+  }
+
+  // Drop shaken entries matching the `optimize.exclude` globs so they compile from original source; returns the count.
+  private static applyShakeExclusions(shaken: Map<string, string>, opt: boolean | MochiSvelteShakerOptions): number {
+    const exclude = typeof opt === 'object' ? (opt.exclude ?? []) : [];
+    if (exclude.length === 0) {
+      return 0;
+    }
+    const cwd = process.cwd();
+    const globs = exclude.map((p) => new Bun.Glob(p));
+    let excluded = 0;
+    // Snapshot the keys: the loop deletes from `shaken` while iterating it.
+    // oxlint-disable-next-line no-useless-spread
+    for (const id of [...shaken.keys()]) {
+      // Glob patterns are written with forward slashes, so match against POSIX-ified paths or Windows never excludes anything.
+      const rel = toPosixPath(path.relative(cwd, id));
+      // Excluded files compile from original source. Safe regardless: the whole-app scan still covered them as call sites of other components.
+      if (globs.some((g) => g.match(rel) || g.match(toPosixPath(id)))) {
+        shaken.delete(id);
+        excluded++;
+      }
+    }
+    return excluded;
   }
 
   /** Log a per-component before→after source-byte breakdown for the changed components. */
@@ -632,19 +652,7 @@ export class ComponentRegistry {
       return;
     }
 
-    // A prebuilt manifest is meant to cover every component the app renders, so a miss costs a cold compile on the
-    // request that hit it — and means this deploy needs its Svelte sources and the compiler at runtime.
-    if (this.loadedFromManifest && !this.development && !opts.force) {
-      logger.warn(
-        `${todo.length} component(s) are missing from the prebuilt manifest and will be compiled now:\n` +
-          todo.map((f) => `  - ${relForDisplay(f)}`).join('\n') +
-          `\nCommon causes: an email template outside \`${EMAIL_TEMPLATE_DIR}/\` (the build walks that directory, since nothing imports a template from a route — move it there), ` +
-          `or another component rendered outside a route, which the build cannot discover. ` +
-          `Otherwise, \`mochi-framework build\` and the server must run from the same working directory (the project root), and both must use the same mochi-framework version. ` +
-          `Until it's fixed, this build needs its Svelte sources and the compiler at runtime. ` +
-          `If none of the above apply, this is a Mochi bug — please report it with a reproduction.`,
-      );
-    }
+    this.warnManifestMiss(todo, opts.force ?? false);
 
     for (const f of todo) {
       mochiEvents.emit('compile:start', { path: f });
@@ -815,14 +823,73 @@ export class ComponentRegistry {
       throw: false,
     });
 
-    // Detection recomputes nested-hydration and unresolved-island errors for every file in this batch, so prior ones for
-    // the recompiled files are dropped first — otherwise a fixed mistake keeps 500-ing every page until a restart and an
-    // unfixed one is duplicated on every save.
-    //
-    // This runs BEFORE the `result.success` throw on purpose: the hydration maps come from the svelte `onLoad`, which
-    // fires for every entry before Bun resolves transitive JS deps, so a later bundler failure must not swallow a
-    // structural error already detected — including under the `bun test`-only EISDIR bug, where the SSR build fails
-    // after preprocessing succeeded.
+    this.recordPreprocessErrors(filePreprocessErrors, fileHydratables, fileServerIslands);
+
+    this.warnOnBarrelImports(result.metafile);
+
+    this.detectNestedIslandErrors(fileHydratables, fileServerIslands, allHydratables);
+
+    if (!result.success) {
+      const message = `Svelte SSR build failed:\n${formatBuildMessages(result.logs)}`;
+      for (const f of todo) {
+        mochiEvents.emit('compile:error', {
+          path: f,
+          message,
+          logs: toCompileErrorLogs(result.logs),
+        });
+      }
+      throw new Error(message);
+    }
+
+    await this.registerCompiledEntries(todo, result.metafile?.outputs ?? {}, compileOutDir, fileHydratables, fileServerIslands, cssMap, importedCssPaths, compileStart);
+
+    mochiEvents.emit('compile:batch-complete', {
+      count: todo.length,
+      durationMs: performance.now() - compileStart,
+    });
+
+    emitCompileCacheSummaries(preprocessCacheStats, compileCacheStats);
+
+    await this.writeComponentCss(cssMap);
+
+    if (importedCssPaths.size > 0) {
+      await this.bundleImportedCss(importedCssPaths);
+    }
+
+    this.registerServerIslandPaths(allServerIslands);
+
+    this.hydratableComponents.push(...allHydratables);
+    if (!opts.deferClientBundle && allHydratables.length > 0) {
+      await this.buildClientBundle();
+    }
+  }
+
+  private warnManifestMiss(todo: string[], force: boolean): void {
+    // A prebuilt manifest is meant to cover every component the app renders, so a miss costs a cold compile on the
+    // request that hit it — and means this deploy needs its Svelte sources and the compiler at runtime.
+    if (!this.loadedFromManifest || this.development || force) {
+      return;
+    }
+    logger.warn(
+      `${todo.length} component(s) are missing from the prebuilt manifest and will be compiled now:\n` +
+        todo.map((f) => `  - ${relForDisplay(f)}`).join('\n') +
+        `\nCommon causes: an email template outside \`${EMAIL_TEMPLATE_DIR}/\` (the build walks that directory, since nothing imports a template from a route — move it there), ` +
+        `or another component rendered outside a route, which the build cannot discover. ` +
+        `Otherwise, \`mochi-framework build\` and the server must run from the same working directory (the project root), and both must use the same mochi-framework version. ` +
+        `Until it's fixed, this build needs its Svelte sources and the compiler at runtime. ` +
+        `If none of the above apply, this is a Mochi bug — please report it with a reproduction.`,
+    );
+  }
+
+  // Recompute preprocess/island errors for this batch. Prior ones for the recompiled files are dropped first — otherwise
+  // a fixed mistake keeps 500-ing every page until a restart and an unfixed one is duplicated on every save. Runs BEFORE
+  // the `result.success` throw on purpose: the hydration maps come from the svelte `onLoad`, which fires for every entry
+  // before Bun resolves transitive JS deps, so a later bundler failure must not swallow a structural error already detected.
+  private recordPreprocessErrors(
+    filePreprocessErrors: Map<string, PreprocessIslandError[]>,
+    fileHydratables: Map<string, HydratableComponent[]>,
+    fileServerIslands: Map<string, ServerIslandComponent[]>,
+  ): void {
     this.errors = this.errors.filter(
       (e) =>
         !(e.kind === 'nested-hydration' && fileHydratables.has(e.parentPath)) &&
@@ -848,22 +915,21 @@ export class ComponentRegistry {
         logger.error(`\n${formatCompileError(compileError)}\n`);
       }
     }
+  }
 
-    this.warnOnBarrelImports(result.metafile);
-
-    // Detect nested hydration — a hydratable component must not itself contain mochi:hydrate or mochi:hydrate:visible children
+  // Detect nested hydration and server-islands-inside-hydratables — both one file deep: a hydratable subtree can't
+  // contain another hydratable directive or a server island, which the client can't render on hydration.
+  private detectNestedIslandErrors(
+    fileHydratables: Map<string, HydratableComponent[]>,
+    fileServerIslands: Map<string, ServerIslandComponent[]>,
+    allHydratables: HydratableComponent[],
+  ): void {
     const hydratablePaths = new Set(allHydratables.map((h) => h.resolvedPath));
     for (const [filePath, children] of fileHydratables) {
       if (hydratablePaths.has(filePath) && children.length > 0) {
         const parent = allHydratables.find((h) => h.resolvedPath === filePath)!;
         for (const child of children) {
-          this.errors.push({
-            kind: 'nested-hydration',
-            parent: parent.displayName,
-            child: child.displayName,
-            parentPath: filePath,
-            childPath: child.resolvedPath,
-          });
+          this.errors.push({ kind: 'nested-hydration', parent: parent.displayName, child: child.displayName, parentPath: filePath, childPath: child.resolvedPath });
           logger.error(
             `\nNested hydration directives are not allowed.\n  <${child.displayName}> with mochi:hydrate, mochi:hydrate:visible, or mochi:clientOnly is inside <${parent.displayName}> which is also hydratable.\n  Remove the directive from ${child.displayName} — it hydrates automatically as part of ${parent.displayName}.\n`,
           );
@@ -871,44 +937,33 @@ export class ComponentRegistry {
       }
     }
 
-    // A server island inside a hydratable subtree can never work: client bundles skip the island preprocessor, so on
-    // hydration the client renders the raw child where SSR emitted a placeholder (observed: HYDRATION_ERROR + client
-    // remount wiping the island). Same one-file-deep limitation as the nested-hydration guard above.
     for (const [filePath, children] of fileServerIslands) {
       if (hydratablePaths.has(filePath) && children.length > 0) {
         const parent = allHydratables.find((h) => h.resolvedPath === filePath)!;
         for (const child of children) {
-          this.errors.push({
-            kind: 'defer-in-hydratable',
-            parent: parent.displayName,
-            child: child.displayName,
-            parentPath: filePath,
-            childPath: child.resolvedPath,
-          });
+          this.errors.push({ kind: 'defer-in-hydratable', parent: parent.displayName, child: child.displayName, parentPath: filePath, childPath: child.resolvedPath });
           logger.error(
             `\nA server island cannot sit inside a hydratable subtree.\n  <${child.displayName}> with mochi:defer or mochi:defer:visible is inside <${parent.displayName}>, which hydrates on the client — where a server island cannot render.\n  Remove mochi:defer from ${child.displayName}, or the hydrate/clientOnly directive from ${parent.displayName}.\n`,
           );
         }
       }
     }
+  }
 
-    if (!result.success) {
-      const message = `Svelte SSR build failed:\n${formatBuildMessages(result.logs)}`;
-      for (const f of todo) {
-        mochiEvents.emit('compile:error', {
-          path: f,
-          message,
-          logs: toCompileErrorLogs(result.logs),
-        });
-      }
-      throw new Error(message);
-    }
-
-    // Attribution walks Bun's output graph: `outputs[outKey].inputs` is a flat record of every source file that fed that
-    // chunk, keyed in the same shape as `inputs[]` and so stable to compare against `cssMap` / `importedCssPaths`. The
-    // source-import walk via `inputs[].imports[].path` is unusable, since Bun stores those importer-relative and
-    // `path.resolve` against cwd fabricates absolutes that miss `inputs[]`, killing the BFS one hop in.
-    const outputsMeta = result.metafile?.outputs ?? {};
+  // Walk Bun's output graph to attribute each entry's transitive inputs, then register the compiled module, per-entry
+  // hydratables/CSS/server-islands, and dev-watcher dep tracking. `outputs[outKey].inputs` is the flat record of every
+  // source file that fed a chunk — stable to compare against `cssMap`/`importedCssPaths`, unlike the importer-relative
+  // `inputs[].imports[].path`.
+  private async registerCompiledEntries(
+    todo: string[],
+    outputsMeta: BuildOutputsMeta,
+    compileOutDir: string,
+    fileHydratables: Map<string, HydratableComponent[]>,
+    fileServerIslands: Map<string, ServerIslandComponent[]>,
+    cssMap: Map<string, string>,
+    importedCssPaths: Set<string>,
+    compileStart: number,
+  ): Promise<void> {
     const entryToOutKey = new Map<string, string>();
     for (const [outKey, outMeta] of Object.entries(outputsMeta)) {
       if (outMeta.entryPoint) {
@@ -947,8 +1002,7 @@ export class ComponentRegistry {
         throw new Error(`Svelte SSR build produced no output for ${filename}`);
       }
 
-      // Entry names are hashed, so the on-disk filename can't be derived from the source basename; the metafile key
-      // carries the real one, and only its basename matters here.
+      // Entry names are hashed, so the on-disk filename can't be derived from the source basename; the metafile key carries the real one, and only its basename matters here.
       const outPath = path.join(compileOutDir, path.basename(outKey));
 
       // Dev rebuilds re-import the same on-disk entry, and Bun's query-string cache-busting returns the stale module on
@@ -958,9 +1012,7 @@ export class ComponentRegistry {
 
       const entryInputs = transitiveInputs(outKey);
 
-      // Side-effect CSS imports reachable from this entry. The plugin records
-      // every `.css` load globally; intersect with the entry's transitive
-      // input set to get the per-entry subset.
+      // Side-effect CSS imports reachable from this entry. The plugin records every `.css` load globally; intersect with the entry's transitive input set to get the per-entry subset.
       const entryCss = new Set<string>();
       for (const p of importedCssPaths) {
         if (entryInputs.has(path.resolve(p))) {
@@ -969,13 +1021,10 @@ export class ComponentRegistry {
       }
       this.entryImportedCss.set(filename, entryCss);
 
-      // Dev-watcher dep tracking: every absolute file path that contributed
-      // to this entry's bundle (via its own output and any shared chunks).
+      // Dev-watcher dep tracking: every absolute file path that contributed to this entry's bundle (via its own output and any shared chunks).
       this.entryDeps.set(filename, entryInputs);
 
-      // Per-entry hydratables / CSS components, restricted to files reachable
-      // from this entry. With one batched build, plugin closures see every
-      // entry's files; we narrow back per-entry via the metafile graph.
+      // Per-entry hydratables / CSS components, restricted to files reachable from this entry.
       const entryHydratables: HydratableComponent[] = [];
       const entryServerIslands: ServerIslandComponent[] = [];
       const entryCssComponents = new Set<string>();
@@ -1009,74 +1058,45 @@ export class ComponentRegistry {
         durationMs: compileDuration,
       });
     }
+  }
 
-    mochiEvents.emit('compile:batch-complete', {
-      count: todo.length,
-      durationMs: performance.now() - compileStart,
-    });
-
-    const files = preprocessCacheStats.hits + preprocessCacheStats.misses;
-    if (files > 0) {
-      mochiEvents.emit('preprocess-cache:summary', {
-        hits: preprocessCacheStats.hits,
-        misses: preprocessCacheStats.misses,
-        files,
-      });
-    }
-
-    const compileCacheFiles = compileCacheStats.hits + compileCacheStats.misses;
-    if (compileCacheFiles > 0) {
-      mochiEvents.emit('compile-cache:summary', {
-        hits: compileCacheStats.hits,
-        misses: compileCacheStats.misses,
-        files: compileCacheFiles,
-      });
-    }
-
-    // Write per-component CSS files to disk (minified) and track their URLs
+  // Write per-component scoped CSS to disk (minified) and track the served URLs, skipping components whose raw CSS is unchanged.
+  private async writeComponentCss(cssMap: Map<string, string>): Promise<void> {
     const cssOutDir = `${this.outDir}/svelte-css`;
     const cssTodo = [...cssMap].filter(([componentPath, cssCode]) => this.cssRawByPath.get(componentPath) !== cssCode);
-    if (cssTodo.length > 0) {
-      // Raw filenames carry a path hash: components that share a basename
-      // (e.g. PageOne.svelte in two demo folders) would otherwise collide on
-      // one raw file now that all of them are written before the build.
-      const rawPathFor = (componentPath: string) => `${cssOutDir}/${path.basename(componentPath, '.svelte')}-${Bun.hash(componentPath).toString(36)}.raw.css`;
-      await Promise.all(cssTodo.map(([componentPath, cssCode]) => Bun.write(rawPathFor(componentPath), cssCode)));
-      // One batched Bun.build instead of one per component. Each raw file is a
-      // standalone entrypoint (svelte-emitted CSS has no imports), so in-memory
-      // outputs map back to their entry by basename.
-      const cssResult = await Bun.build({
-        entrypoints: cssTodo.map(([componentPath]) => rawPathFor(componentPath)),
-        minify: true,
-        throw: false,
-      });
-      // Read outputs even when the batch reports failure: a single malformed
-      // file must not drop minification for the whole cohort. Entries without
-      // an output fall back to their raw CSS below.
-      const minifiedByBase = new Map<string, string>();
-      for (const out of cssResult.outputs) {
-        minifiedByBase.set(path.basename(out.path), await out.text());
-      }
-      const cssWrites: Promise<unknown>[] = [];
-      for (const [componentPath, cssCode] of cssTodo) {
-        const minified = minifiedByBase.get(path.basename(rawPathFor(componentPath))) ?? cssCode;
-        const compName = path.basename(componentPath, '.svelte');
-        const hash = Bun.hash(minified).toString(36);
-        const cssFilename = `${compName}-${hash}.css`;
-        const cssUrl = `${this.assetPrefix}/css/${cssFilename}`;
-        cssWrites.push(Bun.write(`${cssOutDir}/${cssFilename}`, minified));
-        this.clientFiles.set(cssUrl, minified);
-        this.cssFileUrls.set(componentPath, cssUrl);
-        this.cssRawByPath.set(componentPath, cssCode);
-      }
-      await Promise.all(cssWrites);
+    if (cssTodo.length === 0) {
+      return;
     }
-
-    if (importedCssPaths.size > 0) {
-      await this.bundleImportedCss(importedCssPaths);
+    // Raw filenames carry a path hash: components that share a basename (e.g. PageOne.svelte in two demo folders) would otherwise collide on one raw file now that all of them are written before the build.
+    const rawPathFor = (componentPath: string) => `${cssOutDir}/${path.basename(componentPath, '.svelte')}-${Bun.hash(componentPath).toString(36)}.raw.css`;
+    await Promise.all(cssTodo.map(([componentPath, cssCode]) => Bun.write(rawPathFor(componentPath), cssCode)));
+    // One batched Bun.build instead of one per component. Each raw file is a standalone entrypoint (svelte-emitted CSS has no imports), so in-memory outputs map back to their entry by basename.
+    const cssResult = await Bun.build({
+      entrypoints: cssTodo.map(([componentPath]) => rawPathFor(componentPath)),
+      minify: true,
+      throw: false,
+    });
+    // Read outputs even when the batch reports failure: a single malformed file must not drop minification for the whole cohort. Entries without an output fall back to their raw CSS below.
+    const minifiedByBase = new Map<string, string>();
+    for (const out of cssResult.outputs) {
+      minifiedByBase.set(path.basename(out.path), await out.text());
     }
+    const cssWrites: Promise<unknown>[] = [];
+    for (const [componentPath, cssCode] of cssTodo) {
+      const minified = minifiedByBase.get(path.basename(rawPathFor(componentPath))) ?? cssCode;
+      const compName = path.basename(componentPath, '.svelte');
+      const hash = Bun.hash(minified).toString(36);
+      const cssFilename = `${compName}-${hash}.css`;
+      const cssUrl = `${this.assetPrefix}/css/${cssFilename}`;
+      cssWrites.push(Bun.write(`${cssOutDir}/${cssFilename}`, minified));
+      this.clientFiles.set(cssUrl, minified);
+      this.cssFileUrls.set(componentPath, cssUrl);
+      this.cssRawByPath.set(componentPath, cssCode);
+    }
+    await Promise.all(cssWrites);
+  }
 
-    // Register server island component paths
+  private registerServerIslandPaths(allServerIslands: ServerIslandComponent[]): void {
     for (const si of allServerIslands) {
       this.serverIslandPaths.set(si.name, si.resolvedPath);
       if (si.exportName !== 'default') {
@@ -1084,11 +1104,6 @@ export class ComponentRegistry {
       } else {
         this.serverIslandExports.delete(si.name);
       }
-    }
-
-    this.hydratableComponents.push(...allHydratables);
-    if (!opts.deferClientBundle && allHydratables.length > 0) {
-      await this.buildClientBundle();
     }
   }
 
@@ -1126,7 +1141,7 @@ export class ComponentRegistry {
     // intact rather than 404-ing island JS until the next good build. CSS entries in `clientFiles` are per-component and
     // stable, so they survive the swap.
     const newClientFiles = new Map<string, string>();
-    const newComponentEntryUrls = new Map<string, string>();
+    let newComponentEntryUrls = new Map<string, string>();
     let newIslandBootstrapUrl: string | null = null;
 
     // The debug bar builds standalone (production-mode Svelte, own runtime) and only once per process — framework
@@ -1142,23 +1157,7 @@ export class ComponentRegistry {
     // file's module identity consistent across its three uses: `Bun.build` entrypoint, `filesMap` key, import specifier.
     const hydratableIslandPath = toPosixPath(path.join(srcDir, 'web-components', 'HydratableIsland.ts'));
 
-    // Generate per-component virtual entry points
-    const entrypoints: string[] = [hydratableIslandPath];
-    const filesMap: Record<string, string> = {};
-
-    for (const [, comp] of unique) {
-      const entryName = `_hydrate-${comp.name}.js`;
-      const entryPath = toPosixPath(path.join(srcDir, entryName));
-      // String import specifiers (`import { "x" as y }`) are valid ESM and cover
-      // export names that aren't identifiers.
-      const importStmt =
-        comp.exportName === 'default'
-          ? `import ${comp.name} from "${toPosixPath(comp.resolvedPath)}";`
-          : `import { ${JSON.stringify(comp.exportName)} as ${comp.name} } from "${toPosixPath(comp.resolvedPath)}";`;
-      const entrySource = `import { registerComponent } from "${hydratableIslandPath}";\n${importStmt}\nregisterComponent("${comp.name}", ${comp.name});\n`;
-      entrypoints.push(entryPath);
-      filesMap[entryPath] = entrySource;
-    }
+    const { entrypoints, filesMap } = buildIslandEntrypoints(unique, hydratableIslandPath, srcDir);
 
     const imageAssetLoader = createImageAssetLoader({
       outDir: this.outDir,
@@ -1278,89 +1277,16 @@ export class ComponentRegistry {
       newClientFiles.set(`${this.assetPrefix}/client/${filename}`, await output.text());
     }
 
-    // Map entry-point outputs back to components using metafile.entryPoint
-    // This avoids fragile filename matching.
+    // Map entry-point outputs back to components using metafile.entryPoint, avoiding fragile filename matching.
     if (result.metafile) {
-      // entryPath → component name, with `null` for the bootstrap. Both sides go through the same
-      // `toPosixPath(path.resolve(...))` because the entrypoints mix POSIX and native paths while Bun's metafile
-      // entryPoint is native; on Windows the formats diverge, the bootstrap lookup misses, and the hydration `<script>` disappears.
-      const entryToComponent = new Map<string, string | null>();
-      entryToComponent.set(toPosixPath(path.resolve(hydratableIslandPath)), null);
-      for (const [, comp] of unique) {
-        const entryPath = toPosixPath(path.resolve(path.join(srcDir, `_hydrate-${comp.name}.js`)));
-        entryToComponent.set(entryPath, comp.name);
-      }
-
-      for (const [outPath, outMeta] of Object.entries(result.metafile.outputs)) {
-        if (!outMeta.entryPoint) {
-          continue;
-        }
-        const resolvedEntry = toPosixPath(path.resolve(outMeta.entryPoint));
-        const compName = entryToComponent.get(resolvedEntry);
-        const url = `${this.assetPrefix}/client/${path.basename(outPath)}`;
-        if (compName === null) {
-          newIslandBootstrapUrl = url;
-        } else if (compName !== undefined) {
-          newComponentEntryUrls.set(compName, url);
-        }
-      }
-      const outputStats = Object.entries(result.metafile.outputs).map(([outPath, outMeta]) => {
-        const inputs = Object.entries(outMeta.inputs).map(([inputPath, inputMeta]) => ({
-          path: toPosixPath(inputPath).replace(toPosixPath(path.resolve('.')) + '/', ''),
-          size: inputMeta.bytesInOutput,
-        }));
-        inputs.sort((a, b) => b.size - a.size);
-        const imports = (outMeta.imports ?? []).filter((i) => i.kind === 'import-statement').map((i) => path.basename(i.path));
-        return {
-          name: path.basename(outPath),
-          size: outMeta.bytes,
-          inputs,
-          imports,
-        };
-      });
-      outputStats.sort((a, b) => b.size - a.size);
-      this.clientStats = { outputs: outputStats };
-      this.warnOnRetainedComponentStubs(result.metafile);
-      this.warnOnBarrelImports(result.metafile);
+      const urls = this.processClientMetafile(result.metafile, unique, hydratableIslandPath, srcDir);
+      newComponentEntryUrls = urls.componentEntryUrls;
+      newIslandBootstrapUrl = urls.islandBootstrapUrl;
     }
 
-    // Swap the freshly-built maps into the instance fields now the build has
-    // succeeded. Replace only the client-prefix JS entries; the per-component CSS
-    // entries in `clientFiles` are stable and preserved.
     const clientPrefix = `${this.assetPrefix}/client/`;
-    // Snapshot the keys: the loop deletes from `clientFiles` while iterating it.
-    // oxlint-disable-next-line no-useless-spread
-    for (const key of [...this.clientFiles.keys()]) {
-      if (key.startsWith(clientPrefix)) {
-        this.clientFiles.delete(key);
-      }
-    }
-    for (const [k, v] of newClientFiles) {
-      this.clientFiles.set(k, v);
-    }
-    this.componentEntryUrls.clear();
-    for (const [k, v] of newComponentEntryUrls) {
-      this.componentEntryUrls.set(k, v);
-    }
-    this.islandBootstrapUrl = newIslandBootstrapUrl;
-
-    if (this.debugBarBuildPromise && !this.debugBarBundle) {
-      try {
-        this.debugBarBundle = await this.debugBarBuildPromise;
-      } catch (err) {
-        // A rejected promise must not be memoized (the next rebuild retries), and a broken debug bar must not take
-        // down page serving.
-        this.debugBarBuildPromise = null;
-        logger.warn(`[mochi] debug bar build failed: ${err instanceof Error ? err.message : String(err)}`);
-      }
-    }
-    if (this.debugBarBundle) {
-      const debugBarUrl = `${clientPrefix}${this.debugBarBundle.fileName}`;
-      this.clientFiles.set(debugBarUrl, this.debugBarBundle.contents);
-      this.debugBarUrl = debugBarUrl;
-    } else {
-      this.debugBarUrl = null;
-    }
+    this.swapClientBuildOutputs(clientPrefix, newClientFiles, newComponentEntryUrls, newIslandBootstrapUrl);
+    await this.attachDebugBarBundle(clientPrefix);
 
     const outputBytes = this.clientStats?.outputs.reduce((sum, o) => sum + o.size, 0) ?? 0;
     mochiEvents.emit('client-bundle:complete', {
@@ -1376,6 +1302,98 @@ export class ComponentRegistry {
         misses: compileCacheStats.misses,
         files: compileCacheFiles,
       });
+    }
+  }
+
+  // Map each client-build entry-point output back to its component (or the bootstrap) via metafile.entryPoint, avoiding
+  // fragile filename matching, and record the per-output byte stats for the debug bar. Both sides go through the same
+  // `toPosixPath(path.resolve(...))` because the entrypoints mix POSIX and native paths while Bun's metafile entryPoint
+  // is native; on Windows the formats diverge, the bootstrap lookup misses, and the hydration `<script>` disappears.
+  private processClientMetafile(
+    metafile: ClientBuildMetafile,
+    unique: Map<string, HydratableComponent>,
+    hydratableIslandPath: string,
+    srcDir: string,
+  ): { componentEntryUrls: Map<string, string>; islandBootstrapUrl: string | null } {
+    const entryToComponent = new Map<string, string | null>();
+    entryToComponent.set(toPosixPath(path.resolve(hydratableIslandPath)), null);
+    for (const [, comp] of unique) {
+      const entryPath = toPosixPath(path.resolve(path.join(srcDir, `_hydrate-${comp.name}.js`)));
+      entryToComponent.set(entryPath, comp.name);
+    }
+
+    const componentEntryUrls = new Map<string, string>();
+    let islandBootstrapUrl: string | null = null;
+    for (const [outPath, outMeta] of Object.entries(metafile.outputs)) {
+      if (!outMeta.entryPoint) {
+        continue;
+      }
+      const resolvedEntry = toPosixPath(path.resolve(outMeta.entryPoint));
+      const compName = entryToComponent.get(resolvedEntry);
+      const url = `${this.assetPrefix}/client/${path.basename(outPath)}`;
+      if (compName === null) {
+        islandBootstrapUrl = url;
+      } else if (compName !== undefined) {
+        componentEntryUrls.set(compName, url);
+      }
+    }
+    const outputStats = Object.entries(metafile.outputs).map(([outPath, outMeta]) => {
+      const inputs = Object.entries(outMeta.inputs).map(([inputPath, inputMeta]) => ({
+        path: toPosixPath(inputPath).replace(toPosixPath(path.resolve('.')) + '/', ''),
+        size: inputMeta.bytesInOutput,
+      }));
+      inputs.sort((a, b) => b.size - a.size);
+      const imports = (outMeta.imports ?? []).filter((i) => i.kind === 'import-statement').map((i) => path.basename(i.path));
+      return { name: path.basename(outPath), size: outMeta.bytes, inputs, imports };
+    });
+    outputStats.sort((a, b) => b.size - a.size);
+    this.clientStats = { outputs: outputStats };
+    this.warnOnRetainedComponentStubs(metafile);
+    this.warnOnBarrelImports(metafile);
+    return { componentEntryUrls, islandBootstrapUrl };
+  }
+
+  // Swap the freshly-built maps into the instance fields now the build has succeeded. Replace only the client-prefix JS
+  // entries; the per-component CSS entries in `clientFiles` are stable and preserved.
+  private swapClientBuildOutputs(
+    clientPrefix: string,
+    newClientFiles: Map<string, string>,
+    newComponentEntryUrls: Map<string, string>,
+    newIslandBootstrapUrl: string | null,
+  ): void {
+    // Snapshot the keys: the loop deletes from `clientFiles` while iterating it.
+    // oxlint-disable-next-line no-useless-spread
+    for (const key of [...this.clientFiles.keys()]) {
+      if (key.startsWith(clientPrefix)) {
+        this.clientFiles.delete(key);
+      }
+    }
+    for (const [k, v] of newClientFiles) {
+      this.clientFiles.set(k, v);
+    }
+    this.componentEntryUrls.clear();
+    for (const [k, v] of newComponentEntryUrls) {
+      this.componentEntryUrls.set(k, v);
+    }
+    this.islandBootstrapUrl = newIslandBootstrapUrl;
+  }
+
+  private async attachDebugBarBundle(clientPrefix: string): Promise<void> {
+    if (this.debugBarBuildPromise && !this.debugBarBundle) {
+      try {
+        this.debugBarBundle = await this.debugBarBuildPromise;
+      } catch (err) {
+        // A rejected promise must not be memoized (the next rebuild retries), and a broken debug bar must not take down page serving.
+        this.debugBarBuildPromise = null;
+        logger.warn(`[mochi] debug bar build failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    }
+    if (this.debugBarBundle) {
+      const debugBarUrl = `${clientPrefix}${this.debugBarBundle.fileName}`;
+      this.clientFiles.set(debugBarUrl, this.debugBarBundle.contents);
+      this.debugBarUrl = debugBarUrl;
+    } else {
+      this.debugBarUrl = null;
     }
   }
 
@@ -1502,23 +1520,7 @@ export class ComponentRegistry {
       return out;
     };
 
-    const renderOptions: {
-      props?: Record<string, unknown>;
-      transformError: typeof transformError;
-      idPrefix?: string;
-      context?: Map<unknown, unknown>;
-    } = {
-      transformError,
-    };
-    if (props) {
-      renderOptions.props = props;
-    }
-    if (opts?.idPrefix) {
-      renderOptions.idPrefix = opts.idPrefix;
-    }
-    if (opts?.context) {
-      renderOptions.context = opts.context;
-    }
+    const renderOptions = buildRenderOptions(props, opts, transformError);
 
     // Each render owns the whole `islandProps` map: `emitIslandProps` fills it during this `render()` and the
     // HTMLRewriter pass below drains it, so clearing up front keeps sequential same-ctx renders self-contained — an
@@ -1526,169 +1528,56 @@ export class ComponentRegistry {
     const ctx = requestContext.getStore();
     ctx?.islandProps.clear();
 
-    const component = opts?.exportName && opts.exportName !== 'default' ? mod[opts.exportName] : mod.default;
-    if (!component) {
-      throw new Error(
-        `renderComponent: ${filename} has no export "${opts?.exportName ?? 'default'}" — the compiled module and the island registry disagree (stale manifest or removed export).`,
-      );
-    }
+    const component = resolveExportedComponent(mod, opts?.exportName, filename);
     const { body, head } = await render(component, renderOptions);
 
-    let output = body;
-
-    // Track which islands are lazy (have CSS_URL placeholders) during replacement
-    const lazyIslandPaths = new Set<string>();
-    let hasServerCssPlaceholders = false;
-    // Placeholders only exist in island wrapper attributes, so one probe spares island-free pages four full-body scans.
-    if (output.includes('__MOCHI_')) {
-      output = output.replace(/__MOCHI_COMPONENT_URL__(\w+)__/g, (_, name: string) => this.componentEntryUrls.get(name) ?? '');
-
-      output = output.replace(/__MOCHI_CSS_URL__(\w+)__/g, (_, name: string) => {
-        const h = hydratablesByName.get(name);
-        if (h) {
-          lazyIslandPaths.add(h.resolvedPath);
-          return this.cssFileUrls.get(h.resolvedPath) ?? '';
-        }
-        return '';
-      });
-
-      output = output.replace(/__MOCHI_SERVER_CSS_URL__(\w+)__/g, (_, name: string) => {
-        hasServerCssPlaceholders = true;
-        const resolvedPath = this.serverIslandPaths.get(name);
-        return resolvedPath ? (this.cssFileUrls.get(resolvedPath) ?? '') : '';
-      });
-
-      output = output.replaceAll('__MOCHI_ASSET_PREFIX__', this.assetPrefix);
-    }
+    const placeholders = this.resolveIslandPlaceholders(body, hydratablesByName);
+    let output = placeholders.output;
+    const lazyIslandPaths = placeholders.lazyIslandPaths;
 
     const shouldStrip = opts?.stripMarkers !== false && hydratables.length === 0;
-    const hasIslandsOrServerIslands = hydratables.length > 0 || hasServerCssPlaceholders;
+    const hasIslandsOrServerIslands = hydratables.length > 0 || placeholders.hasServerCssPlaceholders;
 
-    // Indexed by ref id so the rewriter below emits each payload as a `<script type="application/json">` block just
-    // before the first island referencing it — HTMLRewriter visits elements in document order, so the first callback for
-    // a given `props-ref` is that payload's first island. Byte-identical payloads share one block, tagged `data-shared`.
-    const propsById = new Map<string, { json: string; emitCount: number }>();
-    if (ctx) {
-      for (const [json, entry] of ctx.islandProps) {
-        propsById.set(entry.id, { json, emitCount: entry.emitCount });
-      }
-    }
-    const emittedProps = new Set<string>();
+    // Indexed by ref id so the rewriter emits each payload as a `<script type="application/json">` block just before the
+    // first island referencing it. Byte-identical payloads share one block, tagged `data-shared`.
+    const propsById = collectIslandPropsById(ctx);
 
-    // Single HTMLRewriter pass: inject island props blocks, collect rendered
-    // island names, detect server islands, and conditionally strip page-level
-    // hydration markers.
-    const renderedIslandNames = new Set<string>();
-    let hasServerIslands = false;
-    if (hasIslandsOrServerIslands || shouldStrip) {
-      let islandDepth = 0;
-      const rewriter = new HTMLRewriter();
-      if (hasIslandsOrServerIslands) {
-        rewriter
-          .on('mochi-hydratable-island', {
-            element(el) {
-              islandDepth++;
-              el.onEndTag(() => {
-                islandDepth--;
-              });
-              const raw = el.getAttribute('component-name');
-              if (raw) {
-                renderedIslandNames.add(raw);
-              }
-              injectIslandPropsBlock(el, propsById, emittedProps);
-            },
-          })
-          .on('mochi-server-island', {
-            element(el) {
-              islandDepth++;
-              el.onEndTag(() => {
-                islandDepth--;
-              });
-              hasServerIslands = true;
-            },
-          });
-      }
-      if (shouldStrip) {
-        rewriter.onDocument({
-          comments(comment) {
-            if (islandDepth === 0 && isSvelteMarker(comment.text)) {
-              comment.remove();
-            }
-          },
-        });
-      }
-      output = rewriter.transform(output);
-    }
+    const rewritten = this.runIslandRewriter(output, hasIslandsOrServerIslands, shouldStrip, propsById);
+    output = rewritten.output;
+    const renderedIslandNames = rewritten.renderedIslandNames;
+    const hasServerIslands = rewritten.hasServerIslands;
 
-    let debugBarData: RenderResult['debugBarData'];
-    if (ctx?.debugBarData) {
-      debugBarData = { ...ctx.debugBarData };
+    const debugBarData = this.buildRenderDebugBarData(ctx, hydratables.length > 0, renderedIslandNames);
 
-      if (this.debugBarEnabled && this.clientStats) {
-        const urlToComponent = new Map<string, string>();
-        for (const [name, url] of this.componentEntryUrls) {
-          urlToComponent.set(url, name);
-        }
-        // Island identity keys are `<localName>_<hash>`; show the bare local name
-        // in the debug bar's bundle list instead of the hashed key.
-        const displayByKey = new Map(this.hydratableComponents.map((h) => [h.name, h.displayName]));
-        const pageHasIslands = hydratables.length > 0;
-        const bundles: NonNullable<typeof debugBarData.bundles> = [];
-        const outputByName = new Map(this.clientStats.outputs.map((o) => [o.name, o]));
+    const { cssUrls, fontPreloadUrls } = this.collectRenderCssUrls(entryKey, cssComponents, islandPaths, hydratablesByPath, lazyIslandPaths, renderedIslandNames);
 
-        // Code splitting hoists anything two entries share into a `chunk-*.js`, but a chunk only
-        // reaches the browser if one of *this page's* entries imports it. Walk the import graph
-        // from the bootstrap plus the islands actually rendered here, so the panel reports (and
-        // totals) the bytes the page really ships rather than every chunk in the build.
-        const clientPrefix = `${this.assetPrefix}/client/`;
-        const entryRoots: string[] = [];
-        if (pageHasIslands && this.islandBootstrapUrl) {
-          entryRoots.push(this.islandBootstrapUrl.slice(clientPrefix.length));
-        }
-        for (const name of renderedIslandNames) {
-          const entryUrl = this.componentEntryUrls.get(name);
-          if (entryUrl) {
-            entryRoots.push(entryUrl.slice(clientPrefix.length));
-          }
-        }
-        const reachable = ComponentRegistry.reachableOutputNames(entryRoots, outputByName);
-        for (const output of this.clientStats.outputs) {
-          const url = `${this.assetPrefix}/client/${output.name}`;
-          if (url === this.islandBootstrapUrl) {
-            if (!pageHasIslands) {
-              continue;
-            }
-            const wcInputs = this.collectWebComponentInputs(output, outputByName);
-            const wcSize = wcInputs.reduce((sum, i) => sum + i.size, 0);
-            bundles.push({
-              url,
-              label: 'Island runtime',
-              sizeBytes: wcSize,
-              kind: 'bootstrap',
-              inputs: cleanInputs(wcInputs),
-            });
-          } else {
-            const compName = urlToComponent.get(url);
-            const cleaned = cleanInputs(output.inputs);
-            const nonWc = cleaned.filter((i) => !i.path.includes('web-components/'));
-            const wcDeduct = cleaned.reduce((s, i) => s + (i.path.includes('web-components/') ? i.size : 0), 0);
-            if (compName) {
-              if (!renderedIslandNames.has(compName)) {
-                continue;
-              }
-              bundles.push({ url, label: displayByKey.get(compName) ?? compName, sizeBytes: output.size - wcDeduct, kind: 'island', inputs: nonWc });
-            } else {
-              if (!reachable.has(output.name)) {
-                continue;
-              }
-              bundles.push({ url, label: output.name, sizeBytes: output.size - wcDeduct, kind: 'chunk', inputs: nonWc });
-            }
-          }
-        }
-        debugBarData.bundles = bundles;
-      }
-    }
+    // Collapse the doubled-marker Svelte SSR bug (`$state` arrays + `{@attach}`); only island wrappers can carry it,
+    // so island-free renders skip the scan.
+    const normalized = hydratables.length > 0 ? normalizeIslandHydrationMarkers(output) : output;
+    const headStr = head ?? '';
+    return {
+      body: normalized,
+      head: shouldStrip ? stripHydrationMarkers(headStr) : headStr,
+      cssUrls,
+      fontPreloadUrls: [...fontPreloadUrls],
+      // Gated on wrappers actually present in the output — the entry's compile-time hydratables may all sit in branches
+      // this render never took.
+      bootstrapUrl: renderedIslandNames.size > 0 ? this.islandBootstrapUrl : null,
+      hasServerIslands,
+      debugBarData,
+    };
+  }
 
+  // Scoped CSS URLs for this render: each component's own stylesheet, minus lazy islands and islands that didn't render,
+  // plus the side-effect CSS imports reachable from the entry and their font preloads.
+  private collectRenderCssUrls(
+    entryKey: string,
+    cssComponents: Set<string>,
+    islandPaths: Set<string>,
+    hydratablesByPath: Map<string, HydratableComponent[]>,
+    lazyIslandPaths: Set<string>,
+    renderedIslandNames: Set<string>,
+  ): { cssUrls: string[]; fontPreloadUrls: string[] } {
     const cssUrls: string[] = [];
     for (const componentPath of cssComponents) {
       const cssUrl = this.cssFileUrls.get(componentPath);
@@ -1707,10 +1596,7 @@ export class ComponentRegistry {
       cssUrls.push(cssUrl);
     }
 
-    // Append URLs for side-effect CSS imports reachable from this entry
-    // (e.g. @fontsource fonts imported in a page's <script>).
-    // Deduped: two CSS imports sharing a font produce the same content-hashed URL, and a duplicate would burn one of
-    // the FONT_PRELOAD_MAX slots.
+    // Deduped: two CSS imports sharing a font produce the same content-hashed URL, and a duplicate would burn one of the FONT_PRELOAD_MAX slots.
     const fontPreloadUrls = new Set<string>();
     const imported = this.entryImportedCss.get(entryKey);
     if (imported) {
@@ -1727,22 +1613,163 @@ export class ComponentRegistry {
         }
       }
     }
+    return { cssUrls, fontPreloadUrls: [...fontPreloadUrls] };
+  }
 
-    // Collapse the doubled-marker Svelte SSR bug (`$state` arrays + `{@attach}`); only island wrappers can carry it,
-    // so island-free renders skip the scan.
-    const normalized = hydratables.length > 0 ? normalizeIslandHydrationMarkers(output) : output;
-    const headStr = head ?? '';
-    return {
-      body: normalized,
-      head: shouldStrip ? stripHydrationMarkers(headStr) : headStr,
-      cssUrls,
-      fontPreloadUrls: [...fontPreloadUrls],
-      // Gated on wrappers actually present in the output — the entry's compile-time hydratables may all sit in branches
-      // this render never took.
-      bootstrapUrl: renderedIslandNames.size > 0 ? this.islandBootstrapUrl : null,
-      hasServerIslands,
-      debugBarData,
-    };
+  // Substitute the `__MOCHI_*__` island-wrapper placeholders with resolved URLs, tracking lazy islands and whether any
+  // server-island CSS placeholder appeared. Placeholders only exist in island wrappers, so one probe spares island-free
+  // pages four full-body scans.
+  private resolveIslandPlaceholders(
+    body: string,
+    hydratablesByName: Map<string, HydratableComponent>,
+  ): { output: string; lazyIslandPaths: Set<string>; hasServerCssPlaceholders: boolean } {
+    const lazyIslandPaths = new Set<string>();
+    let hasServerCssPlaceholders = false;
+    let output = body;
+    if (!output.includes('__MOCHI_')) {
+      return { output, lazyIslandPaths, hasServerCssPlaceholders };
+    }
+    output = output.replace(/__MOCHI_COMPONENT_URL__(\w+)__/g, (_, name: string) => this.componentEntryUrls.get(name) ?? '');
+    output = output.replace(/__MOCHI_CSS_URL__(\w+)__/g, (_, name: string) => {
+      const h = hydratablesByName.get(name);
+      if (h) {
+        lazyIslandPaths.add(h.resolvedPath);
+        return this.cssFileUrls.get(h.resolvedPath) ?? '';
+      }
+      return '';
+    });
+    output = output.replace(/__MOCHI_SERVER_CSS_URL__(\w+)__/g, (_, name: string) => {
+      hasServerCssPlaceholders = true;
+      const resolvedPath = this.serverIslandPaths.get(name);
+      return resolvedPath ? (this.cssFileUrls.get(resolvedPath) ?? '') : '';
+    });
+    output = output.replaceAll('__MOCHI_ASSET_PREFIX__', this.assetPrefix);
+    return { output, lazyIslandPaths, hasServerCssPlaceholders };
+  }
+
+  // Single HTMLRewriter pass: inject island props blocks, collect rendered island names, detect server islands, and
+  // conditionally strip page-level hydration markers.
+  private runIslandRewriter(
+    output: string,
+    hasIslandsOrServerIslands: boolean,
+    shouldStrip: boolean,
+    propsById: Map<string, { json: string; emitCount: number }>,
+  ): { output: string; renderedIslandNames: Set<string>; hasServerIslands: boolean } {
+    const renderedIslandNames = new Set<string>();
+    let hasServerIslands = false;
+    if (!(hasIslandsOrServerIslands || shouldStrip)) {
+      return { output, renderedIslandNames, hasServerIslands };
+    }
+    const emittedProps = new Set<string>();
+    let islandDepth = 0;
+    const rewriter = new HTMLRewriter();
+    if (hasIslandsOrServerIslands) {
+      rewriter
+        .on('mochi-hydratable-island', {
+          element(el) {
+            islandDepth++;
+            el.onEndTag(() => {
+              islandDepth--;
+            });
+            const raw = el.getAttribute('component-name');
+            if (raw) {
+              renderedIslandNames.add(raw);
+            }
+            injectIslandPropsBlock(el, propsById, emittedProps);
+          },
+        })
+        .on('mochi-server-island', {
+          element(el) {
+            islandDepth++;
+            el.onEndTag(() => {
+              islandDepth--;
+            });
+            hasServerIslands = true;
+          },
+        });
+    }
+    if (shouldStrip) {
+      rewriter.onDocument({
+        comments(comment) {
+          if (islandDepth === 0 && isSvelteMarker(comment.text)) {
+            comment.remove();
+          }
+        },
+      });
+    }
+    return { output: rewriter.transform(output), renderedIslandNames, hasServerIslands };
+  }
+
+  private buildRenderDebugBarData(ctx: ReturnType<typeof requestContext.getStore>, pageHasIslands: boolean, renderedIslandNames: Set<string>): RenderResult['debugBarData'] {
+    if (!ctx?.debugBarData) {
+      return undefined;
+    }
+    const debugBarData: RenderResult['debugBarData'] = { ...ctx.debugBarData };
+    if (this.debugBarEnabled && this.clientStats) {
+      debugBarData.bundles = this.computeDebugBundles(this.clientStats, pageHasIslands, renderedIslandNames);
+    }
+    return debugBarData;
+  }
+
+  // Build the debug bar's per-bundle byte breakdown for this render: only the chunks this page actually ships, walking
+  // the import graph from the bootstrap plus the islands rendered here.
+  private computeDebugBundles(
+    clientStats: NonNullable<ComponentRegistry['clientStats']>,
+    pageHasIslands: boolean,
+    renderedIslandNames: Set<string>,
+  ): NonNullable<NonNullable<RenderResult['debugBarData']>['bundles']> {
+    const urlToComponent = new Map<string, string>();
+    for (const [name, url] of this.componentEntryUrls) {
+      urlToComponent.set(url, name);
+    }
+    // Island identity keys are `<localName>_<hash>`; show the bare local name in the debug bar's bundle list instead of the hashed key.
+    const displayByKey = new Map(this.hydratableComponents.map((h) => [h.name, h.displayName]));
+    const bundles: NonNullable<NonNullable<RenderResult['debugBarData']>['bundles']> = [];
+    const outputByName = new Map(clientStats.outputs.map((o) => [o.name, o]));
+
+    // Code splitting hoists anything two entries share into a `chunk-*.js`, but a chunk only reaches the browser if one
+    // of *this page's* entries imports it. Walk the import graph from the bootstrap plus the islands actually rendered
+    // here, so the panel reports the bytes the page really ships rather than every chunk in the build.
+    const clientPrefix = `${this.assetPrefix}/client/`;
+    const entryRoots: string[] = [];
+    if (pageHasIslands && this.islandBootstrapUrl) {
+      entryRoots.push(this.islandBootstrapUrl.slice(clientPrefix.length));
+    }
+    for (const name of renderedIslandNames) {
+      const entryUrl = this.componentEntryUrls.get(name);
+      if (entryUrl) {
+        entryRoots.push(entryUrl.slice(clientPrefix.length));
+      }
+    }
+    const reachable = ComponentRegistry.reachableOutputNames(entryRoots, outputByName);
+    for (const output of clientStats.outputs) {
+      const url = `${this.assetPrefix}/client/${output.name}`;
+      if (url === this.islandBootstrapUrl) {
+        if (!pageHasIslands) {
+          continue;
+        }
+        const wcInputs = this.collectWebComponentInputs(output, outputByName);
+        const wcSize = wcInputs.reduce((sum, i) => sum + i.size, 0);
+        bundles.push({ url, label: 'Island runtime', sizeBytes: wcSize, kind: 'bootstrap', inputs: cleanInputs(wcInputs) });
+      } else {
+        const compName = urlToComponent.get(url);
+        const cleaned = cleanInputs(output.inputs);
+        const nonWc = cleaned.filter((i) => !i.path.includes('web-components/'));
+        const wcDeduct = cleaned.reduce((s, i) => s + (i.path.includes('web-components/') ? i.size : 0), 0);
+        if (compName) {
+          if (!renderedIslandNames.has(compName)) {
+            continue;
+          }
+          bundles.push({ url, label: displayByKey.get(compName) ?? compName, sizeBytes: output.size - wcDeduct, kind: 'island', inputs: nonWc });
+        } else {
+          if (!reachable.has(output.name)) {
+            continue;
+          }
+          bundles.push({ url, label: output.name, sizeBytes: output.size - wcDeduct, kind: 'chunk', inputs: nonWc });
+        }
+      }
+    }
+    return bundles;
   }
 
   /**
@@ -1990,6 +2017,45 @@ export class ComponentRegistry {
     });
   }
 
+  // Write each extracted font to a content-hashed disk path (once, atomically across parallel bundles) and return the
+  // marker→URL map for `url()` substitution plus the preload-worthy URLs.
+  private async writeExtractedFonts(fonts: SurvivingFont[], cssPath: string): Promise<{ preloadUrls: string[]; fontUrlByMarker: Map<string, string> }> {
+    const preloadUrls: string[] = [];
+    const fontUrlByMarker = new Map<string, string>();
+    for (const font of fonts) {
+      const bytes = font.ref.bytes ?? (await Bun.file(font.ref.path).bytes());
+      if (fontChangedSinceResolved(font.ref, bytes)) {
+        const message = `the source font ${relForDisplay(font.ref.path)} was ${font.ref.size} bytes when the bundle resolved it but read back ${bytes.length}, so it changed mid-build. If this persists the file is corrupt.`;
+        logger.error(`CSS bundle for ${cssPath}: ${message}`);
+        this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
+      }
+      const fileName = fontAssetFileName(font.ref, bytes);
+      const diskPath = path.join(this.outDir, 'fonts', fileName);
+      const fontUrl = `${this.assetPrefix}/fonts/${fileName}`;
+      fontUrlByMarker.set(font.markerUri, fontUrl);
+      if (font.preload) {
+        preloadUrls.push(fontUrl);
+      }
+      // Registering before the first await keeps the check-then-set atomic across the concurrently bundling
+      // entrypoints, so a font shared between stylesheets is written and counted in the stats exactly once.
+      if (!this.fontAssets.has(fontUrl)) {
+        this.fontAssets.set(fontUrl, { diskPath, contentType: font.contentType });
+        this.importedCssStats.push({
+          name: path.posix.join('fonts', fileName),
+          size: bytes.length,
+          inputs: [{ path: relForDisplay(font.ref.path), size: bytes.length }],
+          imports: [],
+        });
+        // The content-hashed name means an existing file already holds these exact bytes; skipping the rewrite
+        // keeps a dev-rebundle from truncating a file a concurrent request may be reading.
+        if (!(await Bun.file(diskPath).exists())) {
+          await Bun.write(diskPath, bytes);
+        }
+      }
+    }
+    return { preloadUrls, fontUrlByMarker };
+  }
+
   private async bundleImportedCssBatch(cssPaths: Iterable<string>): Promise<void> {
     const importCssOutDir = path.resolve(`${this.outDir}/import-css`);
     const todo = [...cssPaths].filter((p) => !this.importedCssUrls.has(p));
@@ -2075,39 +2141,7 @@ export class ComponentRegistry {
           logger.error(`CSS bundle for ${cssPath}: ${message}`);
           this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
         }
-        const preloadUrls: string[] = [];
-        const fontUrlByMarker = new Map<string, string>();
-        for (const font of fontPass.fonts) {
-          const bytes = font.ref.bytes ?? (await Bun.file(font.ref.path).bytes());
-          if (fontChangedSinceResolved(font.ref, bytes)) {
-            const message = `the source font ${relForDisplay(font.ref.path)} was ${font.ref.size} bytes when the bundle resolved it but read back ${bytes.length}, so it changed mid-build. If this persists the file is corrupt.`;
-            logger.error(`CSS bundle for ${cssPath}: ${message}`);
-            this.errors.push({ kind: 'css-bundle-failed', cssPath, message });
-          }
-          const fileName = fontAssetFileName(font.ref, bytes);
-          const diskPath = path.join(this.outDir, 'fonts', fileName);
-          const fontUrl = `${this.assetPrefix}/fonts/${fileName}`;
-          fontUrlByMarker.set(font.markerUri, fontUrl);
-          if (font.preload) {
-            preloadUrls.push(fontUrl);
-          }
-          // Registering before the first await keeps the check-then-set atomic across the concurrently bundling
-          // entrypoints, so a font shared between stylesheets is written and counted in the stats exactly once.
-          if (!this.fontAssets.has(fontUrl)) {
-            this.fontAssets.set(fontUrl, { diskPath, contentType: font.contentType });
-            this.importedCssStats.push({
-              name: path.posix.join('fonts', fileName),
-              size: bytes.length,
-              inputs: [{ path: relForDisplay(font.ref.path), size: bytes.length }],
-              imports: [],
-            });
-            // The content-hashed name means an existing file already holds these exact bytes; skipping the rewrite
-            // keeps a dev-rebundle from truncating a file a concurrent request may be reading.
-            if (!(await Bun.file(diskPath).exists())) {
-              await Bun.write(diskPath, bytes);
-            }
-          }
-        }
+        const { preloadUrls, fontUrlByMarker } = await this.writeExtractedFonts(fontPass.fonts, cssPath);
         cssText = substituteFontUrls(cssText, fontUrlByMarker);
         for (const font of fontPass.fonts) {
           if (cssText.includes(font.ref.markerB64)) {
@@ -2410,7 +2444,32 @@ export class ComponentRegistry {
       registry.clientFiles.set(urlPath, content);
     }
 
-    // Restore side-effect CSS import mappings
+    ComponentRegistry.restoreManifestCssMaps(registry, manifest, resolveManifestPath);
+
+    // Load SSR modules and populate compiledComponents
+    for (const [filename, entry] of Object.entries(manifest.components)) {
+      const modulePath = resolveManifestPath(entry.ssrModule);
+      const mod = await import(Bun.pathToFileURL(modulePath).href);
+      // Manifests written before exportName existed omit it — those islands are
+      // all default imports, so normalize before anything indexes on it.
+      const hydratables = entry.hydratables.map((h) => ({ ...h, exportName: h.exportName ?? 'default', resolvedPath: decodeSourcePath(h.resolvedPath) }));
+      registry.compiledComponents.set(decodeSourcePath(filename), {
+        module: mod,
+        cssComponents: new Set(entry.cssComponents.map((p) => decodeSourcePath(p))),
+        hydratables,
+        ...indexHydratables(hydratables),
+        ssrPath: modulePath,
+      });
+      registry.hydratableComponents.push(...hydratables);
+    }
+
+    await ComponentRegistry.restoreManifestIslandAssets(registry, manifest, resolveManifestPath);
+
+    return registry;
+  }
+
+  // Restore side-effect CSS import mappings, font assets, and per-entry CSS from the manifest.
+  private static restoreManifestCssMaps(registry: ComponentRegistry, manifest: MochiManifest, resolveManifestPath: (p: string) => string): void {
     if (manifest.importedCssUrls) {
       for (const [cssPath, url] of Object.entries(manifest.importedCssUrls)) {
         registry.importedCssUrls.set(decodeSourcePath(cssPath), url);
@@ -2436,25 +2495,10 @@ export class ComponentRegistry {
         registry.entryImportedCss.set(decodeSourcePath(entryPath), new Set(cssPaths.map((p) => decodeSourcePath(p))));
       }
     }
+  }
 
-    // Load SSR modules and populate compiledComponents
-    for (const [filename, entry] of Object.entries(manifest.components)) {
-      const modulePath = resolveManifestPath(entry.ssrModule);
-      const mod = await import(Bun.pathToFileURL(modulePath).href);
-      // Manifests written before exportName existed omit it — those islands are
-      // all default imports, so normalize before anything indexes on it.
-      const hydratables = entry.hydratables.map((h) => ({ ...h, exportName: h.exportName ?? 'default', resolvedPath: decodeSourcePath(h.resolvedPath) }));
-      registry.compiledComponents.set(decodeSourcePath(filename), {
-        module: mod,
-        cssComponents: new Set(entry.cssComponents.map((p) => decodeSourcePath(p))),
-        hydratables,
-        ...indexHydratables(hydratables),
-        ssrPath: modulePath,
-      });
-      registry.hydratableComponents.push(...hydratables);
-    }
-
-    // Load server island paths from manifest
+  // Restore server-island paths/exports, locally-imported image assets, and the prebuilt ServerIsland inline script.
+  private static async restoreManifestIslandAssets(registry: ComponentRegistry, manifest: MochiManifest, resolveManifestPath: (p: string) => string): Promise<void> {
     if (manifest.serverIslandPaths) {
       for (const [name, resolvedPath] of Object.entries(manifest.serverIslandPaths)) {
         registry.serverIslandPaths.set(name, decodeSourcePath(resolvedPath));
@@ -2466,8 +2510,7 @@ export class ComponentRegistry {
       }
     }
 
-    // Restore locally-imported image assets and repopulate the global request-time
-    // registry so the serving process can stream/transform them from disk.
+    // Restore locally-imported image assets and repopulate the global request-time registry so the serving process can stream/transform them from disk.
     if (manifest.localImageAssets) {
       for (const [url, asset] of Object.entries(manifest.localImageAssets)) {
         const diskPath = resolveManifestPath(asset.diskPath);
@@ -2480,7 +2523,77 @@ export class ComponentRegistry {
     if (manifest.serverIslandScript) {
       registry.serverIslandClientJs = await Bun.file(resolveManifestPath(manifest.serverIslandScript)).text();
     }
-
-    return registry;
   }
+}
+
+function buildRenderOptions(
+  props: Record<string, unknown> | undefined,
+  opts: { idPrefix?: string; context?: Map<unknown, unknown> } | undefined,
+  transformError: (err: unknown) => Error,
+): { props?: Record<string, unknown>; transformError: (err: unknown) => Error; idPrefix?: string; context?: Map<unknown, unknown> } {
+  const renderOptions: { props?: Record<string, unknown>; transformError: (err: unknown) => Error; idPrefix?: string; context?: Map<unknown, unknown> } = { transformError };
+  if (props) {
+    renderOptions.props = props;
+  }
+  if (opts?.idPrefix) {
+    renderOptions.idPrefix = opts.idPrefix;
+  }
+  if (opts?.context) {
+    renderOptions.context = opts.context;
+  }
+  return renderOptions;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- the SSR module is dynamically imported, so its export shape is untyped.
+function resolveExportedComponent(mod: { default: any } & Record<string, any>, exportName: string | undefined, filename: string): any {
+  const component = exportName && exportName !== 'default' ? mod[exportName] : mod.default;
+  if (!component) {
+    throw new Error(
+      `renderComponent: ${filename} has no export "${exportName ?? 'default'}" — the compiled module and the island registry disagree (stale manifest or removed export).`,
+    );
+  }
+  return component;
+}
+
+// One virtual client entry per island: import the component (default or named) and register it under its island key.
+function buildIslandEntrypoints(
+  unique: Map<string, HydratableComponent>,
+  hydratableIslandPath: string,
+  srcDir: string,
+): { entrypoints: string[]; filesMap: Record<string, string> } {
+  const entrypoints: string[] = [hydratableIslandPath];
+  const filesMap: Record<string, string> = {};
+  for (const [, comp] of unique) {
+    const entryPath = toPosixPath(path.join(srcDir, `_hydrate-${comp.name}.js`));
+    // String import specifiers (`import { "x" as y }`) are valid ESM and cover export names that aren't identifiers.
+    const importStmt =
+      comp.exportName === 'default'
+        ? `import ${comp.name} from "${toPosixPath(comp.resolvedPath)}";`
+        : `import { ${JSON.stringify(comp.exportName)} as ${comp.name} } from "${toPosixPath(comp.resolvedPath)}";`;
+    const entrySource = `import { registerComponent } from "${hydratableIslandPath}";\n${importStmt}\nregisterComponent("${comp.name}", ${comp.name});\n`;
+    entrypoints.push(entryPath);
+    filesMap[entryPath] = entrySource;
+  }
+  return { entrypoints, filesMap };
+}
+
+function emitCompileCacheSummaries(preprocessCacheStats: { hits: number; misses: number }, compileCacheStats: { hits: number; misses: number }): void {
+  const files = preprocessCacheStats.hits + preprocessCacheStats.misses;
+  if (files > 0) {
+    mochiEvents.emit('preprocess-cache:summary', { hits: preprocessCacheStats.hits, misses: preprocessCacheStats.misses, files });
+  }
+  const compileCacheFiles = compileCacheStats.hits + compileCacheStats.misses;
+  if (compileCacheFiles > 0) {
+    mochiEvents.emit('compile-cache:summary', { hits: compileCacheStats.hits, misses: compileCacheStats.misses, files: compileCacheFiles });
+  }
+}
+
+function collectIslandPropsById(ctx: ReturnType<typeof requestContext.getStore>): Map<string, { json: string; emitCount: number }> {
+  const propsById = new Map<string, { json: string; emitCount: number }>();
+  if (ctx) {
+    for (const [json, entry] of ctx.islandProps) {
+      propsById.set(entry.id, { json, emitCount: entry.emitCount });
+    }
+  }
+  return propsById;
 }

--- a/packages/mochi/src/compiler/cssFontAssets.ts
+++ b/packages/mochi/src/compiler/cssFontAssets.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { BunPlugin } from 'bun';
 import MagicString from 'magic-string';
-import { parseCss, parseDataUri, removalSpans, type FontSource, type UrlRef } from './cssAst';
+import { parseCss, parseDataUri, removalSpans, type FontFace, type FontSource, type UrlRef } from './cssAst';
 
 /**
  * A font file Bun's bundler resolved behind a `url()` in a CSS build, replaced with marker bytes by
@@ -179,8 +179,27 @@ export function classifyFontAssets(css: string, refs: FontRef[], opts: { dropLeg
   }
 
   const edits = new MagicString(css);
+  const dropped = pruneAndMarkFontFaces(document.fontFaces, refByUrl, found, edits, opts.dropLegacyWoff);
+
+  // A ref whose sources were all pruned no longer occurs; a ref referenced outside any @font-face block still does.
+  const fonts: SurvivingFont[] = [];
+  for (const [ref, entry] of found) {
+    if (urlsByRef.get(ref)?.some((url) => !dropped.has(url))) {
+      fonts.push({ ref, ...entry });
+    }
+  }
+  return { css: edits.toString(), fonts, parseFailed: false };
+}
+
+function pruneAndMarkFontFaces(
+  fontFaces: FontFace[],
+  refByUrl: Map<UrlRef, FontRef>,
+  found: Map<FontRef, { contentType: string; markerUri: string; preload: boolean }>,
+  edits: MagicString,
+  dropLegacyWoff: boolean,
+): Set<UrlRef> {
   const dropped = new Set<UrlRef>();
-  for (const face of document.fontFaces) {
+  for (const face of fontFaces) {
     // Overlap with U+0000–00FF, the glyphs first paint always needs; a face visible there is worth preloading.
     const latinVisible = face.unicodeRanges === null || face.unicodeRanges.some((range) => range.lo <= 0xff);
     const formats = face.sources.map((source) => sourceFormat(source, source.url ? refByUrl.get(source.url) : undefined));
@@ -191,7 +210,7 @@ export function classifyFontAssets(css: string, refs: FontRef[], opts: { dropLeg
     const dropIndices = new Set<number>();
     face.sources.forEach((source, i) => {
       // Legacy woff goes whether inlined or marked — a data: URI copy is payload all the same.
-      if (opts.dropLegacyWoff && hasWoff2 && formats[i] === 'woff' && source.url) {
+      if (dropLegacyWoff && hasWoff2 && formats[i] === 'woff' && source.url) {
         dropIndices.add(i);
         return;
       }
@@ -216,15 +235,7 @@ export function classifyFontAssets(css: string, refs: FontRef[], opts: { dropLeg
       }
     }
   }
-
-  // A ref whose sources were all pruned no longer occurs; a ref referenced outside any @font-face block still does.
-  const fonts: SurvivingFont[] = [];
-  for (const [ref, entry] of found) {
-    if (urlsByRef.get(ref)?.some((url) => !dropped.has(url))) {
-      fonts.push({ ref, ...entry });
-    }
-  }
-  return { css: edits.toString(), fonts, parseFailed: false };
+  return dropped;
 }
 
 function sourceFormat(source: FontSource, ref: FontRef | undefined): string | null {

--- a/packages/mochi/src/compiler/svelteAstPreprocess.ts
+++ b/packages/mochi/src/compiler/svelteAstPreprocess.ts
@@ -103,62 +103,7 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
   const ast = parse(source, { modern: true });
   const s = new MagicString(source);
 
-  // Svelte allows one `$props.id()` per component (`props_duplicate`), so an author's existing declaration has to be
-  // reused rather than shadowed. Only top-level instance-script declarations are scanned; a `$props.id()` nested in a
-  // function or snippet slips through and collides, which stays unhandled until someone hits it.
-  const importMap = new Map<string, { source: string; exportName: string }>();
-  // Local names bound by imports the island pipeline can't handle (bare package specifiers, namespace imports,
-  // non-svelte sources), kept so a directive on one of them can name the offending specifier in its compile error.
-  const unsupportedImports = new Map<string, string>();
-  let pidVar: string | null = null;
-  if (ast.instance) {
-    for (const node of ast.instance.content.body) {
-      if (node.type === 'ImportDeclaration' && typeof node.source.value === 'string') {
-        const importSource = node.source.value;
-        // Resolving the framework's own public components to their on-disk `.svelte` lets a directive sit straight on
-        // the package import (`<MochiCaptcha mochi:hydrate />`). Only named imports resolve; the rest fall through to
-        // the usual unresolved-island error.
-        if (importSource === FRAMEWORK_COMPONENTS_SPECIFIER) {
-          for (const spec of node.specifiers ?? []) {
-            const framework = spec.type === 'ImportSpecifier' && spec.imported.type === 'Identifier' ? resolveFrameworkComponent(spec.imported.name) : null;
-            if (framework) {
-              importMap.set(spec.local.name, { source: framework.resolvedPath, exportName: framework.exportName });
-            } else {
-              unsupportedImports.set(spec.local.name, importSource);
-            }
-          }
-          continue;
-        }
-        const supported =
-          /\.(svelte|md|svx)$/.test(importSource) && // TODO: Needs to be configurable to support arbitrary extensions
-          (importSource.startsWith('./') || importSource.startsWith('../') || path.isAbsolute(importSource));
-        for (const spec of node.specifiers ?? []) {
-          if (supported && spec.type === 'ImportDefaultSpecifier') {
-            importMap.set(spec.local.name, { source: importSource, exportName: 'default' });
-          } else if (supported && spec.type === 'ImportSpecifier') {
-            const exportName = spec.imported.type === 'Identifier' ? spec.imported.name : String(spec.imported.value);
-            importMap.set(spec.local.name, { source: importSource, exportName });
-          } else {
-            unsupportedImports.set(spec.local.name, importSource);
-          }
-        }
-      } else if (node.type === 'VariableDeclaration') {
-        for (const decl of node.declarations) {
-          if (
-            decl.id.type === 'Identifier' &&
-            decl.init?.type === 'CallExpression' &&
-            decl.init.callee.type === 'MemberExpression' &&
-            decl.init.callee.object.type === 'Identifier' &&
-            decl.init.callee.object.name === '$props' &&
-            decl.init.callee.property.type === 'Identifier' &&
-            decl.init.callee.property.name === 'id'
-          ) {
-            pidVar = decl.id.name;
-          }
-        }
-      }
-    }
-  }
+  const { importMap, unsupportedImports, pidVar } = scanComponentImports(ast.instance);
   const pid = pidVar ?? '__mochi_pid__';
 
   const hydratables: HydratableComponent[] = [];
@@ -168,6 +113,219 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
   const seenServer = new Set<string>();
   // Set by the hydrate/visible branch alone, since only those islands SSR in-page and so need the context boundary imported below.
   let needsBoundary = false;
+
+  const emitClientOnlyIsland = (comp: AST.Component, directives: MochiDirectives, islandKey: string, resolved: string, exportName: string, dedupKey: string): string => {
+    if (!seen.has(dedupKey)) {
+      seen.add(dedupKey);
+      hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
+    }
+
+    // Children are the optional SSR fallback, emitted as placeholder markup and removed once the client mounts.
+    // Static markup only: nested `mochi:*` islands stay untransformed and get wiped on mount.
+    const fallback = comp.fragment.nodes.map((n) => source.slice(n.start, n.end)).join('');
+
+    // Nothing renders server-side, so there is no hydration id to carry and the payload dedups on serialized props alone.
+    const propsExpr = buildPropsFromAst(source, comp.attributes);
+    let attrs = `component-name="${islandKey}" component-url="__MOCHI_COMPONENT_URL__${islandKey}__" client-only`;
+    if (propsExpr !== '{}') {
+      attrs += ` props-ref={__mochi_emit_props__(${propsExpr})}`;
+    }
+
+    // `mochi:clientOnly:visible` defers `mount()` until the wrapper enters the viewport, reusing the hydratable visible path.
+    const isVisible = directives.clientOnly!.name === 'mochi:clientOnly:visible';
+    if (isVisible) {
+      let visibleOptionsExpr: string | null = null;
+      if (directives.clientOnly!.value !== true && !Array.isArray(directives.clientOnly!.value)) {
+        const expr = directives.clientOnly!.value.expression as unknown as Positioned;
+        visibleOptionsExpr = source.slice(expr.start, expr.end);
+      }
+      attrs += ` hydrate-on="visible" css-url="__MOCHI_CSS_URL__${islandKey}__"`;
+      if (visibleOptionsExpr) {
+        attrs += ` hydrate-options={JSON.stringify(${visibleOptionsExpr})}`;
+      }
+    }
+
+    // The component skips SSR entirely, leaving no throw to catch and no hydration marker to force, so no `<svelte:boundary>`.
+    return `<mochi-hydratable-island ${attrs}>${fallback}</mochi-hydratable-island>`;
+  };
+
+  const emitServerIsland = (comp: AST.Component, directives: MochiDirectives, islandKey: string, resolved: string, exportName: string, dedupKey: string): string => {
+    if (!seenServer.has(dedupKey)) {
+      seenServer.add(dedupKey);
+      serverIslands.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
+    }
+
+    // The authored also-hydrate mode rides inside the encrypted envelope (`__mochi_ah`, transport-only, stripped before
+    // render) and the endpoint reads it from the decrypted payload: were it trusted from a `?hydrate=` query param, an
+    // attacker could append `hydrate=eager` to any sealed token and have the endpoint echo the props back in plaintext.
+    const alsoHydrateMode: AlsoHydrateMode | null = directives.hydrate ? (directives.hydrate.name === 'mochi:hydrate:visible' ? 'visible' : 'eager') : null;
+    const isServerVisible = directives.server!.name === 'mochi:defer:visible';
+
+    // Extract directive options (e.g. mochi:defer={{retries: 10}} or
+    // mochi:defer:visible={{rootMargin: '200px', retries: 5}})
+    let serverOptionsExpr: string | null = null;
+    if (directives.server!.value !== true && !Array.isArray(directives.server!.value)) {
+      const exprTag = directives.server!.value;
+      const expr = exprTag.expression as unknown as Positioned;
+      serverOptionsExpr = source.slice(expr.start, expr.end);
+    }
+
+    if (directives.hydrate && !seen.has(dedupKey)) {
+      seen.add(dedupKey);
+      hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
+    }
+
+    // Children become fallback content
+    const childrenSource = comp.fragment.nodes.map((n) => source.slice(n.start, n.end)).join('');
+    const alsoHydrateAttrs = directives.hydrate ? ` also-hydrate="${alsoHydrateMode}" component-url="__MOCHI_COMPONENT_URL__${islandKey}__"` : '';
+
+    if (isServerVisible) {
+      // `mochi:defer:visible` defers the fetch until the wrapper enters the viewport (`rootMargin` rides inside the
+      // existing `server-options` JSON) — laziness is the point, so it is exempt from nested-island inlining.
+      const autoEntries = directives.hydrate ? [`islandId: __mochi_iid`, `${ALSO_HYDRATE_ENVELOPE_KEY}: ${JSON.stringify(alsoHydrateMode)}`] : [`islandId: __mochi_iid`];
+      const propsExpr = buildPropsFromAst(source, comp.attributes, autoEntries);
+      // Server islands always emit signed-props, since islandId is always injected and every prop must be encrypted
+      // against reads and tampering via query parameters. The component name is bound as AAD, so a token sealed for
+      // one component can't be replayed against another.
+      let attrs = `component-name="${islandKey}" signed-props={__mochi_encrypt_props__(__mochi_stringify__(${propsExpr}), ${JSON.stringify(islandKey)})} css-url="__MOCHI_SERVER_CSS_URL__${islandKey}__" data-asset-prefix="__MOCHI_ASSET_PREFIX__" defer-on="visible"`;
+      if (serverOptionsExpr) {
+        attrs += ` server-options={JSON.stringify(${serverOptionsExpr})}`;
+      }
+      attrs += alsoHydrateAttrs;
+      return `{#if true}{@const __mochi_iid = \`\${${pid}}-\${__mochi_uid__++}\`}<mochi-server-island ${attrs}>${childrenSource}</mochi-server-island>{/if}`;
+    }
+
+    return serverInlineReplacement(comp, directives, islandKey, childrenSource, alsoHydrateAttrs, serverOptionsExpr, alsoHydrateMode);
+  };
+
+  // Non-visible defer sites branch at render time: inside an island-endpoint render (`shouldInlineIsland`), the child
+  // renders in-process instead of emitting another fetch placeholder — the props are the same values the placeholder
+  // would have sealed, so the inlined HTML is what the follow-up fetch would have returned. The `{@const}` bindings keep
+  // user props/options expressions evaluated exactly once whichever branch is taken.
+  function serverInlineReplacement(
+    comp: AST.Component,
+    directives: MochiDirectives,
+    islandKey: string,
+    childrenSource: string,
+    alsoHydrateAttrs: string,
+    serverOptionsExpr: string | null,
+    alsoHydrateMode: AlsoHydrateMode | null,
+  ): string {
+    const userPropsExpr = buildPropsFromAst(source, comp.attributes);
+    const optsRef = serverOptionsExpr ? '__mochi_sopts__' : null;
+    const envelope = `{ ...__mochi_props__, islandId: __mochi_iid${directives.hydrate ? `, ${ALSO_HYDRATE_ENVELOPE_KEY}: ${JSON.stringify(alsoHydrateMode)}` : ''} }`;
+    // Server islands always emit signed-props, since islandId is always injected and every prop must be encrypted
+    // against reads and tampering via query parameters. The component name is bound as AAD, so a token sealed for
+    // one component can't be replayed against another. Spreading `__mochi_props__` first keeps the envelope's key
+    // order — and with it the deterministic encrypted token — byte-identical to the pre-inlining emission.
+    let attrs = `component-name="${islandKey}" signed-props={__mochi_encrypt_props__(__mochi_stringify__(${envelope}), ${JSON.stringify(islandKey)})} css-url="__MOCHI_SERVER_CSS_URL__${islandKey}__" data-asset-prefix="__MOCHI_ASSET_PREFIX__"`;
+    if (optsRef) {
+      attrs += ` server-options={JSON.stringify(${optsRef})}`;
+    }
+    attrs += alsoHydrateAttrs;
+    const placeholder = `<mochi-server-island ${attrs}>${childrenSource}</mochi-server-island>`;
+
+    let inlineBody: string;
+    if (directives.hydrate) {
+      // Mirrors the island endpoint's also-hydrate wrapper (`props` attribute, no `hydrate-on`) so the inlined
+      // fragment behaves like the fetched one, and the in-page hydrate branch's boundary nesting so hydration
+      // markers land where client `hydrate()` expects them. The endpoint appends the bootstrap script for the
+      // whole response via `result.bootstrapUrl`.
+      needsBoundary = true;
+      const propsAttr = userPropsExpr !== '{}' ? ` props={__mochi_stringify__(__mochi_props__)}` : '';
+      inlineBody = `<MochiHydratableBoundary_><mochi-hydratable-island component-name="${islandKey}"${propsAttr} component-url="__MOCHI_COMPONENT_URL__${islandKey}__"><svelte:boundary><${comp.name} {...__mochi_props__} /></svelte:boundary></mochi-hydratable-island></MochiHydratableBoundary_>`;
+    } else {
+      inlineBody = `<${comp.name} {...__mochi_props__} />`;
+    }
+
+    // A throwing inlined child degrades to the placeholder (`failed` snippet), i.e. exactly the pre-inlining
+    // behavior: the client fetches the island and a still-failing render returns the endpoint's failure stub.
+    const consts =
+      `{@const __mochi_iid = \`\${${pid}}-\${__mochi_uid__++}\`}` +
+      (serverOptionsExpr ? `{@const __mochi_sopts__ = (${serverOptionsExpr})}` : '') +
+      `{@const __mochi_props__ = (${userPropsExpr})}`;
+    return `{#if true}${consts}{#if __mochi_inline_island__(${optsRef ?? ''})}<svelte:boundary>${inlineBody}{#snippet failed()}${placeholder}{/snippet}</svelte:boundary>{:else}${placeholder}{/if}{/if}`;
+  }
+
+  const emitHydrateIsland = (comp: AST.Component, directives: MochiDirectives, islandKey: string, resolved: string, exportName: string, dedupKey: string): string | null => {
+    const mochiAttr = directives.hydrate!;
+
+    const hasRealChildren = comp.fragment.nodes.some((n) => !(n.type === 'Text' && n.data.trim() === '') && n.type !== 'Comment');
+    if (hasRealChildren) {
+      errors.push({ reason: 'hydrate-children', component: comp.name, directive: mochiAttr.name, filePath });
+      return null;
+    }
+
+    if (!seen.has(dedupKey)) {
+      seen.add(dedupKey);
+      hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
+    }
+
+    const propsSource = comp.attributes
+      .filter((a) => !(a.type === 'Attribute' && a.name.startsWith('mochi:')))
+      .map((a) => source.slice(a.start, a.end))
+      .join(' ');
+
+    const isVisible = mochiAttr.name === 'mochi:hydrate:visible';
+    let visibleOptionsExpr: string | null = null;
+    if (isVisible && mochiAttr.value !== true && !Array.isArray(mochiAttr.value)) {
+      const exprTag = mochiAttr.value;
+      const expr = exprTag.expression as unknown as Positioned;
+      visibleOptionsExpr = source.slice(expr.start, expr.end);
+    }
+
+    const propsExpr = buildPropsFromAst(source, comp.attributes);
+    let attrs = `component-name="${islandKey}" component-url="__MOCHI_COMPONENT_URL__${islandKey}__"`;
+    // Skipping empty props keeps `{}` out of the HTML. `__mochi_emit_props__` registers the payload in the
+    // per-request dedup map and returns a ref id, which ComponentRegistry's post-render HTMLRewriter pass turns
+    // into a <script type="application/json"> block just before the payload's first island.
+    if (propsExpr !== '{}') {
+      attrs += ` props-ref={__mochi_emit_props__(${propsExpr})}`;
+    }
+    if (isVisible) {
+      attrs += ` hydrate-on="visible"`;
+      attrs += ` css-url="__MOCHI_CSS_URL__${islandKey}__"`;
+      if (visibleOptionsExpr) {
+        attrs += ` hydrate-options={JSON.stringify(${visibleOptionsExpr})}`;
+      }
+    }
+
+    // Build the inner component tag. No framework props are injected — the
+    // `isHydratable()` signal reaches the subtree via the context boundary
+    // wrapper below, and components needing a unique id use Svelte's native
+    // `$props.id()`.
+    let innerTag: string;
+    if (comp.fragment.nodes.length > 0) {
+      const childrenSource = comp.fragment.nodes.map((n) => source.slice(n.start, n.end)).join('');
+      innerTag = `<${comp.name}${propsSource ? ' ' + propsSource : ''}>${childrenSource}</${comp.name}>`;
+    } else {
+      innerTag = `<${comp.name}${propsSource ? ' ' + propsSource : ''} />`;
+    }
+
+    // The outer <svelte:boundary> keeps an SSR throw inside the island from taking down the parent page render, and
+    // sits outside <mochi-hydratable-island> so its <!--[-->…<!--]--> markers land at page level for
+    // stripHydrationMarkers. SSR of `failed` needs `transformError` passed to `render()` (see ComponentRegistry.renderComponent).
+    //
+    // The INNER boundary is essential: a bare component invocation emits no hydration-block marker, so
+    // <mochi-hydratable-island>'s firstChild would be the rendered element and Svelte's `hydrate()` — which walks
+    // children for `<!--[-->` / HYDRATION_START — throws HYDRATION_ERROR and falls back to `mount()`, silently
+    // losing hydration and breaking `hydratable()` lookups.
+    const failedSnippet =
+      `{#snippet failed(error)}` + `<mochi-island-failure data-component=${JSON.stringify(comp.name)} data-message={error.message}></mochi-island-failure>` + `{/snippet}`;
+    // The `{#if true}` wrapper gives each island its own scope: every island declares `{#snippet failed}` under the
+    // same name, and Svelte otherwise collapses them into one shared snippet, so a throwing island would render a
+    // sibling's failure stub.
+    //
+    // <MochiHydratableBoundary_> seeds the `isHydratable()` context for the island root and its whole subtree, and
+    // must sit outside <mochi-hydratable-island>: its `{@render children?.()}` emits a trailing `<!---->` SSR anchor
+    // that would otherwise land before the inner boundary's `<!--]-->` and break client `hydrate()` (see the note above).
+    needsBoundary = true;
+    return (
+      `{#if true}<svelte:boundary>${failedSnippet}` +
+      `<MochiHydratableBoundary_><mochi-hydratable-island ${attrs}><svelte:boundary>${innerTag}</svelte:boundary></mochi-hydratable-island></MochiHydratableBoundary_>` +
+      `</svelte:boundary>{/if}`
+    );
+  };
 
   walk(ast.fragment as AST.SvelteNode, null, {
     Component(comp, { next }) {
@@ -183,14 +341,12 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
 
       const entry = importMap.get(comp.name);
       if (!entry) {
-        // For dotted names (`<NS.Widget>`), the base identifier's import is the one worth naming in the compile error.
-        const base = comp.name.split('.')[0]!;
         errors.push({
           reason: 'unresolved',
           component: comp.name,
           directive: islandDirective.name,
           filePath,
-          importSource: unsupportedImports.get(comp.name) ?? unsupportedImports.get(base) ?? importMap.get(base)?.source ?? null,
+          importSource: unresolvedImportSource(comp.name, importMap, unsupportedImports),
         });
         next();
         return;
@@ -213,220 +369,18 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
       // for why the bare `comp.name` below, still used for the Svelte tag and error text, can't serve as the key.
       const islandKey = islandIdentity(comp.name, resolved, exportName);
 
-      for (const attr of comp.attributes) {
-        if (attr.type === 'Attribute' && attr.name === 'islandId') {
-          throw new Error(
-            `\`islandId\` is a reserved framework name and cannot be passed as a prop to a \`${islandDirective.name}\` island. ` +
-              `For a unique id inside ${comp.name}, use Svelte's \`$props.id()\`.`,
-          );
-        }
-      }
+      assertNoReservedIslandIdProp(comp, islandDirective);
 
       if (directives.clientOnly) {
-        // --- CLIENT ONLY ---
-        if (!seen.has(dedupKey)) {
-          seen.add(dedupKey);
-          hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
-        }
-
-        // Children are the optional SSR fallback, emitted as placeholder markup and removed once the client mounts.
-        // Static markup only: nested `mochi:*` islands stay untransformed and get wiped on mount.
-        const fallback = comp.fragment.nodes.map((n) => source.slice(n.start, n.end)).join('');
-
-        // Nothing renders server-side, so there is no hydration id to carry and the payload dedups on serialized props alone.
-        const propsExpr = buildPropsFromAst(source, comp.attributes);
-        let attrs = `component-name="${islandKey}" component-url="__MOCHI_COMPONENT_URL__${islandKey}__" client-only`;
-        if (propsExpr !== '{}') {
-          attrs += ` props-ref={__mochi_emit_props__(${propsExpr})}`;
-        }
-
-        // `mochi:clientOnly:visible` defers `mount()` until the wrapper enters the viewport, reusing the hydratable visible path.
-        const isVisible = directives.clientOnly.name === 'mochi:clientOnly:visible';
-        if (isVisible) {
-          let visibleOptionsExpr: string | null = null;
-          if (directives.clientOnly.value !== true && !Array.isArray(directives.clientOnly.value)) {
-            const expr = directives.clientOnly.value.expression as unknown as Positioned;
-            visibleOptionsExpr = source.slice(expr.start, expr.end);
-          }
-          attrs += ` hydrate-on="visible" css-url="__MOCHI_CSS_URL__${islandKey}__"`;
-          if (visibleOptionsExpr) {
-            attrs += ` hydrate-options={JSON.stringify(${visibleOptionsExpr})}`;
-          }
-        }
-
-        // The component skips SSR entirely, leaving no throw to catch and no hydration marker to force, so no `<svelte:boundary>`.
-        const replacement = `<mochi-hydratable-island ${attrs}>${fallback}</mochi-hydratable-island>`;
-
-        s.overwrite(comp.start, comp.end, replacement);
+        s.overwrite(comp.start, comp.end, emitClientOnlyIsland(comp, directives, islandKey, resolved, exportName, dedupKey));
       } else if (directives.server) {
-        if (!seenServer.has(dedupKey)) {
-          seenServer.add(dedupKey);
-          serverIslands.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
-        }
-
-        // The authored also-hydrate mode rides inside the encrypted envelope (`__mochi_ah`, transport-only, stripped before
-        // render) and the endpoint reads it from the decrypted payload: were it trusted from a `?hydrate=` query param, an
-        // attacker could append `hydrate=eager` to any sealed token and have the endpoint echo the props back in plaintext.
-        const alsoHydrateMode: AlsoHydrateMode | null = directives.hydrate ? (directives.hydrate.name === 'mochi:hydrate:visible' ? 'visible' : 'eager') : null;
-        const isServerVisible = directives.server.name === 'mochi:defer:visible';
-
-        // Extract directive options (e.g. mochi:defer={{retries: 10}} or
-        // mochi:defer:visible={{rootMargin: '200px', retries: 5}})
-        let serverOptionsExpr: string | null = null;
-        if (directives.server.value !== true && !Array.isArray(directives.server.value)) {
-          const exprTag = directives.server.value;
-          const expr = exprTag.expression as unknown as Positioned;
-          serverOptionsExpr = source.slice(expr.start, expr.end);
-        }
-
-        if (directives.hydrate && !seen.has(dedupKey)) {
-          seen.add(dedupKey);
-          hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
-        }
-
-        // Children become fallback content
-        const childrenSource = comp.fragment.nodes.map((n) => source.slice(n.start, n.end)).join('');
-        const alsoHydrateAttrs = directives.hydrate ? ` also-hydrate="${alsoHydrateMode}" component-url="__MOCHI_COMPONENT_URL__${islandKey}__"` : '';
-
-        let replacement: string;
-        if (isServerVisible) {
-          // `mochi:defer:visible` defers the fetch until the wrapper enters the viewport (`rootMargin` rides inside the
-          // existing `server-options` JSON) — laziness is the point, so it is exempt from nested-island inlining.
-          const autoEntries = directives.hydrate ? [`islandId: __mochi_iid`, `${ALSO_HYDRATE_ENVELOPE_KEY}: ${JSON.stringify(alsoHydrateMode)}`] : [`islandId: __mochi_iid`];
-          const propsExpr = buildPropsFromAst(source, comp.attributes, autoEntries);
-          // Server islands always emit signed-props, since islandId is always injected and every prop must be encrypted
-          // against reads and tampering via query parameters. The component name is bound as AAD, so a token sealed for
-          // one component can't be replayed against another.
-          let attrs = `component-name="${islandKey}" signed-props={__mochi_encrypt_props__(__mochi_stringify__(${propsExpr}), ${JSON.stringify(islandKey)})} css-url="__MOCHI_SERVER_CSS_URL__${islandKey}__" data-asset-prefix="__MOCHI_ASSET_PREFIX__" defer-on="visible"`;
-          if (serverOptionsExpr) {
-            attrs += ` server-options={JSON.stringify(${serverOptionsExpr})}`;
-          }
-          attrs += alsoHydrateAttrs;
-          replacement = `{#if true}{@const __mochi_iid = \`\${${pid}}-\${__mochi_uid__++}\`}<mochi-server-island ${attrs}>${childrenSource}</mochi-server-island>{/if}`;
-        } else {
-          // Non-visible defer sites branch at render time: inside an island-endpoint render (`shouldInlineIsland`), the
-          // child renders in-process instead of emitting another fetch placeholder — the props are the same values the
-          // placeholder would have sealed, so the inlined HTML is what the follow-up fetch would have returned. The
-          // `{@const}` bindings keep user props/options expressions evaluated exactly once whichever branch is taken.
-          const userPropsExpr = buildPropsFromAst(source, comp.attributes);
-          const optsRef = serverOptionsExpr ? '__mochi_sopts__' : null;
-          const envelope = `{ ...__mochi_props__, islandId: __mochi_iid${directives.hydrate ? `, ${ALSO_HYDRATE_ENVELOPE_KEY}: ${JSON.stringify(alsoHydrateMode)}` : ''} }`;
-          // Server islands always emit signed-props, since islandId is always injected and every prop must be encrypted
-          // against reads and tampering via query parameters. The component name is bound as AAD, so a token sealed for
-          // one component can't be replayed against another. Spreading `__mochi_props__` first keeps the envelope's key
-          // order — and with it the deterministic encrypted token — byte-identical to the pre-inlining emission.
-          let attrs = `component-name="${islandKey}" signed-props={__mochi_encrypt_props__(__mochi_stringify__(${envelope}), ${JSON.stringify(islandKey)})} css-url="__MOCHI_SERVER_CSS_URL__${islandKey}__" data-asset-prefix="__MOCHI_ASSET_PREFIX__"`;
-          if (optsRef) {
-            attrs += ` server-options={JSON.stringify(${optsRef})}`;
-          }
-          attrs += alsoHydrateAttrs;
-          const placeholder = `<mochi-server-island ${attrs}>${childrenSource}</mochi-server-island>`;
-
-          let inlineBody: string;
-          if (directives.hydrate) {
-            // Mirrors the island endpoint's also-hydrate wrapper (`props` attribute, no `hydrate-on`) so the inlined
-            // fragment behaves like the fetched one, and the in-page hydrate branch's boundary nesting so hydration
-            // markers land where client `hydrate()` expects them. The endpoint appends the bootstrap script for the
-            // whole response via `result.bootstrapUrl`.
-            needsBoundary = true;
-            const propsAttr = userPropsExpr !== '{}' ? ` props={__mochi_stringify__(__mochi_props__)}` : '';
-            inlineBody = `<MochiHydratableBoundary_><mochi-hydratable-island component-name="${islandKey}"${propsAttr} component-url="__MOCHI_COMPONENT_URL__${islandKey}__"><svelte:boundary><${comp.name} {...__mochi_props__} /></svelte:boundary></mochi-hydratable-island></MochiHydratableBoundary_>`;
-          } else {
-            inlineBody = `<${comp.name} {...__mochi_props__} />`;
-          }
-
-          // A throwing inlined child degrades to the placeholder (`failed` snippet), i.e. exactly the pre-inlining
-          // behavior: the client fetches the island and a still-failing render returns the endpoint's failure stub.
-          const consts =
-            `{@const __mochi_iid = \`\${${pid}}-\${__mochi_uid__++}\`}` +
-            (serverOptionsExpr ? `{@const __mochi_sopts__ = (${serverOptionsExpr})}` : '') +
-            `{@const __mochi_props__ = (${userPropsExpr})}`;
-          replacement = `{#if true}${consts}{#if __mochi_inline_island__(${optsRef ?? ''})}<svelte:boundary>${inlineBody}{#snippet failed()}${placeholder}{/snippet}</svelte:boundary>{:else}${placeholder}{/if}{/if}`;
-        }
-
-        s.overwrite(comp.start, comp.end, replacement);
+        s.overwrite(comp.start, comp.end, emitServerIsland(comp, directives, islandKey, resolved, exportName, dedupKey));
       } else {
-        const mochiAttr = directives.hydrate!;
-
-        const hasRealChildren = comp.fragment.nodes.some((n) => !(n.type === 'Text' && n.data.trim() === '') && n.type !== 'Comment');
-        if (hasRealChildren) {
-          errors.push({ reason: 'hydrate-children', component: comp.name, directive: mochiAttr.name, filePath });
+        const replacement = emitHydrateIsland(comp, directives, islandKey, resolved, exportName, dedupKey);
+        if (replacement === null) {
           next();
           return;
         }
-
-        if (!seen.has(dedupKey)) {
-          seen.add(dedupKey);
-          hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
-        }
-
-        const propsSource = comp.attributes
-          .filter((a) => !(a.type === 'Attribute' && a.name.startsWith('mochi:')))
-          .map((a) => source.slice(a.start, a.end))
-          .join(' ');
-
-        const isVisible = mochiAttr.name === 'mochi:hydrate:visible';
-        let visibleOptionsExpr: string | null = null;
-        if (isVisible && mochiAttr.value !== true && !Array.isArray(mochiAttr.value)) {
-          const exprTag = mochiAttr.value;
-          const expr = exprTag.expression as unknown as Positioned;
-          visibleOptionsExpr = source.slice(expr.start, expr.end);
-        }
-
-        const propsExpr = buildPropsFromAst(source, comp.attributes);
-        let attrs = `component-name="${islandKey}" component-url="__MOCHI_COMPONENT_URL__${islandKey}__"`;
-        // Skipping empty props keeps `{}` out of the HTML. `__mochi_emit_props__` registers the payload in the
-        // per-request dedup map and returns a ref id, which ComponentRegistry's post-render HTMLRewriter pass turns
-        // into a <script type="application/json"> block just before the payload's first island.
-        if (propsExpr !== '{}') {
-          attrs += ` props-ref={__mochi_emit_props__(${propsExpr})}`;
-        }
-        if (isVisible) {
-          attrs += ` hydrate-on="visible"`;
-          attrs += ` css-url="__MOCHI_CSS_URL__${islandKey}__"`;
-          if (visibleOptionsExpr) {
-            attrs += ` hydrate-options={JSON.stringify(${visibleOptionsExpr})}`;
-          }
-        }
-
-        // Build the inner component tag. No framework props are injected — the
-        // `isHydratable()` signal reaches the subtree via the context boundary
-        // wrapper below, and components needing a unique id use Svelte's native
-        // `$props.id()`.
-        let innerTag: string;
-        if (comp.fragment.nodes.length > 0) {
-          const childrenSource = comp.fragment.nodes.map((n) => source.slice(n.start, n.end)).join('');
-          innerTag = `<${comp.name}${propsSource ? ' ' + propsSource : ''}>${childrenSource}</${comp.name}>`;
-        } else {
-          innerTag = `<${comp.name}${propsSource ? ' ' + propsSource : ''} />`;
-        }
-
-        // The outer <svelte:boundary> keeps an SSR throw inside the island from taking down the parent page render, and
-        // sits outside <mochi-hydratable-island> so its <!--[-->…<!--]--> markers land at page level for
-        // stripHydrationMarkers. SSR of `failed` needs `transformError` passed to `render()` (see ComponentRegistry.renderComponent).
-        //
-        // TODO: The inner svelte:boundary feel wrong, there MUST be a way
-        // for the hydration markers to be emitted without it, or have svelte not error
-        // out when they don't match up int his case...
-        //
-        // The INNER boundary is essential: a bare component invocation emits no hydration-block marker, so
-        // <mochi-hydratable-island>'s firstChild would be the rendered element and Svelte's `hydrate()` — which walks
-        // children for `<!--[-->` / HYDRATION_START — throws HYDRATION_ERROR and falls back to `mount()`, silently
-        // losing hydration and breaking `hydratable()` lookups.
-        const failedSnippet =
-          `{#snippet failed(error)}` + `<mochi-island-failure data-component=${JSON.stringify(comp.name)} data-message={error.message}></mochi-island-failure>` + `{/snippet}`;
-        // The `{#if true}` wrapper gives each island its own scope: every island declares `{#snippet failed}` under the
-        // same name, and Svelte otherwise collapses them into one shared snippet, so a throwing island would render a
-        // sibling's failure stub.
-        //
-        // <MochiHydratableBoundary_> seeds the `isHydratable()` context for the island root and its whole subtree, and
-        // must sit outside <mochi-hydratable-island>: its `{@render children?.()}` emits a trailing `<!---->` SSR anchor
-        // that would otherwise land before the inner boundary's `<!--]-->` and break client `hydrate()` (see the note above).
-        needsBoundary = true;
-        const replacement =
-          `{#if true}<svelte:boundary>${failedSnippet}` +
-          `<MochiHydratableBoundary_><mochi-hydratable-island ${attrs}><svelte:boundary>${innerTag}</svelte:boundary></mochi-hydratable-island></MochiHydratableBoundary_>` +
-          `</svelte:boundary>{/if}`;
         s.overwrite(comp.start, comp.end, replacement);
       }
 
@@ -434,41 +388,70 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
     },
   });
 
-  // Inject imports into the component's <script> tag
-  const needsEmitProps = hydratables.length > 0;
-  const needsStringify = serverIslands.length > 0;
-  const needsSignProps = serverIslands.length > 0;
-  // Only server islands need the `__mochi_iid` transport id, riding inside their signed envelope as `idPrefix` for the
-  // standalone render; the other kinds let Svelte recover `$props.id()` from its own `<!--$...-->` markers.
-  const needsUid = serverIslands.length > 0;
-
-  if ((needsEmitProps || needsStringify || needsSignProps || needsBoundary) && ast.instance) {
-    const contentStart = (ast.instance.content as unknown as Positioned).start;
-    let imports = '';
-    if (needsEmitProps) {
-      imports += '\nimport { emitIslandProps as __mochi_emit_props__ } from "mochi-framework";';
-    }
-    if (needsBoundary) {
-      imports += '\nimport MochiHydratableBoundary_ from "mochi-framework/hydratable-boundary";';
-    }
-    if (needsStringify) {
-      imports += '\nimport { stringify as __mochi_stringify__ } from "mochi-framework";';
-    }
-    if (needsUid) {
-      imports += '\nlet __mochi_uid__ = 0;';
-      // Island ids are `${$props.id()}-${counter}`: the rune is unique per component instance per render and the counter
-      // separates multiple islands inside one instance, staying SSR-stable because Svelte reads the id back from its marker.
-      if (!pidVar) {
-        imports += '\nconst __mochi_pid__ = $props.id();';
-      }
-    }
-    if (needsSignProps) {
-      imports += '\nimport { encryptProps as __mochi_encrypt_props__, shouldInlineIsland as __mochi_inline_island__ } from "mochi-server-island-runtime";';
-    }
-    s.appendRight(contentStart, imports);
-  }
+  injectIslandRuntimeImports(s, ast.instance, hydratables.length > 0, serverIslands.length > 0, needsBoundary, pidVar);
 
   return { transformed: s.toString(), hydratables, serverIslands, errors };
+}
+
+// For dotted names (`<NS.Widget>`), the base identifier's import is the one worth naming in the compile error.
+function unresolvedImportSource(name: string, importMap: Map<string, { source: string; exportName: string }>, unsupportedImports: Map<string, string>): string | null {
+  const base = name.split('.')[0]!;
+  return unsupportedImports.get(name) ?? unsupportedImports.get(base) ?? importMap.get(base)?.source ?? null;
+}
+
+function assertNoReservedIslandIdProp(comp: AST.Component, islandDirective: AST.Attribute): void {
+  for (const attr of comp.attributes) {
+    if (attr.type === 'Attribute' && attr.name === 'islandId') {
+      throw new Error(
+        `\`islandId\` is a reserved framework name and cannot be passed as a prop to a \`${islandDirective.name}\` island. ` +
+          `For a unique id inside ${comp.name}, use Svelte's \`$props.id()\`.`,
+      );
+    }
+  }
+}
+
+// Inject the runtime imports the rewritten island markup references into the component's <script> tag.
+function injectIslandRuntimeImports(
+  s: MagicString,
+  instance: AST.Root['instance'],
+  hasHydratables: boolean,
+  hasServerIslands: boolean,
+  needsBoundary: boolean,
+  pidVar: string | null,
+): void {
+  const needsEmitProps = hasHydratables;
+  const needsStringify = hasServerIslands;
+  const needsSignProps = hasServerIslands;
+  // Only server islands need the `__mochi_iid` transport id, riding inside their signed envelope as `idPrefix` for the
+  // standalone render; the other kinds let Svelte recover `$props.id()` from its own `<!--$...-->` markers.
+  const needsUid = hasServerIslands;
+
+  if (!(needsEmitProps || needsStringify || needsSignProps || needsBoundary) || !instance) {
+    return;
+  }
+  const contentStart = (instance.content as unknown as Positioned).start;
+  let imports = '';
+  if (needsEmitProps) {
+    imports += '\nimport { emitIslandProps as __mochi_emit_props__ } from "mochi-framework";';
+  }
+  if (needsBoundary) {
+    imports += '\nimport MochiHydratableBoundary_ from "mochi-framework/hydratable-boundary";';
+  }
+  if (needsStringify) {
+    imports += '\nimport { stringify as __mochi_stringify__ } from "mochi-framework";';
+  }
+  if (needsUid) {
+    imports += '\nlet __mochi_uid__ = 0;';
+    // Island ids are `${$props.id()}-${counter}`: the rune is unique per component instance per render and the counter
+    // separates multiple islands inside one instance, staying SSR-stable because Svelte reads the id back from its marker.
+    if (!pidVar) {
+      imports += '\nconst __mochi_pid__ = $props.id();';
+    }
+  }
+  if (needsSignProps) {
+    imports += '\nimport { encryptProps as __mochi_encrypt_props__, shouldInlineIsland as __mochi_inline_island__ } from "mochi-server-island-runtime";';
+  }
+  s.appendRight(contentStart, imports);
 }
 
 /**
@@ -493,6 +476,99 @@ function islandIdentity(name: string, resolvedPath: string, exportName: string):
   const encoded = encodeSourcePath(resolvedPath);
   const identity = exportName === 'default' ? encoded : `${encoded}#${exportName}`;
   return `${name}_${Bun.hash(identity).toString(36)}`;
+}
+
+interface ScannedImports {
+  importMap: Map<string, { source: string; exportName: string }>;
+  unsupportedImports: Map<string, string>;
+  pidVar: string | null;
+}
+
+type InstanceBody = NonNullable<AST.Root['instance']>['content']['body'];
+type ImportNode = Extract<InstanceBody[number], { type: 'ImportDeclaration' }>;
+type VariableNode = Extract<InstanceBody[number], { type: 'VariableDeclaration' }>;
+
+// Svelte allows one `$props.id()` per component (`props_duplicate`), so an author's existing declaration has to be
+// reused rather than shadowed. Only top-level instance-script declarations are scanned; a `$props.id()` nested in a
+// function or snippet slips through and collides, which stays unhandled until someone hits it.
+function scanComponentImports(instance: AST.Root['instance']): ScannedImports {
+  const importMap = new Map<string, { source: string; exportName: string }>();
+  // Local names bound by imports the island pipeline can't handle (bare package specifiers, namespace imports,
+  // non-svelte sources), kept so a directive on one of them can name the offending specifier in its compile error.
+  const unsupportedImports = new Map<string, string>();
+  let pidVar: string | null = null;
+  if (!instance) {
+    return { importMap, unsupportedImports, pidVar };
+  }
+  for (const node of instance.content.body) {
+    if (node.type === 'ImportDeclaration' && typeof node.source.value === 'string') {
+      registerComponentImport(node, node.source.value, importMap, unsupportedImports);
+    } else if (node.type === 'VariableDeclaration') {
+      pidVar = findPropsIdVar(node.declarations) ?? pidVar;
+    }
+  }
+  return { importMap, unsupportedImports, pidVar };
+}
+
+function registerComponentImport(
+  node: ImportNode,
+  importSource: string,
+  importMap: Map<string, { source: string; exportName: string }>,
+  unsupportedImports: Map<string, string>,
+): void {
+  const specifiers = node.specifiers ?? [];
+  // Resolving the framework's own public components to their on-disk `.svelte` lets a directive sit straight on the
+  // package import (`<MochiCaptcha mochi:hydrate />`). Only named imports resolve; the rest fall through to the usual
+  // unresolved-island error.
+  if (importSource === FRAMEWORK_COMPONENTS_SPECIFIER) {
+    registerFrameworkComponentImports(specifiers, importMap, unsupportedImports);
+    return;
+  }
+  const supported =
+    /\.(svelte|md|svx)$/.test(importSource) && // TODO: Needs to be configurable to support arbitrary extensions
+    (importSource.startsWith('./') || importSource.startsWith('../') || path.isAbsolute(importSource));
+  for (const spec of specifiers) {
+    if (supported && spec.type === 'ImportDefaultSpecifier') {
+      importMap.set(spec.local.name, { source: importSource, exportName: 'default' });
+    } else if (supported && spec.type === 'ImportSpecifier') {
+      const exportName = spec.imported.type === 'Identifier' ? spec.imported.name : String(spec.imported.value);
+      importMap.set(spec.local.name, { source: importSource, exportName });
+    } else {
+      unsupportedImports.set(spec.local.name, importSource);
+    }
+  }
+}
+
+function registerFrameworkComponentImports(
+  specifiers: ImportNode['specifiers'],
+  importMap: Map<string, { source: string; exportName: string }>,
+  unsupportedImports: Map<string, string>,
+): void {
+  for (const spec of specifiers) {
+    const framework = spec.type === 'ImportSpecifier' && spec.imported.type === 'Identifier' ? resolveFrameworkComponent(spec.imported.name) : null;
+    if (framework) {
+      importMap.set(spec.local.name, { source: framework.resolvedPath, exportName: framework.exportName });
+    } else {
+      unsupportedImports.set(spec.local.name, FRAMEWORK_COMPONENTS_SPECIFIER);
+    }
+  }
+}
+
+function findPropsIdVar(declarations: VariableNode['declarations']): string | null {
+  for (const decl of declarations) {
+    if (
+      decl.id.type === 'Identifier' &&
+      decl.init?.type === 'CallExpression' &&
+      decl.init.callee.type === 'MemberExpression' &&
+      decl.init.callee.object.type === 'Identifier' &&
+      decl.init.callee.object.name === '$props' &&
+      decl.init.callee.property.type === 'Identifier' &&
+      decl.init.callee.property.name === 'id'
+    ) {
+      return decl.id.name;
+    }
+  }
+  return null;
 }
 
 interface MochiDirectives {

--- a/packages/mochi/src/compiler/svelteAstPreprocess.ts
+++ b/packages/mochi/src/compiler/svelteAstPreprocess.ts
@@ -75,6 +75,23 @@ export interface HydrateIslandChildrenError {
 
 export type PreprocessIslandError = UnresolvedIslandError | ServerOnlyIslandError | HydrateIslandChildrenError;
 
+// The `{expression}` value of a `mochi:*` directive (e.g. `mochi:defer={{retries: 10}}`), or null for a bare directive.
+function directiveOptionsExpr(source: string, attr: AST.Attribute): string | null {
+  if (attr.value === true || Array.isArray(attr.value)) {
+    return null;
+  }
+  const expr = attr.value.expression as unknown as Positioned;
+  return source.slice(expr.start, expr.end);
+}
+
+// One component can be hit from several call sites; each list dedups on the resolved-path+export key.
+function registerIsland(list: HydratableComponent[], registered: Set<string>, dedupKey: string, entry: HydratableComponent): void {
+  if (!registered.has(dedupKey)) {
+    registered.add(dedupKey);
+    list.push(entry);
+  }
+}
+
 export interface PreprocessResult {
   transformed: string;
   hydratables: HydratableComponent[];
@@ -114,11 +131,8 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
   // Set by the hydrate/visible branch alone, since only those islands SSR in-page and so need the context boundary imported below.
   let needsBoundary = false;
 
-  const emitClientOnlyIsland = (comp: AST.Component, directives: MochiDirectives, islandKey: string, resolved: string, exportName: string, dedupKey: string): string => {
-    if (!seen.has(dedupKey)) {
-      seen.add(dedupKey);
-      hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
-    }
+  const emitClientOnlyIsland = (comp: AST.Component, clientOnly: AST.Attribute, islandKey: string, resolved: string, exportName: string, dedupKey: string): string => {
+    registerIsland(hydratables, seen, dedupKey, { name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
 
     // Children are the optional SSR fallback, emitted as placeholder markup and removed once the client mounts.
     // Static markup only: nested `mochi:*` islands stay untransformed and get wiped on mount.
@@ -132,13 +146,9 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
     }
 
     // `mochi:clientOnly:visible` defers `mount()` until the wrapper enters the viewport, reusing the hydratable visible path.
-    const isVisible = directives.clientOnly!.name === 'mochi:clientOnly:visible';
+    const isVisible = clientOnly.name === 'mochi:clientOnly:visible';
     if (isVisible) {
-      let visibleOptionsExpr: string | null = null;
-      if (directives.clientOnly!.value !== true && !Array.isArray(directives.clientOnly!.value)) {
-        const expr = directives.clientOnly!.value.expression as unknown as Positioned;
-        visibleOptionsExpr = source.slice(expr.start, expr.end);
-      }
+      const visibleOptionsExpr = directiveOptionsExpr(source, clientOnly);
       attrs += ` hydrate-on="visible" css-url="__MOCHI_CSS_URL__${islandKey}__"`;
       if (visibleOptionsExpr) {
         attrs += ` hydrate-options={JSON.stringify(${visibleOptionsExpr})}`;
@@ -149,30 +159,26 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
     return `<mochi-hydratable-island ${attrs}>${fallback}</mochi-hydratable-island>`;
   };
 
-  const emitServerIsland = (comp: AST.Component, directives: MochiDirectives, islandKey: string, resolved: string, exportName: string, dedupKey: string): string => {
-    if (!seenServer.has(dedupKey)) {
-      seenServer.add(dedupKey);
-      serverIslands.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
-    }
+  const emitServerIsland = (
+    comp: AST.Component,
+    directives: { server: AST.Attribute; hydrate: AST.Attribute | null },
+    islandKey: string,
+    resolved: string,
+    exportName: string,
+    dedupKey: string,
+  ): string => {
+    registerIsland(serverIslands, seenServer, dedupKey, { name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
 
     // The authored also-hydrate mode rides inside the encrypted envelope (`__mochi_ah`, transport-only, stripped before
     // render) and the endpoint reads it from the decrypted payload: were it trusted from a `?hydrate=` query param, an
     // attacker could append `hydrate=eager` to any sealed token and have the endpoint echo the props back in plaintext.
     const alsoHydrateMode: AlsoHydrateMode | null = directives.hydrate ? (directives.hydrate.name === 'mochi:hydrate:visible' ? 'visible' : 'eager') : null;
-    const isServerVisible = directives.server!.name === 'mochi:defer:visible';
+    const isServerVisible = directives.server.name === 'mochi:defer:visible';
 
-    // Extract directive options (e.g. mochi:defer={{retries: 10}} or
-    // mochi:defer:visible={{rootMargin: '200px', retries: 5}})
-    let serverOptionsExpr: string | null = null;
-    if (directives.server!.value !== true && !Array.isArray(directives.server!.value)) {
-      const exprTag = directives.server!.value;
-      const expr = exprTag.expression as unknown as Positioned;
-      serverOptionsExpr = source.slice(expr.start, expr.end);
-    }
+    const serverOptionsExpr = directiveOptionsExpr(source, directives.server);
 
-    if (directives.hydrate && !seen.has(dedupKey)) {
-      seen.add(dedupKey);
-      hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
+    if (directives.hydrate) {
+      registerIsland(hydratables, seen, dedupKey, { name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
     }
 
     // Children become fallback content
@@ -195,7 +201,7 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
       return `{#if true}{@const __mochi_iid = \`\${${pid}}-\${__mochi_uid__++}\`}<mochi-server-island ${attrs}>${childrenSource}</mochi-server-island>{/if}`;
     }
 
-    return serverInlineReplacement(comp, directives, islandKey, childrenSource, alsoHydrateAttrs, serverOptionsExpr, alsoHydrateMode);
+    return serverInlineReplacement(comp, directives.hydrate, islandKey, childrenSource, alsoHydrateAttrs, serverOptionsExpr, alsoHydrateMode);
   };
 
   // Non-visible defer sites branch at render time: inside an island-endpoint render (`shouldInlineIsland`), the child
@@ -204,7 +210,7 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
   // user props/options expressions evaluated exactly once whichever branch is taken.
   function serverInlineReplacement(
     comp: AST.Component,
-    directives: MochiDirectives,
+    hydrate: AST.Attribute | null,
     islandKey: string,
     childrenSource: string,
     alsoHydrateAttrs: string,
@@ -213,7 +219,7 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
   ): string {
     const userPropsExpr = buildPropsFromAst(source, comp.attributes);
     const optsRef = serverOptionsExpr ? '__mochi_sopts__' : null;
-    const envelope = `{ ...__mochi_props__, islandId: __mochi_iid${directives.hydrate ? `, ${ALSO_HYDRATE_ENVELOPE_KEY}: ${JSON.stringify(alsoHydrateMode)}` : ''} }`;
+    const envelope = `{ ...__mochi_props__, islandId: __mochi_iid${hydrate ? `, ${ALSO_HYDRATE_ENVELOPE_KEY}: ${JSON.stringify(alsoHydrateMode)}` : ''} }`;
     // Server islands always emit signed-props, since islandId is always injected and every prop must be encrypted
     // against reads and tampering via query parameters. The component name is bound as AAD, so a token sealed for
     // one component can't be replayed against another. Spreading `__mochi_props__` first keeps the envelope's key
@@ -226,7 +232,7 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
     const placeholder = `<mochi-server-island ${attrs}>${childrenSource}</mochi-server-island>`;
 
     let inlineBody: string;
-    if (directives.hydrate) {
+    if (hydrate) {
       // Mirrors the island endpoint's also-hydrate wrapper (`props` attribute, no `hydrate-on`) so the inlined
       // fragment behaves like the fetched one, and the in-page hydrate branch's boundary nesting so hydration
       // markers land where client `hydrate()` expects them. The endpoint appends the bootstrap script for the
@@ -247,8 +253,8 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
     return `{#if true}${consts}{#if __mochi_inline_island__(${optsRef ?? ''})}<svelte:boundary>${inlineBody}{#snippet failed()}${placeholder}{/snippet}</svelte:boundary>{:else}${placeholder}{/if}{/if}`;
   }
 
-  const emitHydrateIsland = (comp: AST.Component, directives: MochiDirectives, islandKey: string, resolved: string, exportName: string, dedupKey: string): string | null => {
-    const mochiAttr = directives.hydrate!;
+  const emitHydrateIsland = (comp: AST.Component, hydrate: AST.Attribute, islandKey: string, resolved: string, exportName: string, dedupKey: string): string | null => {
+    const mochiAttr = hydrate;
 
     const hasRealChildren = comp.fragment.nodes.some((n) => !(n.type === 'Text' && n.data.trim() === '') && n.type !== 'Comment');
     if (hasRealChildren) {
@@ -256,10 +262,7 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
       return null;
     }
 
-    if (!seen.has(dedupKey)) {
-      seen.add(dedupKey);
-      hydratables.push({ name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
-    }
+    registerIsland(hydratables, seen, dedupKey, { name: islandKey, displayName: comp.name, resolvedPath: resolved, exportName });
 
     const propsSource = comp.attributes
       .filter((a) => !(a.type === 'Attribute' && a.name.startsWith('mochi:')))
@@ -267,12 +270,7 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
       .join(' ');
 
     const isVisible = mochiAttr.name === 'mochi:hydrate:visible';
-    let visibleOptionsExpr: string | null = null;
-    if (isVisible && mochiAttr.value !== true && !Array.isArray(mochiAttr.value)) {
-      const exprTag = mochiAttr.value;
-      const expr = exprTag.expression as unknown as Positioned;
-      visibleOptionsExpr = source.slice(expr.start, expr.end);
-    }
+    const visibleOptionsExpr = isVisible ? directiveOptionsExpr(source, mochiAttr) : null;
 
     const propsExpr = buildPropsFromAst(source, comp.attributes);
     let attrs = `component-name="${islandKey}" component-url="__MOCHI_COMPONENT_URL__${islandKey}__"`;
@@ -306,6 +304,10 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
     // sits outside <mochi-hydratable-island> so its <!--[-->…<!--]--> markers land at page level for
     // stripHydrationMarkers. SSR of `failed` needs `transformError` passed to `render()` (see ComponentRegistry.renderComponent).
     //
+    // TODO: The inner svelte:boundary feel wrong, there MUST be a way
+    // for the hydration markers to be emitted without it, or have svelte not error
+    // out when they don't match up int his case...
+    //
     // The INNER boundary is essential: a bare component invocation emits no hydration-block marker, so
     // <mochi-hydratable-island>'s firstChild would be the rendered element and Svelte's `hydrate()` — which walks
     // children for `<!--[-->` / HYDRATION_START — throws HYDRATION_ERROR and falls back to `mount()`, silently
@@ -330,14 +332,13 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
   walk(ast.fragment as AST.SvelteNode, null, {
     Component(comp, { next }) {
       const directives = findMochiDirectives(comp.attributes);
-      if (!directives.server && !directives.hydrate && !directives.clientOnly) {
+      // `islandId` is reserved on every directive alike, so a component can move between them without a prop
+      // silently changing meaning; on `mochi:defer` it is the transport key inside the signed envelope.
+      const islandDirective = directives.clientOnly ?? directives.server ?? directives.hydrate;
+      if (!islandDirective) {
         next();
         return;
       }
-
-      // `islandId` is reserved on every directive alike, so a component can move between them without a prop
-      // silently changing meaning; on `mochi:defer` it is the transport key inside the signed envelope.
-      const islandDirective = directives.clientOnly ?? directives.server ?? directives.hydrate!;
 
       const entry = importMap.get(comp.name);
       if (!entry) {
@@ -372,11 +373,11 @@ export function preprocessHydratable(source: string, filePath: string): Preproce
       assertNoReservedIslandIdProp(comp, islandDirective);
 
       if (directives.clientOnly) {
-        s.overwrite(comp.start, comp.end, emitClientOnlyIsland(comp, directives, islandKey, resolved, exportName, dedupKey));
+        s.overwrite(comp.start, comp.end, emitClientOnlyIsland(comp, directives.clientOnly, islandKey, resolved, exportName, dedupKey));
       } else if (directives.server) {
-        s.overwrite(comp.start, comp.end, emitServerIsland(comp, directives, islandKey, resolved, exportName, dedupKey));
-      } else {
-        const replacement = emitHydrateIsland(comp, directives, islandKey, resolved, exportName, dedupKey);
+        s.overwrite(comp.start, comp.end, emitServerIsland(comp, { server: directives.server, hydrate: directives.hydrate }, islandKey, resolved, exportName, dedupKey));
+      } else if (directives.hydrate) {
+        const replacement = emitHydrateIsland(comp, directives.hydrate, islandKey, resolved, exportName, dedupKey);
         if (replacement === null) {
           next();
           return;
@@ -554,7 +555,10 @@ function registerFrameworkComponentImports(
   }
 }
 
+// Last match wins, matching the scan across sibling declarations — Svelte rejects a second `$props.id()` anyway, so the
+// two only ever disagree on source it refuses to compile, and agreeing costs nothing.
 function findPropsIdVar(declarations: VariableNode['declarations']): string | null {
+  let found: string | null = null;
   for (const decl of declarations) {
     if (
       decl.id.type === 'Identifier' &&
@@ -565,10 +569,10 @@ function findPropsIdVar(declarations: VariableNode['declarations']): string | nu
       decl.init.callee.property.type === 'Identifier' &&
       decl.init.callee.property.name === 'id'
     ) {
-      return decl.id.name;
+      found = decl.id.name;
     }
   }
-  return null;
+  return found;
 }
 
 interface MochiDirectives {

--- a/packages/mochi/src/dev/consoleLogger.ts
+++ b/packages/mochi/src/dev/consoleLogger.ts
@@ -531,17 +531,17 @@ function colorKind(kind: MochiRequestKind): string {
   }
 }
 
-function buildEmitLine(
-  label: string,
-  kind: MochiRequestKind | undefined,
-  path: string,
-  status: number | undefined,
-  note: string | undefined,
-  duration: number | undefined,
-  neutral: boolean,
-  slow: number,
-  verySlow: number,
-): string {
+function buildEmitLine({
+  label,
+  kind,
+  path,
+  status,
+  note,
+  duration,
+  neutral,
+  slow,
+  verySlow,
+}: Required<Pick<EmitInput, 'label' | 'path' | 'neutral' | 'slow' | 'verySlow'>> & Pick<EmitInput, 'kind' | 'status' | 'note' | 'duration'>): string {
   const ts = styleText('dim', formatTimestamp(new Date()));
   const labelStr = styleText('cyan', label);
   const kindStr = kind ? ' ' + colorKind(kind) : '';
@@ -554,7 +554,7 @@ function buildEmitLine(
 }
 
 function emit({ label, kind, path, status, note, duration, neutral = false, slow = DEFAULT_SLOW, verySlow = DEFAULT_VERY_SLOW, level = 'info', source }: EmitInput): void {
-  const line = buildEmitLine(label, kind, path, status, note, duration, neutral, slow, verySlow);
+  const line = buildEmitLine({ label, kind, path, status, note, duration, neutral, slow, verySlow });
 
   const isServerError = status != null && status >= 500;
   const isSlow = !neutral && duration != null && duration >= slow;

--- a/packages/mochi/src/dev/consoleLogger.ts
+++ b/packages/mochi/src/dev/consoleLogger.ts
@@ -531,7 +531,17 @@ function colorKind(kind: MochiRequestKind): string {
   }
 }
 
-function emit({ label, kind, path, status, note, duration, neutral = false, slow = DEFAULT_SLOW, verySlow = DEFAULT_VERY_SLOW, level = 'info', source }: EmitInput): void {
+function buildEmitLine(
+  label: string,
+  kind: MochiRequestKind | undefined,
+  path: string,
+  status: number | undefined,
+  note: string | undefined,
+  duration: number | undefined,
+  neutral: boolean,
+  slow: number,
+  verySlow: number,
+): string {
   const ts = styleText('dim', formatTimestamp(new Date()));
   const labelStr = styleText('cyan', label);
   const kindStr = kind ? ' ' + colorKind(kind) : '';
@@ -540,8 +550,11 @@ function emit({ label, kind, path, status, note, duration, neutral = false, slow
   const notePart = note ?? '';
   const middle = [statusPart, notePart].filter(Boolean).join(' ');
   const durationStr = duration != null ? ' ' + (neutral ? styleText('dim', formatMs(duration)) : colorDuration(duration, slow, verySlow)) : '';
+  return `${ts} ${labelStr}${kindStr} ${pathStr} ${middle}${durationStr}`;
+}
 
-  const line = `${ts} ${labelStr}${kindStr} ${pathStr} ${middle}${durationStr}`;
+function emit({ label, kind, path, status, note, duration, neutral = false, slow = DEFAULT_SLOW, verySlow = DEFAULT_VERY_SLOW, level = 'info', source }: EmitInput): void {
+  const line = buildEmitLine(label, kind, path, status, note, duration, neutral, slow, verySlow);
 
   const isServerError = status != null && status >= 500;
   const isSlow = !neutral && duration != null && duration >= slow;

--- a/packages/mochi/src/dev/devWatcher.ts
+++ b/packages/mochi/src/dev/devWatcher.ts
@@ -95,6 +95,34 @@ export interface DevWatcherDeps {
   initialCronSignature?: string;
 }
 
+type RouteChangeCounts = { updated: number; added: string[]; removed: string[]; api: number; ws: number; sse: number; page: number; file: number };
+
+function summarizeRouteCounts(counts: RouteChangeCounts): string[] {
+  const parts: string[] = [];
+  if (counts.api) {
+    parts.push(`${counts.api} api`);
+  }
+  if (counts.ws) {
+    parts.push(`${counts.ws} ws`);
+  }
+  if (counts.sse) {
+    parts.push(`${counts.sse} sse`);
+  }
+  if (counts.page) {
+    parts.push(`${counts.page} page`);
+  }
+  if (counts.file) {
+    parts.push(`${counts.file} file`);
+  }
+  if (counts.added.length) {
+    parts.push(`+${counts.added.length} new`);
+  }
+  if (counts.removed.length) {
+    parts.push(`-${counts.removed.length} removed`);
+  }
+  return parts;
+}
+
 /**
  * Wire up the dev-mode file watcher — chokidar over the source tree, public dir, and `svelte.config.js`. Saves debounce
  * at 100ms and serialize through a Promise chain so the live-reload signal fires only once client chunks are ready. CSS
@@ -419,10 +447,116 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
     delete baseBunRoutes[pattern];
   }
 
-  async function applyRouteChanges(
-    freshRoutes: Record<string, unknown>,
-  ): Promise<{ updated: number; added: string[]; removed: string[]; api: number; ws: number; sse: number; page: number; file: number }> {
-    const counts = { updated: 0, added: [] as string[], removed: [] as string[], api: 0, ws: 0, sse: 0, page: 0, file: 0 };
+  async function reregisterRoute(pattern: string, handler: unknown, previousType: DevRouteType, counts: RouteChangeCounts): Promise<void> {
+    if (!registerRoutePattern || !unregisterRoutePattern) {
+      return;
+    }
+    unregisterRoutePattern(pattern);
+    removeBunRoute(pattern, previousType);
+    const result = await registerRoutePattern(pattern, handler as MochiRouteValue);
+    if (!result) {
+      return;
+    }
+    addBunRoute(pattern, result.bunRouteValue, result.type);
+    if (previousType === 'file' && result.type === 'file') {
+      counts.file++;
+      counts.updated++;
+      logger.info(`Route updated file: ${pattern}`);
+    } else {
+      counts.added.push(pattern);
+      counts.removed.push(pattern);
+      logger.info(`Route retyped ${previousType}→${result.type}: ${pattern}`);
+    }
+  }
+
+  function updateRouteInPlace(pattern: string, handler: unknown, counts: RouteChangeCounts): void {
+    if (isMochiApi(handler) && apiHandlerMap?.has(pattern)) {
+      apiHandlerMap.set(pattern, handler.handler);
+      updateRouteLimiter?.(pattern, handler.rateLimit);
+      counts.api++;
+      counts.updated++;
+    } else if (isMochiWs(handler) && wsHandlersMap?.has(pattern)) {
+      wsHandlersMap.set(pattern, handler.handlers as MochiWsHandlers<unknown>);
+      counts.ws++;
+      counts.updated++;
+    } else if (isMochiSse(handler) && sseHandlerMap?.has(pattern)) {
+      sseHandlerMap.set(pattern, handler.handler);
+      counts.sse++;
+      counts.updated++;
+    } else if (isMochiPage(handler) && pageConfigMap?.has(pattern)) {
+      pageConfigMap.set(pattern, { serverProps: handler.serverProps, actions: handler.actions });
+      updateRouteLimiter?.(pattern, handler.rateLimit);
+      counts.page++;
+      counts.updated++;
+    }
+  }
+
+  async function applyExistingRoute(pattern: string, handler: unknown, type: DevRouteType, counts: RouteChangeCounts): Promise<void> {
+    const currentType = currentRouteType(pattern);
+    if (currentType && currentType !== type && registerRoutePattern && unregisterRoutePattern) {
+      await reregisterRoute(pattern, handler, currentType, counts);
+    } else if (type === 'file' && registerRoutePattern && unregisterRoutePattern) {
+      // File routes have no handler map to mutate in place — their source is baked into the registered closure — so swap by re-registering.
+      await reregisterRoute(pattern, handler, 'file', counts);
+    } else {
+      updateRouteInPlace(pattern, handler, counts);
+    }
+  }
+
+  async function addNewRoute(pattern: string, handler: unknown, counts: RouteChangeCounts): Promise<void> {
+    if (!registerRoutePattern) {
+      return;
+    }
+    try {
+      const result = await registerRoutePattern(pattern, handler as MochiRouteValue);
+      if (result) {
+        addBunRoute(pattern, result.bunRouteValue, result.type);
+        counts[result.type]++;
+        counts.added.push(pattern);
+        logger.info(`Route added ${result.type}: ${pattern}`);
+      }
+    } catch (e) {
+      logger.warn(`Failed to register route ${pattern}: ${e instanceof Error ? e.message : e}`);
+      counts.added.push(pattern);
+    }
+  }
+
+  function removeStaleRoutes(freshPatterns: Set<string>, counts: RouteChangeCounts): void {
+    if (!unregisterRoutePattern) {
+      return;
+    }
+    for (const pattern of knownEntryPatterns) {
+      if (!freshPatterns.has(pattern)) {
+        const removedType = currentRouteType(pattern);
+        unregisterRoutePattern(pattern);
+        removeBunRoute(pattern, removedType);
+        counts.removed.push(pattern);
+        logger.info(`Route removed: ${pattern}`);
+      }
+    }
+  }
+
+  // Deleting an explicitly-declared sibling (`/a/` alongside `/a`) leaves the survivor without the mirror a cold boot
+  // would have given it, so its canonical form would redirect into a 404 until restart.
+  function ensureAltSlashMirrors(freshPatterns: Set<string>): void {
+    if (!trailingSlashPolicy) {
+      return;
+    }
+    for (const pattern of freshPatterns) {
+      const value = bunRoutes[pattern];
+      if (value === undefined || !mirrorsAltSlash(currentRouteType(pattern))) {
+        continue;
+      }
+      const alt = alternateSlashPattern(pattern);
+      if (alt && !(alt in bunRoutes)) {
+        bunRoutes[alt] = value;
+        baseBunRoutes[alt] = value;
+      }
+    }
+  }
+
+  async function applyRouteChanges(freshRoutes: Record<string, unknown>): Promise<RouteChangeCounts> {
+    const counts: RouteChangeCounts = { updated: 0, added: [], removed: [], api: 0, ws: 0, sse: 0, page: 0, file: 0 };
     const freshPatterns = new Set(Object.keys(freshRoutes));
 
     for (const [pattern, handler] of Object.entries(freshRoutes)) {
@@ -430,98 +564,39 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       if (!type) {
         continue;
       }
-
       if (knownEntryPatterns.has(pattern)) {
-        const currentType = currentRouteType(pattern);
-
-        if (currentType && currentType !== type && registerRoutePattern && unregisterRoutePattern) {
-          unregisterRoutePattern(pattern);
-          removeBunRoute(pattern, currentType);
-          const result = await registerRoutePattern(pattern, handler as MochiRouteValue);
-          if (result) {
-            addBunRoute(pattern, result.bunRouteValue, result.type);
-            counts.added.push(pattern);
-            counts.removed.push(pattern);
-            logger.info(`Route retyped ${currentType}→${type}: ${pattern}`);
-          }
-        } else if (type === 'file' && registerRoutePattern && unregisterRoutePattern) {
-          // File routes have no handler map to mutate in place — their source
-          // is baked into the registered closure — so swap by re-registering.
-          unregisterRoutePattern(pattern);
-          removeBunRoute(pattern, 'file');
-          const result = await registerRoutePattern(pattern, handler as MochiRouteValue);
-          if (result) {
-            addBunRoute(pattern, result.bunRouteValue, result.type);
-            counts.file++;
-            counts.updated++;
-            logger.info(`Route updated file: ${pattern}`);
-          }
-        } else {
-          if (isMochiApi(handler) && apiHandlerMap?.has(pattern)) {
-            apiHandlerMap.set(pattern, handler.handler);
-            updateRouteLimiter?.(pattern, handler.rateLimit);
-            counts.api++;
-            counts.updated++;
-          } else if (isMochiWs(handler) && wsHandlersMap?.has(pattern)) {
-            wsHandlersMap.set(pattern, handler.handlers as MochiWsHandlers<unknown>);
-            counts.ws++;
-            counts.updated++;
-          } else if (isMochiSse(handler) && sseHandlerMap?.has(pattern)) {
-            sseHandlerMap.set(pattern, handler.handler);
-            counts.sse++;
-            counts.updated++;
-          } else if (isMochiPage(handler) && pageConfigMap?.has(pattern)) {
-            pageConfigMap.set(pattern, { serverProps: handler.serverProps, actions: handler.actions });
-            updateRouteLimiter?.(pattern, handler.rateLimit);
-            counts.page++;
-            counts.updated++;
-          }
-        }
-      } else if (registerRoutePattern) {
-        try {
-          const result = await registerRoutePattern(pattern, handler as MochiRouteValue);
-          if (result) {
-            addBunRoute(pattern, result.bunRouteValue, result.type);
-            counts[result.type]++;
-            counts.added.push(pattern);
-            logger.info(`Route added ${result.type}: ${pattern}`);
-          }
-        } catch (e) {
-          logger.warn(`Failed to register route ${pattern}: ${e instanceof Error ? e.message : e}`);
-          counts.added.push(pattern);
-        }
+        await applyExistingRoute(pattern, handler, type, counts);
+      } else {
+        await addNewRoute(pattern, handler, counts);
       }
     }
 
-    if (unregisterRoutePattern) {
-      for (const pattern of knownEntryPatterns) {
-        if (!freshPatterns.has(pattern)) {
-          const removedType = currentRouteType(pattern);
-          unregisterRoutePattern(pattern);
-          removeBunRoute(pattern, removedType);
-          counts.removed.push(pattern);
-          logger.info(`Route removed: ${pattern}`);
-        }
-      }
-    }
-
-    // Deleting an explicitly-declared sibling (`/a/` alongside `/a`) leaves the survivor without the mirror a cold
-    // boot would have given it, so its canonical form would redirect into a 404 until restart.
-    if (trailingSlashPolicy) {
-      for (const pattern of freshPatterns) {
-        const value = bunRoutes[pattern];
-        if (value === undefined || !mirrorsAltSlash(currentRouteType(pattern))) {
-          continue;
-        }
-        const alt = alternateSlashPattern(pattern);
-        if (alt && !(alt in bunRoutes)) {
-          bunRoutes[alt] = value;
-          baseBunRoutes[alt] = value;
-        }
-      }
-    }
+    removeStaleRoutes(freshPatterns, counts);
+    ensureAltSlashMirrors(freshPatterns);
 
     knownEntryPatterns = freshPatterns;
+    return counts;
+  }
+
+  async function reapplyEntryRoutes(freshRoutes: Record<string, unknown>): Promise<RouteChangeCounts> {
+    if (!moduleStateWarned && reachedModuleChurnThreshold(++entryReloadCount)) {
+      mochiEvents.emit('recompile:module-churn', { reloadCount: entryReloadCount });
+      moduleStateWarned = true;
+    }
+    const counts = await applyRouteChanges(freshRoutes);
+    const hasChanges = counts.updated > 0 || counts.added.length > 0 || counts.removed.length > 0;
+    if (hasChanges) {
+      logger.info(`Entry rebuilt — ${summarizeRouteCounts(counts).join(', ')}`);
+    }
+    if (counts.added.length > 0 || counts.removed.length > 0) {
+      server.reload({
+        routes: {
+          ...bunRoutes,
+          '/__mochi_live_reload': liveReloadHandler,
+        },
+        fetch: composedFetch,
+      } as Parameters<typeof server.reload>[0]);
+    }
     return counts;
   }
 
@@ -531,59 +606,11 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       const start = performance.now();
       let summary: { pages: Set<string>; clientBundleCount: number } = { pages: new Set(), clientBundleCount: 0 };
       let failed = false;
-      let counts: { updated: number; added: string[]; removed: string[]; api: number; ws: number; sse: number; page: number; file: number } = {
-        updated: 0,
-        added: [],
-        removed: [],
-        api: 0,
-        ws: 0,
-        sse: 0,
-        page: 0,
-        file: 0,
-      };
+      let counts: RouteChangeCounts = { updated: 0, added: [], removed: [], api: 0, ws: 0, sse: 0, page: 0, file: 0 };
       try {
         const freshRoutes = await buildEntry();
         if (freshRoutes) {
-          if (!moduleStateWarned && reachedModuleChurnThreshold(++entryReloadCount)) {
-            mochiEvents.emit('recompile:module-churn', { reloadCount: entryReloadCount });
-            moduleStateWarned = true;
-          }
-          counts = await applyRouteChanges(freshRoutes);
-          const hasChanges = counts.updated > 0 || counts.added.length > 0 || counts.removed.length > 0;
-          if (hasChanges) {
-            const parts: string[] = [];
-            if (counts.api) {
-              parts.push(`${counts.api} api`);
-            }
-            if (counts.ws) {
-              parts.push(`${counts.ws} ws`);
-            }
-            if (counts.sse) {
-              parts.push(`${counts.sse} sse`);
-            }
-            if (counts.page) {
-              parts.push(`${counts.page} page`);
-            }
-            if (counts.file) {
-              parts.push(`${counts.file} file`);
-            }
-            if (counts.added.length) {
-              parts.push(`+${counts.added.length} new`);
-            }
-            if (counts.removed.length) {
-              parts.push(`-${counts.removed.length} removed`);
-            }
-            logger.info(`Entry rebuilt — ${parts.join(', ')}`);
-          }
-          if (counts.added.length > 0 || counts.removed.length > 0) {
-            server.reload({
-              routes: {
-                ...bunRoutes,
-                '/__mochi_live_reload': liveReloadHandler,
-              },
-              fetch: composedFetch,
-            } as Parameters<typeof server.reload>[0]);
-          }
+          counts = await reapplyEntryRoutes(freshRoutes);
         }
         // A server-entry module can also be inlined into page SSR bundles, so recompile any dependent page here —
         // before the reload below — so the browser fetches fresh HTML in one reload instead of a stale bundle then a

--- a/packages/mochi/src/email/mailer.ts
+++ b/packages/mochi/src/email/mailer.ts
@@ -68,11 +68,8 @@ export function htmlToText(html: string): string {
 }
 
 /** Send one transactional message through the configured transport, falling back to the `log` transport. Callable from route actions, API handlers, and queue jobs alike. */
-export async function sendEmail(message: MochiEmailMessage): Promise<MochiEmailResult> {
-  const runtime = getEmailRuntime();
-  const { options } = runtime;
-
-  const from = message.from ?? options.from;
+async function resolveEmailMessage(runtime: ReturnType<typeof getEmailRuntime>, message: MochiEmailMessage): Promise<ResolvedEmailMessage> {
+  const from = message.from ?? runtime.options.from;
   if (!from) {
     throw new EmailError('No `from` address. Set a message `from` or configure `email.from` in Mochi.serve().');
   }
@@ -99,7 +96,7 @@ export async function sendEmail(message: MochiEmailMessage): Promise<MochiEmailR
   // `component`/`props` are stripped — already rendered into `html` — and the normalized fields are overridden, keeping
   // the raw `string`/array union and an unfilled `from` away from any transport.
   const { component: _component, props: _props, ...passthrough } = message;
-  const resolved: ResolvedEmailMessage = {
+  return {
     ...passthrough,
     from,
     to,
@@ -108,6 +105,13 @@ export async function sendEmail(message: MochiEmailMessage): Promise<MochiEmailR
     html,
     text,
   };
+}
+
+export async function sendEmail(message: MochiEmailMessage): Promise<MochiEmailResult> {
+  const runtime = getEmailRuntime();
+  const { options } = runtime;
+
+  const resolved = await resolveEmailMessage(runtime, message);
 
   // The seam for application code to rewrite an outgoing message — audit BCC, List-Unsubscribe headers, a staging
   // catch-all — or veto it by returning null. It runs before the transport, so the dev outbox and SMTP both deliver the

--- a/packages/mochi/src/email/mailer.ts
+++ b/packages/mochi/src/email/mailer.ts
@@ -67,7 +67,6 @@ export function htmlToText(html: string): string {
   return decodeHtmlEntities(out).replace(/\s+/g, ' ').trim();
 }
 
-/** Send one transactional message through the configured transport, falling back to the `log` transport. Callable from route actions, API handlers, and queue jobs alike. */
 async function resolveEmailMessage(runtime: ReturnType<typeof getEmailRuntime>, message: MochiEmailMessage): Promise<ResolvedEmailMessage> {
   const from = message.from ?? runtime.options.from;
   if (!from) {
@@ -107,6 +106,7 @@ async function resolveEmailMessage(runtime: ReturnType<typeof getEmailRuntime>, 
   };
 }
 
+/** Send one transactional message through the configured transport, falling back to the `log` transport. Callable from route actions, API handlers, and queue jobs alike. */
 export async function sendEmail(message: MochiEmailMessage): Promise<MochiEmailResult> {
   const runtime = getEmailRuntime();
   const { options } = runtime;

--- a/packages/mochi/src/image/config.ts
+++ b/packages/mochi/src/image/config.ts
@@ -91,20 +91,26 @@ export function resolveImageOptions(opts: MochiImageOptions | undefined): Resolv
     defaultFormat,
     defaultQuality,
     outputFormats,
+    inputFormats: o.inputFormats ?? DEFAULT_INPUT_FORMATS,
     maxPixels,
     autoOrient,
-    allowedHosts: o.allowedHosts,
-    ...resolveImageLimits(o),
+    ...resolveRemoteFetchOptions(o),
+    ...resolveCacheOptions(o),
   };
 }
 
-function resolveImageLimits(o: MochiImageOptions) {
+function resolveRemoteFetchOptions(o: MochiImageOptions) {
   return {
-    cacheDir: o.cacheDir ?? './.mochi/image-cache',
-    inputFormats: o.inputFormats ?? DEFAULT_INPUT_FORMATS,
+    allowedHosts: o.allowedHosts,
     blockPrivateNetworks: o.blockPrivateNetworks ?? true,
     fetchTimeoutMs: o.fetchTimeoutMs ?? 10_000,
     maxResponseBytes: o.maxResponseBytes ?? 20 * 1024 * 1024,
+  };
+}
+
+function resolveCacheOptions(o: MochiImageOptions) {
+  return {
+    cacheDir: o.cacheDir ?? './.mochi/image-cache',
     timeToStale: o.timeToStale ?? 14_400_000,
     timeToEvict: o.timeToEvict ?? 86_400_000,
     compressPayload: o.compressPayload ?? true,

--- a/packages/mochi/src/image/config.ts
+++ b/packages/mochi/src/image/config.ts
@@ -87,15 +87,21 @@ export function resolveImageOptions(opts: MochiImageOptions | undefined): Resolv
   return {
     enabled: o.enabled ?? true,
     sizes,
-    cacheDir: o.cacheDir ?? './.mochi/image-cache',
     storage: o.storage,
     defaultFormat,
     defaultQuality,
     outputFormats,
-    inputFormats: o.inputFormats ?? DEFAULT_INPUT_FORMATS,
     maxPixels,
     autoOrient,
     allowedHosts: o.allowedHosts,
+    ...resolveImageLimits(o),
+  };
+}
+
+function resolveImageLimits(o: MochiImageOptions) {
+  return {
+    cacheDir: o.cacheDir ?? './.mochi/image-cache',
+    inputFormats: o.inputFormats ?? DEFAULT_INPUT_FORMATS,
     blockPrivateNetworks: o.blockPrivateNetworks ?? true,
     fetchTimeoutMs: o.fetchTimeoutMs ?? 10_000,
     maxResponseBytes: o.maxResponseBytes ?? 20 * 1024 * 1024,

--- a/packages/mochi/src/image/imageEndpoint.ts
+++ b/packages/mochi/src/image/imageEndpoint.ts
@@ -2,12 +2,13 @@ import { getImageRuntime, getSize } from './config';
 import { getCachedOriginal } from './imageApi';
 import { decryptImageRequest } from './imageCrypto';
 import { originalId, variantId } from './imageCache';
+import type { ImageCache } from './imageCache';
 import { getMochiConfig } from '../mochiConfig';
 import { logger } from '../utils/log';
 import { baseContentType, INLINE_SAFE_IMAGE_TYPES } from '../utils/inlineContentTypeSafety';
 import { runPipeline } from './resize';
 import { ImageError } from './types';
-import type { ResolvedImageSize } from './types';
+import type { ResolvedImageSize, ResolvedImageOptions } from './types';
 
 function textResponse(status: number, message: string): Response {
   return new Response(message, {
@@ -92,76 +93,84 @@ export function createImageHandler(): (req: Request) => Promise<Response> {
     // Full-size original: serve the shared cached bytes verbatim (originals may be
     // gif/svg/etc.). Covers explicit originals and unknown-size fallbacks.
     if (!size) {
-      try {
-        const { bytes, contentType, status, createdAt } = await getCachedOriginal(request.src, options, cache);
-        const etag = `"${originalId(request.src)}-${createdAt}"`;
-        const cacheControl = resolveImageCacheControl(options.timeToStale, options.timeToEvict, development);
-        if (req.headers.get('if-none-match') === etag) {
-          return new Response(null, { status: 304, headers: { ETag: etag, 'X-Content-Type-Options': 'nosniff', ...(cacheControl ? { 'Cache-Control': cacheControl } : {}) } });
-        }
-        const safe = safeOriginalContentType(contentType);
-        return new Response(bytes as unknown as BodyInit, {
-          status: 200,
-          headers: {
-            'Content-Type': safe.contentType,
-            'Content-Length': String(bytes.byteLength),
-            'X-Content-Type-Options': 'nosniff',
-            ...(safe.attachment ? { 'Content-Disposition': 'attachment' } : {}),
-            ETag: etag,
-            ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
-            'X-Mochi-Cache': status,
-          },
-        });
-      } catch (err) {
-        if (err instanceof ImageError) {
-          return textResponse(err.status, err.message);
-        }
-        return textResponse(500, 'Image processing failed');
-      }
+      return serveOriginalImage(req, request.src, options, cache, development);
     }
 
-    try {
-      const id = variantId(request.src, size.configHash);
-      const { entry, status } = await cache.getVariant(request.src, id, async () => {
-        const { bytes, createdAt } = await getCachedOriginal(request.src, options, cache);
-        const result = await runPipeline(bytes, size, options);
-        return {
-          bytes: result.bytes,
-          contentType: result.contentType,
-          width: result.width,
-          height: result.height,
-          format: result.format,
-          originalCreatedAt: createdAt,
-        };
-      });
-
-      // The ETag carries the variant id, which folds in the size config hash, plus the original generation the bytes
-      // came from, so a redefinition and a source refresh both revalidate while a re-encode from the same generation
-      // keeps its ETag and avoids a spurious re-download.
-      const etag = `"${id}-${entry.meta.originalCreatedAt ?? entry.meta.createdAt}"`;
-      const cacheControl = resolveImageCacheControl(options.timeToStale, options.timeToEvict, development);
-      if (req.headers.get('if-none-match') === etag) {
-        return new Response(null, { status: 304, headers: { ETag: etag, 'X-Content-Type-Options': 'nosniff', ...(cacheControl ? { 'Cache-Control': cacheControl } : {}) } });
-      }
-
-      // Uint8Array is a valid BodyInit at runtime; the cast bridges the
-      // ArrayBufferLike/ArrayBuffer generic mismatch in the DOM lib types.
-      return new Response(entry.bytes as unknown as BodyInit, {
-        status: 200,
-        headers: {
-          'Content-Type': entry.meta.contentType,
-          'Content-Length': String(entry.bytes.byteLength),
-          'X-Content-Type-Options': 'nosniff',
-          ETag: etag,
-          ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
-          'X-Mochi-Cache': status,
-        },
-      });
-    } catch (err) {
-      if (err instanceof ImageError) {
-        return textResponse(err.status, err.message);
-      }
-      return textResponse(500, 'Image processing failed');
-    }
+    return serveVariantImage(req, request.src, size, options, cache, development);
   };
+}
+
+async function serveOriginalImage(req: Request, src: string, options: ResolvedImageOptions, cache: ImageCache, development: boolean): Promise<Response> {
+  try {
+    const { bytes, contentType, status, createdAt } = await getCachedOriginal(src, options, cache);
+    const etag = `"${originalId(src)}-${createdAt}"`;
+    const cacheControl = resolveImageCacheControl(options.timeToStale, options.timeToEvict, development);
+    if (req.headers.get('if-none-match') === etag) {
+      return new Response(null, { status: 304, headers: { ETag: etag, 'X-Content-Type-Options': 'nosniff', ...(cacheControl ? { 'Cache-Control': cacheControl } : {}) } });
+    }
+    const safe = safeOriginalContentType(contentType);
+    return new Response(bytes as unknown as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': safe.contentType,
+        'Content-Length': String(bytes.byteLength),
+        'X-Content-Type-Options': 'nosniff',
+        ...(safe.attachment ? { 'Content-Disposition': 'attachment' } : {}),
+        ETag: etag,
+        ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
+        'X-Mochi-Cache': status,
+      },
+    });
+  } catch (err) {
+    if (err instanceof ImageError) {
+      return textResponse(err.status, err.message);
+    }
+    return textResponse(500, 'Image processing failed');
+  }
+}
+
+async function serveVariantImage(req: Request, src: string, size: ResolvedImageSize, options: ResolvedImageOptions, cache: ImageCache, development: boolean): Promise<Response> {
+  try {
+    const id = variantId(src, size.configHash);
+    const { entry, status } = await cache.getVariant(src, id, async () => {
+      const { bytes, createdAt } = await getCachedOriginal(src, options, cache);
+      const result = await runPipeline(bytes, size, options);
+      return {
+        bytes: result.bytes,
+        contentType: result.contentType,
+        width: result.width,
+        height: result.height,
+        format: result.format,
+        originalCreatedAt: createdAt,
+      };
+    });
+
+    // The ETag carries the variant id, which folds in the size config hash, plus the original generation the bytes
+    // came from, so a redefinition and a source refresh both revalidate while a re-encode from the same generation
+    // keeps its ETag and avoids a spurious re-download.
+    const etag = `"${id}-${entry.meta.originalCreatedAt ?? entry.meta.createdAt}"`;
+    const cacheControl = resolveImageCacheControl(options.timeToStale, options.timeToEvict, development);
+    if (req.headers.get('if-none-match') === etag) {
+      return new Response(null, { status: 304, headers: { ETag: etag, 'X-Content-Type-Options': 'nosniff', ...(cacheControl ? { 'Cache-Control': cacheControl } : {}) } });
+    }
+
+    // Uint8Array is a valid BodyInit at runtime; the cast bridges the
+    // ArrayBufferLike/ArrayBuffer generic mismatch in the DOM lib types.
+    return new Response(entry.bytes as unknown as BodyInit, {
+      status: 200,
+      headers: {
+        'Content-Type': entry.meta.contentType,
+        'Content-Length': String(entry.bytes.byteLength),
+        'X-Content-Type-Options': 'nosniff',
+        ETag: etag,
+        ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
+        'X-Mochi-Cache': status,
+      },
+    });
+  } catch (err) {
+    if (err instanceof ImageError) {
+      return textResponse(err.status, err.message);
+    }
+    return textResponse(500, 'Image processing failed');
+  }
 }

--- a/packages/mochi/src/image/imageEndpoint.ts
+++ b/packages/mochi/src/image/imageEndpoint.ts
@@ -100,27 +100,34 @@ export function createImageHandler(): (req: Request) => Promise<Response> {
   };
 }
 
-async function serveOriginalImage(req: Request, src: string, options: ResolvedImageOptions, cache: ImageCache, development: boolean): Promise<Response> {
+// The one place image bytes become an HTTP response, so conditional-request handling and cache/security headers can
+// never diverge between originals and variants.
+function respondWithImageBytes(
+  req: Request,
+  bytes: Uint8Array,
+  meta: { etag: string; cacheControl: string | undefined; cacheStatus: string; contentType: string; attachment?: boolean },
+): Response {
+  const validators = { ETag: meta.etag, 'X-Content-Type-Options': 'nosniff', ...(meta.cacheControl ? { 'Cache-Control': meta.cacheControl } : {}) };
+  if (req.headers.get('if-none-match') === meta.etag) {
+    return new Response(null, { status: 304, headers: validators });
+  }
+  // Uint8Array is a valid BodyInit at runtime; the cast bridges the
+  // ArrayBufferLike/ArrayBuffer generic mismatch in the DOM lib types.
+  return new Response(bytes as unknown as BodyInit, {
+    status: 200,
+    headers: {
+      'Content-Type': meta.contentType,
+      'Content-Length': String(bytes.byteLength),
+      ...(meta.attachment ? { 'Content-Disposition': 'attachment' } : {}),
+      ...validators,
+      'X-Mochi-Cache': meta.cacheStatus,
+    },
+  });
+}
+
+async function serveImage(fn: () => Promise<Response>): Promise<Response> {
   try {
-    const { bytes, contentType, status, createdAt } = await getCachedOriginal(src, options, cache);
-    const etag = `"${originalId(src)}-${createdAt}"`;
-    const cacheControl = resolveImageCacheControl(options.timeToStale, options.timeToEvict, development);
-    if (req.headers.get('if-none-match') === etag) {
-      return new Response(null, { status: 304, headers: { ETag: etag, 'X-Content-Type-Options': 'nosniff', ...(cacheControl ? { 'Cache-Control': cacheControl } : {}) } });
-    }
-    const safe = safeOriginalContentType(contentType);
-    return new Response(bytes as unknown as BodyInit, {
-      status: 200,
-      headers: {
-        'Content-Type': safe.contentType,
-        'Content-Length': String(bytes.byteLength),
-        'X-Content-Type-Options': 'nosniff',
-        ...(safe.attachment ? { 'Content-Disposition': 'attachment' } : {}),
-        ETag: etag,
-        ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
-        'X-Mochi-Cache': status,
-      },
-    });
+    return await fn();
   } catch (err) {
     if (err instanceof ImageError) {
       return textResponse(err.status, err.message);
@@ -129,8 +136,18 @@ async function serveOriginalImage(req: Request, src: string, options: ResolvedIm
   }
 }
 
-async function serveVariantImage(req: Request, src: string, size: ResolvedImageSize, options: ResolvedImageOptions, cache: ImageCache, development: boolean): Promise<Response> {
-  try {
+function serveOriginalImage(req: Request, src: string, options: ResolvedImageOptions, cache: ImageCache, development: boolean): Promise<Response> {
+  return serveImage(async () => {
+    const { bytes, contentType, status, createdAt } = await getCachedOriginal(src, options, cache);
+    const etag = `"${originalId(src)}-${createdAt}"`;
+    const cacheControl = resolveImageCacheControl(options.timeToStale, options.timeToEvict, development);
+    const safe = safeOriginalContentType(contentType);
+    return respondWithImageBytes(req, bytes, { etag, cacheControl, cacheStatus: status, contentType: safe.contentType, attachment: safe.attachment });
+  });
+}
+
+function serveVariantImage(req: Request, src: string, size: ResolvedImageSize, options: ResolvedImageOptions, cache: ImageCache, development: boolean): Promise<Response> {
+  return serveImage(async () => {
     const id = variantId(src, size.configHash);
     const { entry, status } = await cache.getVariant(src, id, async () => {
       const { bytes, createdAt } = await getCachedOriginal(src, options, cache);
@@ -150,27 +167,6 @@ async function serveVariantImage(req: Request, src: string, size: ResolvedImageS
     // keeps its ETag and avoids a spurious re-download.
     const etag = `"${id}-${entry.meta.originalCreatedAt ?? entry.meta.createdAt}"`;
     const cacheControl = resolveImageCacheControl(options.timeToStale, options.timeToEvict, development);
-    if (req.headers.get('if-none-match') === etag) {
-      return new Response(null, { status: 304, headers: { ETag: etag, 'X-Content-Type-Options': 'nosniff', ...(cacheControl ? { 'Cache-Control': cacheControl } : {}) } });
-    }
-
-    // Uint8Array is a valid BodyInit at runtime; the cast bridges the
-    // ArrayBufferLike/ArrayBuffer generic mismatch in the DOM lib types.
-    return new Response(entry.bytes as unknown as BodyInit, {
-      status: 200,
-      headers: {
-        'Content-Type': entry.meta.contentType,
-        'Content-Length': String(entry.bytes.byteLength),
-        'X-Content-Type-Options': 'nosniff',
-        ETag: etag,
-        ...(cacheControl ? { 'Cache-Control': cacheControl } : {}),
-        'X-Mochi-Cache': status,
-      },
-    });
-  } catch (err) {
-    if (err instanceof ImageError) {
-      return textResponse(err.status, err.message);
-    }
-    return textResponse(500, 'Image processing failed');
-  }
+    return respondWithImageBytes(req, entry.bytes, { etag, cacheControl, cacheStatus: status, contentType: entry.meta.contentType });
+  });
 }

--- a/packages/mochi/src/image/resize.ts
+++ b/packages/mochi/src/image/resize.ts
@@ -76,6 +76,36 @@ export async function runPipeline(input: Uint8Array, size: ResolvedImageSize, op
     width = Math.max(1, Math.round(meta.width * (height / meta.height)));
   }
 
+  const pipe = applyImageTransforms(img, size, width, height);
+
+  let out: Uint8Array;
+  try {
+    out = await pipe.bytes();
+  } catch (err) {
+    if (isUnsupportedFormatError(err)) {
+      throw new ImageError(415, 'Output format unsupported on this platform');
+    }
+    throw new ImageError(500, 'Image encode failed');
+  }
+
+  let outMeta: Bun.Image.Metadata;
+  try {
+    outMeta = await new Image(out).metadata();
+  } catch {
+    outMeta = { width: width ?? meta.width, height: height ?? meta.height, format: size.format };
+  }
+
+  return {
+    bytes: out,
+    contentType: MIME[size.format],
+    width: outMeta.width,
+    height: outMeta.height,
+    format: size.format,
+  };
+}
+
+// resize → rotate → flip → flop → modulate → format-encode, in that fixed order.
+function applyImageTransforms(img: Bun.Image, size: ResolvedImageSize, width: number | undefined, height: number | undefined): Bun.Image {
   let pipe = img;
   if (width) {
     const resizeOpts: Bun.Image.ResizeOptions = { fit: size.fit };
@@ -111,31 +141,7 @@ export async function runPipeline(input: Uint8Array, size: ResolvedImageSize, op
       pipe = pipe.png();
       break;
   }
-
-  let out: Uint8Array;
-  try {
-    out = await pipe.bytes();
-  } catch (err) {
-    if (isUnsupportedFormatError(err)) {
-      throw new ImageError(415, 'Output format unsupported on this platform');
-    }
-    throw new ImageError(500, 'Image encode failed');
-  }
-
-  let outMeta: Bun.Image.Metadata;
-  try {
-    outMeta = await new Image(out).metadata();
-  } catch {
-    outMeta = { width: width ?? meta.width, height: height ?? meta.height, format: size.format };
-  }
-
-  return {
-    bytes: out,
-    contentType: MIME[size.format],
-    width: outMeta.width,
-    height: outMeta.height,
-    format: size.format,
-  };
+  return pipe;
 }
 
 export async function computePlaceholder(input: Uint8Array, opts: ResolvedImageOptions): Promise<string> {

--- a/packages/mochi/src/image/resize.ts
+++ b/packages/mochi/src/image/resize.ts
@@ -104,7 +104,6 @@ export async function runPipeline(input: Uint8Array, size: ResolvedImageSize, op
   };
 }
 
-// resize → rotate → flip → flop → modulate → format-encode, in that fixed order.
 function applyImageTransforms(img: Bun.Image, size: ResolvedImageSize, width: number | undefined, height: number | undefined): Bun.Image {
   let pipe = img;
   if (width) {

--- a/packages/mochi/src/protection/config.ts
+++ b/packages/mochi/src/protection/config.ts
@@ -12,27 +12,31 @@ export const PROTECTION_CLEARANCE_COOKIE = '_mochi_clearance';
 /** Absolute path of the built-in interstitial component — the default `protection.page`, and the file to copy when authoring a custom one. */
 export const PROTECTION_SHELL_COMPONENT = Bun.fileURLToPath(new URL('../templates/ProtectionShell/ProtectionShell.svelte', import.meta.url));
 
-export function resolveProtectionOptions(opts: MochiProtectionOptions, fallbackBits: number): ResolvedProtectionOptions {
-  const bits = opts.bits ?? fallbackBits;
+function assertValidProtectionOptions(opts: MochiProtectionOptions, bits: number, maxAgeMs: number, maxAttempts: number, cookieName: string): void {
   if (!Number.isInteger(bits) || bits < 1 || bits > 32) {
     throw new Error(`Protection: bits must be an integer between 1 and 32, got ${bits}`);
   }
-  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_PROTECTION_MAX_AGE_MS;
   if (!Number.isFinite(maxAgeMs) || maxAgeMs <= 0) {
     throw new Error(`Protection: maxAgeMs must be a positive finite number, got ${maxAgeMs}`);
   }
   if (opts.protect !== undefined && typeof opts.protect !== 'function') {
     throw new Error('Protection: protect must be a function returning a boolean');
   }
-  const maxAttempts = opts.maxAttempts ?? DEFAULT_PROTECTION_MAX_ATTEMPTS;
   if (!Number.isInteger(maxAttempts) || maxAttempts < 1) {
     throw new Error(`Protection: maxAttempts must be a positive integer, got ${maxAttempts}`);
   }
-  const cookieName = opts.cookieName ?? PROTECTION_CLEARANCE_COOKIE;
   // RFC 6265 token characters — anything else silently breaks Set-Cookie parsing in some clients.
   if (!/^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/.test(cookieName)) {
     throw new Error(`Protection: cookieName must be a valid cookie name (RFC 6265 token), got ${JSON.stringify(cookieName)}`);
   }
+}
+
+export function resolveProtectionOptions(opts: MochiProtectionOptions, fallbackBits: number): ResolvedProtectionOptions {
+  const bits = opts.bits ?? fallbackBits;
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_PROTECTION_MAX_AGE_MS;
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_PROTECTION_MAX_ATTEMPTS;
+  const cookieName = opts.cookieName ?? PROTECTION_CLEARANCE_COOKIE;
+  assertValidProtectionOptions(opts, bits, maxAgeMs, maxAttempts, cookieName);
   return {
     enabled: opts.enabled,
     protect: opts.protect,

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -636,7 +636,7 @@ function producerMethods<T>(name: string): MochiQueue<T> {
   };
 }
 
-const QUEUE_NAME_RE = /^[\w.\-/]+$/;
+export const QUEUE_NAME_RE = /^[\w.\-/]+$/;
 
 function noStorageError(name: string): Error {
   return new Error(

--- a/packages/mochi/src/queue.ts
+++ b/packages/mochi/src/queue.ts
@@ -977,6 +977,10 @@ export async function startCronRuntime(jobs: MochiCronJob[], opts: StartCronOpti
     ...(opts.workerPollingSeconds ? { pollingIntervalSeconds: opts.workerPollingSeconds } : {}),
   } as WorkOptions & { includeMetadata: true; perJobResults: true };
 
+  await scheduleCronJobs(boss, active, cronWorkOptions);
+}
+
+async function scheduleCronJobs(boss: BunBoss, active: MochiCronJob[], cronWorkOptions: WorkOptions & { includeMetadata: true; perJobResults: true }): Promise<void> {
   for (const job of active) {
     const queueName = cronQueueName(job.name);
     await boss.createQueue(queueName); // idempotent (ON CONFLICT DO NOTHING); config-preserving on an existing queue.

--- a/packages/mochi/src/runtime/csrf.ts
+++ b/packages/mochi/src/runtime/csrf.ts
@@ -132,20 +132,28 @@ function csrfCheckDefault(
 
   const expectedOriginConfigured = Boolean(proxy?.origin || proxy?.hostHeader);
   if (!expectedOriginConfigured) {
-    if (development) {
-      logger.warn(
-        `CSRF: ${request.method} ${url.pathname} would be blocked in production: no proxy.origin or proxy.hostHeader configured, so the expected origin can't be trusted. Set Mochi.serve({ proxy: { origin: '...' } }) before deploying.`,
-      );
-      return null;
-    }
-    const message = `Cross-site ${request.method} form submissions are forbidden`;
-    const reason = 'Mochi is running in production mode without proxy.origin or proxy.hostHeader configured.';
-    logger.warn(
-      `CSRF: blocking ${request.method} ${url.pathname} from origin ${request.headers.get('origin') ?? '<missing>'}: no proxy.origin or proxy.hostHeader configured, so the expected origin can't be trusted. Set Mochi.serve({ proxy: { origin: '...' } }).`,
-    );
-    return csrfForbidden(request, message, reason);
+    return csrfUnconfiguredDecision(request, url, development);
   }
 
+  return csrfOriginMatchDecision(request, url, proxy, development, trustedOrigins);
+}
+
+function csrfUnconfiguredDecision(request: Request, url: URL, development: boolean): Response | null {
+  if (development) {
+    logger.warn(
+      `CSRF: ${request.method} ${url.pathname} would be blocked in production: no proxy.origin or proxy.hostHeader configured, so the expected origin can't be trusted. Set Mochi.serve({ proxy: { origin: '...' } }) before deploying.`,
+    );
+    return null;
+  }
+  const message = `Cross-site ${request.method} form submissions are forbidden`;
+  const reason = 'Mochi is running in production mode without proxy.origin or proxy.hostHeader configured.';
+  logger.warn(
+    `CSRF: blocking ${request.method} ${url.pathname} from origin ${request.headers.get('origin') ?? '<missing>'}: no proxy.origin or proxy.hostHeader configured, so the expected origin can't be trusted. Set Mochi.serve({ proxy: { origin: '...' } }).`,
+  );
+  return csrfForbidden(request, message, reason);
+}
+
+function csrfOriginMatchDecision(request: Request, url: URL, proxy: MochiProxyOptions | undefined, development: boolean, trustedOrigins: ReadonlySet<string>): Response | null {
   const expectedOrigin = resolveExpectedOrigin(request, url, proxy);
   const origin = request.headers.get('origin');
   const expectedNormalized = normalizeOrigin(expectedOrigin);

--- a/packages/mochi/src/runtime/enhance.client.test.ts
+++ b/packages/mochi/src/runtime/enhance.client.test.ts
@@ -477,4 +477,43 @@ describe('error results are always logged', () => {
     errorSpy.mockRestore();
     cleanup();
   });
+
+  test('a throw while building the request body is reported as an error result, not an unhandled rejection', async () => {
+    const form = makeForm();
+    setFetch(() => Promise.resolve(new Response('{"type":"success"}')));
+    const errorSpy = spyOn(logger, 'error').mockImplementation(() => {});
+    const RealURLSearchParams = globalThis.URLSearchParams;
+    globalThis.URLSearchParams = class {
+      constructor() {
+        throw new TypeError('body serialisation blew up');
+      }
+    } as unknown as typeof URLSearchParams;
+
+    const settled = deferred();
+    let seen: unknown;
+    const cleanup = attach(form, {
+      submit:
+        () =>
+        ({ result }) => {
+          seen = result;
+          settled.resolve();
+        },
+      onPending: (v) => {
+        if (!v) {
+          setTimeout(() => settled.resolve(), 0);
+        }
+      },
+    });
+
+    try {
+      dispatchSubmit(form);
+      await settled.promise;
+      expect(seen).toEqual({ type: 'error', error: expect.any(TypeError) });
+      expect(errorSpy.mock.calls.filter(([label]) => label === 'enhance:')).toHaveLength(1);
+    } finally {
+      globalThis.URLSearchParams = RealURLSearchParams;
+      errorSpy.mockRestore();
+      cleanup();
+    }
+  });
 });

--- a/packages/mochi/src/runtime/enhance.client.ts
+++ b/packages/mochi/src/runtime/enhance.client.ts
@@ -15,6 +15,50 @@ export function deserialize<Success extends MochiFormShape = MochiFormShape, Fai
 }
 
 // Shallow-cloning keeps attribute-named inputs like `<input name="action">` from shadowing real form properties on read.
+// An `<input type="file">` without `enctype="multipart/form-data"` silently coerces the file to its filename, or an
+// empty string, on the wire. See https://github.com/sveltejs/kit/issues/9819.
+function assertMultipartForFiles(formData: FormData, enctype: string): void {
+  if (enctype === 'multipart/form-data') {
+    return;
+  }
+  for (const value of formData.values()) {
+    if (typeof value !== 'string') {
+      throw new Error('Form contains <input type="file"> but is missing enctype="multipart/form-data". Native and enhanced submissions would behave differently.');
+    }
+  }
+}
+
+// POST the form as an enhanced action; returns the deserialized result, or null when the request was aborted mid-flight.
+async function performEnhancedSubmit<Success extends MochiFormShape, Failure extends MochiFormShape>(
+  action: URL,
+  enctype: string,
+  formData: FormData,
+  controller: AbortController,
+): Promise<MochiEnhanceResult<Success, Failure> | null> {
+  const headers = new Headers({ accept: 'application/json', 'x-mochi-action': 'true' });
+  // For multipart, leave Content-Type unset so fetch can generate the full `multipart/form-data; boundary=...` header —
+  // setting it ourselves would drop the boundary and the server couldn't parse the body.
+  if (enctype !== 'multipart/form-data') {
+    headers.set('Content-Type', enctype === 'text/plain' ? 'text/plain' : 'application/x-www-form-urlencoded');
+  }
+  // `URLSearchParams` accepts `FormData` at runtime via its iterable interface, but lib.dom.d.ts types it more narrowly.
+  // @ts-expect-error - FormData is iterable and accepted at runtime
+  const body: BodyInit = enctype === 'multipart/form-data' ? formData : new URLSearchParams(formData);
+  try {
+    const response = await fetch(action, { method: 'POST', headers, cache: 'no-store', body, signal: controller.signal });
+    const result = deserialize<Success, Failure>(await response.text());
+    if (result.type === 'error') {
+      result.status = response.status;
+    }
+    return result;
+  } catch (err: unknown) {
+    if ((err as { name?: string } | null)?.name === 'AbortError') {
+      return null;
+    }
+    return { type: 'error', error: err };
+  }
+}
+
 function clone<T extends HTMLElement>(element: T): T {
   return HTMLElement.prototype.cloneNode.call(element) as T;
 }
@@ -82,15 +126,7 @@ export function enhance<Success extends MochiFormShape = MochiFormShape, Failure
       const enctype = submitter?.hasAttribute('formenctype') ? submitter.formEnctype : formClone.enctype;
       const formData = new FormData(formElement, submitter);
 
-      // An `<input type="file">` without `enctype="multipart/form-data"` silently coerces the file to its filename, or
-      // an empty string, on the wire. See https://github.com/sveltejs/kit/issues/9819.
-      if (enctype !== 'multipart/form-data') {
-        for (const value of formData.values()) {
-          if (typeof value !== 'string') {
-            throw new Error('Form contains <input type="file"> but is missing enctype="multipart/form-data". Native and enhanced submissions would behave differently.');
-          }
-        }
-      }
+      assertMultipartForFiles(formData, enctype);
 
       const controller = new AbortController();
 
@@ -115,41 +151,10 @@ export function enhance<Success extends MochiFormShape = MochiFormShape, Failure
 
         const callback = userCallback ?? fallbackCallback;
 
-        let result: MochiEnhanceResult<Success, Failure>;
-        try {
-          const headers = new Headers({
-            accept: 'application/json',
-            'x-mochi-action': 'true',
-          });
-          // For multipart, leave Content-Type unset so fetch can generate the full
-          // `multipart/form-data; boundary=...` header — setting it ourselves would
-          // drop the boundary and the server couldn't parse the body.
-          if (enctype !== 'multipart/form-data') {
-            headers.set('Content-Type', enctype === 'text/plain' ? 'text/plain' : 'application/x-www-form-urlencoded');
-          }
-          // `URLSearchParams` accepts `FormData` at runtime via its iterable
-          // interface, but lib.dom.d.ts only types `string | string[][] |
-          // Record<string,string> | URLSearchParams`. See
-          // https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/URLSearchParams.
-          // @ts-expect-error - FormData is iterable and accepted at runtime
-          const body: BodyInit = enctype === 'multipart/form-data' ? formData : new URLSearchParams(formData);
-
-          const response = await fetch(action, {
-            method: 'POST',
-            headers,
-            cache: 'no-store',
-            body,
-            signal: controller.signal,
-          });
-          result = deserialize<Success, Failure>(await response.text());
-          if (result.type === 'error') {
-            result.status = response.status;
-          }
-        } catch (err: unknown) {
-          if ((err as { name?: string } | null)?.name === 'AbortError') {
-            return;
-          }
-          result = { type: 'error', error: err };
+        const result = await performEnhancedSubmit<Success, Failure>(action, enctype, formData, controller);
+        // AbortError: the submit was cancelled mid-flight, so skip the callback dispatch entirely.
+        if (result === null) {
+          return;
         }
 
         // Logged before the callback dispatch so a custom handler that only branches on

--- a/packages/mochi/src/runtime/enhance.client.ts
+++ b/packages/mochi/src/runtime/enhance.client.ts
@@ -14,7 +14,6 @@ export function deserialize<Success extends MochiFormShape = MochiFormShape, Fai
   return parsed;
 }
 
-// Shallow-cloning keeps attribute-named inputs like `<input name="action">` from shadowing real form properties on read.
 // An `<input type="file">` without `enctype="multipart/form-data"` silently coerces the file to its filename, or an
 // empty string, on the wire. See https://github.com/sveltejs/kit/issues/9819.
 function assertMultipartForFiles(formData: FormData, enctype: string): void {
@@ -28,23 +27,24 @@ function assertMultipartForFiles(formData: FormData, enctype: string): void {
   }
 }
 
-// POST the form as an enhanced action; returns the deserialized result, or null when the request was aborted mid-flight.
 async function performEnhancedSubmit<Success extends MochiFormShape, Failure extends MochiFormShape>(
   action: URL,
   enctype: string,
   formData: FormData,
   controller: AbortController,
 ): Promise<MochiEnhanceResult<Success, Failure> | null> {
-  const headers = new Headers({ accept: 'application/json', 'x-mochi-action': 'true' });
-  // For multipart, leave Content-Type unset so fetch can generate the full `multipart/form-data; boundary=...` header —
-  // setting it ourselves would drop the boundary and the server couldn't parse the body.
-  if (enctype !== 'multipart/form-data') {
-    headers.set('Content-Type', enctype === 'text/plain' ? 'text/plain' : 'application/x-www-form-urlencoded');
-  }
-  // `URLSearchParams` accepts `FormData` at runtime via its iterable interface, but lib.dom.d.ts types it more narrowly.
-  // @ts-expect-error - FormData is iterable and accepted at runtime
-  const body: BodyInit = enctype === 'multipart/form-data' ? formData : new URLSearchParams(formData);
+  // Body/header construction stays inside the try so a throw there still surfaces as an `error` result to the caller's
+  // callback rather than escaping `handleSubmit` as an unhandled rejection.
   try {
+    const headers = new Headers({ accept: 'application/json', 'x-mochi-action': 'true' });
+    // For multipart, leave Content-Type unset so fetch can generate the full `multipart/form-data; boundary=...` header —
+    // setting it ourselves would drop the boundary and the server couldn't parse the body.
+    if (enctype !== 'multipart/form-data') {
+      headers.set('Content-Type', enctype === 'text/plain' ? 'text/plain' : 'application/x-www-form-urlencoded');
+    }
+    // `URLSearchParams` accepts `FormData` at runtime via its iterable interface, but lib.dom.d.ts types it more narrowly.
+    // @ts-expect-error - FormData is iterable and accepted at runtime
+    const body: BodyInit = enctype === 'multipart/form-data' ? formData : new URLSearchParams(formData);
     const response = await fetch(action, { method: 'POST', headers, cache: 'no-store', body, signal: controller.signal });
     const result = deserialize<Success, Failure>(await response.text());
     if (result.type === 'error') {
@@ -59,6 +59,7 @@ async function performEnhancedSubmit<Success extends MochiFormShape, Failure ext
   }
 }
 
+// Shallow-cloning keeps attribute-named inputs like `<input name="action">` from shadowing real form properties on read.
 function clone<T extends HTMLElement>(element: T): T {
   return HTMLElement.prototype.cloneNode.call(element) as T;
 }

--- a/packages/mochi/src/runtime/proxy.ts
+++ b/packages/mochi/src/runtime/proxy.ts
@@ -67,6 +67,10 @@ export function resolveExpectedOrigin(request: Request, url: URL, options: Mochi
     return url.origin;
   }
 
+  return originFromHeaders(request, url, protocolHeader, hostHeader, portHeader);
+}
+
+function originFromHeaders(request: Request, url: URL, protocolHeader: string | undefined, hostHeader: string | undefined, portHeader: string | undefined): string {
   const protocolFromHeader = protocolHeader ? request.headers.get(protocolHeader) : null;
   const hostFromHeader = hostHeader ? request.headers.get(hostHeader) : null;
   const portFromHeader = portHeader ? request.headers.get(portHeader) : null;

--- a/packages/mochi/src/runtime/rateLimit.ts
+++ b/packages/mochi/src/runtime/rateLimit.ts
@@ -203,6 +203,14 @@ function parseWindow(window: string | number): number {
  * own `rateLimit` config, while the shared global limiter passes nothing and its routes share one bucket. An explicit
  * `group` wins, and is how you opt back into cross-route sharing.
  */
+function resolveHeaderConfig(headers: MochiRateLimitOptions['headers']): { standard: boolean; legacy: boolean; retryAfter: boolean } {
+  return {
+    standard: headers?.standard ?? true,
+    legacy: headers?.legacy ?? true,
+    retryAfter: headers?.retryAfter ?? true,
+  };
+}
+
 export function createRouteLimiter(options: MochiRateLimitOptions, autoGroup?: string): RouteLimiter {
   const store = options.store ?? memoryStore();
   const userKey = options.key;
@@ -223,11 +231,7 @@ export function createRouteLimiter(options: MochiRateLimitOptions, autoGroup?: s
     tiers: options.tiers,
     tier: userTier ? (req) => userTier(req, getRequestContext()) : undefined,
     response: options.response ?? { hitlimit: true, message: DEFAULT_MESSAGE },
-    headers: {
-      standard: options.headers?.standard ?? true,
-      legacy: options.headers?.legacy ?? true,
-      retryAfter: options.headers?.retryAfter ?? true,
-    },
+    headers: resolveHeaderConfig(options.headers),
     store,
     onStoreError: options.onStoreError ?? (() => 'allow'),
     skip: userSkip ? (req) => userSkip(req, getRequestContext()) : undefined,

--- a/packages/mochi/src/runtime/rateLimit.ts
+++ b/packages/mochi/src/runtime/rateLimit.ts
@@ -197,12 +197,6 @@ function parseWindow(window: string | number): number {
   return parseInt(match[1]) * WINDOW_UNITS[match[2]]!;
 }
 
-/**
- * `autoGroup` namespaces this limiter's stored keys behind a `group:<autoGroup>:` prefix (hitlimit's `resolveKey`), so
- * counters stay separate from another route on the same persisted store. Mochi passes the route pattern for a route's
- * own `rateLimit` config, while the shared global limiter passes nothing and its routes share one bucket. An explicit
- * `group` wins, and is how you opt back into cross-route sharing.
- */
 function resolveHeaderConfig(headers: MochiRateLimitOptions['headers']): { standard: boolean; legacy: boolean; retryAfter: boolean } {
   return {
     standard: headers?.standard ?? true,
@@ -211,6 +205,12 @@ function resolveHeaderConfig(headers: MochiRateLimitOptions['headers']): { stand
   };
 }
 
+/**
+ * `autoGroup` namespaces this limiter's stored keys behind a `group:<autoGroup>:` prefix (hitlimit's `resolveKey`), so
+ * counters stay separate from another route on the same persisted store. Mochi passes the route pattern for a route's
+ * own `rateLimit` config, while the shared global limiter passes nothing and its routes share one bucket. An explicit
+ * `group` wins, and is how you opt back into cross-route sharing.
+ */
 export function createRouteLimiter(options: MochiRateLimitOptions, autoGroup?: string): RouteLimiter {
   const store = options.store ?? memoryStore();
   const userKey = options.key;

--- a/packages/mochi/src/web-components/HydratableIsland.ts
+++ b/packages/mochi/src/web-components/HydratableIsland.ts
@@ -116,23 +116,7 @@ class HydratableIsland extends HTMLElement {
     if (!Component) {
       return;
     }
-    let props: Record<string, unknown>;
-    try {
-      props = propsRaw ? devalueParse(propsRaw) : {};
-    } catch (err) {
-      if (propsRaw && err instanceof SyntaxError) {
-        const m = err.message.match(/position (\d+)/);
-        const pos = m ? Number(m[1]) : -1;
-        if (pos >= 0) {
-          const ch = propsRaw.charCodeAt(pos);
-          const around = propsRaw.slice(Math.max(0, pos - 20), pos + 20);
-          logger.error(`Failed to parse props for "${name}" at position ${pos} (char U+${ch.toString(16).padStart(4, '0')}, len=${propsRaw.length}):`, JSON.stringify(around));
-        } else {
-          logger.error(`Failed to parse props for "${name}" (len=${propsRaw.length}):`, err.message);
-        }
-      }
-      throw err;
-    }
+    const props = parseIslandProps(propsRaw, name);
     // `transformError` makes `<svelte:boundary>` work for client-side errors, like a throw inside `$effect` after
     // hydration. It returns an Error in the same shape as the SSR transformError, `message` enumerable to match, so
     // user-written `failed` snippets can rely on `error instanceof Error`.
@@ -166,6 +150,25 @@ class HydratableIsland extends HTMLElement {
       void unmount(instance);
     };
     logger.log(clientOnly ? 'Mounted' : 'Hydrated', name);
+  }
+}
+
+function parseIslandProps(propsRaw: string | null, name: string): Record<string, unknown> {
+  try {
+    return propsRaw ? devalueParse(propsRaw) : {};
+  } catch (err) {
+    if (propsRaw && err instanceof SyntaxError) {
+      const m = err.message.match(/position (\d+)/);
+      const pos = m ? Number(m[1]) : -1;
+      if (pos >= 0) {
+        const ch = propsRaw.charCodeAt(pos);
+        const around = propsRaw.slice(Math.max(0, pos - 20), pos + 20);
+        logger.error(`Failed to parse props for "${name}" at position ${pos} (char U+${ch.toString(16).padStart(4, '0')}, len=${propsRaw.length}):`, JSON.stringify(around));
+      } else {
+        logger.error(`Failed to parse props for "${name}" (len=${propsRaw.length}):`, err.message);
+      }
+    }
+    throw err;
   }
 }
 

--- a/packages/mochi/src/web-components/ServerIsland.ts
+++ b/packages/mochi/src/web-components/ServerIsland.ts
@@ -127,64 +127,22 @@ class ServerIsland extends HTMLElement {
   }
 
   async _fetchContent(options: Record<string, unknown> = {}): Promise<boolean> {
-    const g = (k: string) => this.getAttribute(k);
-    const componentName = g('component-name');
+    const componentName = this.getAttribute('component-name');
     if (!componentName) {
       return false;
     }
 
     const tag = `[mochi] Server island "${componentName}"`;
     const ll = window.__mochi_log_level;
-    const signedProps = g('signed-props');
-    const alsoHydrate = g('also-hydrate') || '';
-    const assetPrefix = g('data-asset-prefix');
-    let url = `${assetPrefix}/island/${encodeURIComponent(componentName)}`;
-    const params = new URLSearchParams();
-    if (signedProps) {
-      params.set('props', signedProps);
-    }
-    const qs = params.toString();
-    if (qs) {
-      url += `?${qs}`;
-    }
-
-    if (url.length > 1800) {
-      window.__mochi_warn?.(`${tag} URL is ${url.length} chars. Consider reducing prop size.`);
-    }
-
+    const alsoHydrate = this.getAttribute('also-hydrate') || '';
+    const url = buildIslandFetchUrl(componentName, this.getAttribute('signed-props'), this.getAttribute('data-asset-prefix'), tag);
     const maxRetries = typeof options.retries === 'number' ? options.retries : 9;
 
     let lastErr: unknown;
     for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
       try {
-        const response = await fetch(url);
-        if (!response.ok) {
-          if (response.status >= 400 && response.status < 500) {
-            throw Object.assign(new Error(`HTTP ${response.status}`), { abort: true });
-          }
-          throw new Error(`HTTP ${response.status}`);
-        }
-        const html = await response.text();
-
-        if (ll === 'log' || ll === 'debug') {
-          console.log(`${tag} loaded (attempt ${attempt}, ${(html.length / 1024).toFixed(1)}kB, alsoHydrate=${alsoHydrate || 'none'})`);
-        }
-
-        const cssUrl = g('css-url');
-        if (cssUrl && !_css.has(cssUrl)) {
-          _css.add(cssUrl);
-          const link = document.createElement('link');
-          link.rel = 'stylesheet';
-          link.href = cssUrl;
-          document.head.appendChild(link);
-        }
-
-        this._unmountChildren();
-
-        // SAFETY: HTML comes from our own same-origin server-island endpoint with encrypted props.
-        // If the island endpoint ever returns user-controlled content, this must be sanitized.
-        this.innerHTML = html;
-        this._everLoaded = true;
+        const html = await this._loadIslandHtml(url);
+        this._applyIslandResponse(html, alsoHydrate, tag, ll, attempt);
         return true;
       } catch (err) {
         lastErr = err;
@@ -197,8 +155,7 @@ class ServerIsland extends HTMLElement {
           console.warn(`${tag} failed (attempt ${attempt}/${maxRetries + 1}): ${err}`);
         }
         if (attempt <= maxRetries) {
-          const delay = attempt <= 3 ? 1000 : attempt <= 6 ? 3000 : 5000;
-          await new Promise((r) => setTimeout(r, delay));
+          await new Promise((r) => setTimeout(r, islandRetryDelayMs(attempt)));
         }
       }
     }
@@ -210,6 +167,59 @@ class ServerIsland extends HTMLElement {
     window.__mochi_warn?.(msg);
     return false;
   }
+
+  async _loadIslandHtml(url: string): Promise<string> {
+    const response = await fetch(url);
+    if (!response.ok) {
+      if (response.status >= 400 && response.status < 500) {
+        throw Object.assign(new Error(`HTTP ${response.status}`), { abort: true });
+      }
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await response.text();
+  }
+
+  _applyIslandResponse(html: string, alsoHydrate: string, tag: string, ll: string | undefined, attempt: number): void {
+    if (ll === 'log' || ll === 'debug') {
+      console.log(`${tag} loaded (attempt ${attempt}, ${(html.length / 1024).toFixed(1)}kB, alsoHydrate=${alsoHydrate || 'none'})`);
+    }
+
+    const cssUrl = this.getAttribute('css-url');
+    if (cssUrl && !_css.has(cssUrl)) {
+      _css.add(cssUrl);
+      const link = document.createElement('link');
+      link.rel = 'stylesheet';
+      link.href = cssUrl;
+      document.head.appendChild(link);
+    }
+
+    this._unmountChildren();
+
+    // SAFETY: HTML comes from our own same-origin server-island endpoint with encrypted props.
+    // If the island endpoint ever returns user-controlled content, this must be sanitized.
+    this.innerHTML = html;
+    this._everLoaded = true;
+  }
+}
+
+function buildIslandFetchUrl(componentName: string, signedProps: string | null, assetPrefix: string | null, tag: string): string {
+  let url = `${assetPrefix}/island/${encodeURIComponent(componentName)}`;
+  const params = new URLSearchParams();
+  if (signedProps) {
+    params.set('props', signedProps);
+  }
+  const qs = params.toString();
+  if (qs) {
+    url += `?${qs}`;
+  }
+  if (url.length > 1800) {
+    window.__mochi_warn?.(`${tag} URL is ${url.length} chars. Consider reducing prop size.`);
+  }
+  return url;
+}
+
+function islandRetryDelayMs(attempt: number): number {
+  return attempt <= 3 ? 1000 : attempt <= 6 ? 3000 : 5000;
 }
 
 if (!customElements.get('mochi-server-island')) {

--- a/packages/site/scripts/shoot.ts
+++ b/packages/site/scripts/shoot.ts
@@ -186,6 +186,28 @@ const ASPECT = 9 / 16;
 /** Mirrors FILL in src/shot/registry.ts — the fraction of the limiting axis fitScale() aims to fill. */
 const EXPECTED_FILL_PCT = 90;
 
+// A mis-scaled or off-centre subject is invisible in the PNG, so it is checked here rather than by eye.
+function collectShotProblems(measured: Measurement, width: number, height: number, fill: number, consoleErrors: string[], subject: string): string[] {
+  const problems: string[] = [];
+  if (measured.frame.w !== width || measured.frame.h !== height) {
+    problems.push(`frame is ${measured.frame.w}x${measured.frame.h}, expected ${width}x${height}`);
+  }
+  if (measured.viewport.w !== width || measured.viewport.h !== height) {
+    problems.push(`viewport is ${measured.viewport.w}x${measured.viewport.h}, expected ${width}x${height} — the shot would be cropped or letterboxed`);
+  }
+  if (Math.abs(measured.gapLeft - measured.gapRight) > 1 || Math.abs(measured.gapTop - measured.gapBottom) > 1) {
+    problems.push(`subject is off-centre (gaps L${measured.gapLeft} R${measured.gapRight} T${measured.gapTop} B${measured.gapBottom})`);
+  }
+  // fitScale() targets FILL (90%) of the limiting axis; a large miss means `natural` in the registry is wrong.
+  if (Math.abs(fill - EXPECTED_FILL_PCT) > 5) {
+    problems.push(`subject fills ${fill}% of the limiting axis, expected ~90% — check \`natural\` for '${subject}' in src/shot/registry.ts`);
+  }
+  if (consoleErrors.length > 0) {
+    problems.push(`console errors: ${consoleErrors.join(' | ')}`);
+  }
+  return problems;
+}
+
 async function main(): Promise<void> {
   const args = parseCliArgs();
   const width = args.w ?? DEFAULT_WIDTH;
@@ -234,25 +256,8 @@ async function main(): Promise<void> {
     if (measured.error) {
       throw new Error(measured.error);
     }
-    // A mis-scaled or off-centre subject is invisible in the PNG, so it is checked here rather than by eye.
-    const problems: string[] = [];
-    if (measured.frame.w !== width || measured.frame.h !== height) {
-      problems.push(`frame is ${measured.frame.w}x${measured.frame.h}, expected ${width}x${height}`);
-    }
-    if (measured.viewport.w !== width || measured.viewport.h !== height) {
-      problems.push(`viewport is ${measured.viewport.w}x${measured.viewport.h}, expected ${width}x${height} — the shot would be cropped or letterboxed`);
-    }
-    if (Math.abs(measured.gapLeft - measured.gapRight) > 1 || Math.abs(measured.gapTop - measured.gapBottom) > 1) {
-      problems.push(`subject is off-centre (gaps L${measured.gapLeft} R${measured.gapRight} T${measured.gapTop} B${measured.gapBottom})`);
-    }
     const fill = Math.max(measured.pctW, measured.pctH);
-    // fitScale() targets FILL (90%) of the limiting axis; a large miss means `natural` in the registry is wrong.
-    if (Math.abs(fill - EXPECTED_FILL_PCT) > 5) {
-      problems.push(`subject fills ${fill}% of the limiting axis, expected ~90% — check \`natural\` for '${args.subject}' in src/shot/registry.ts`);
-    }
-    if (consoleErrors.length > 0) {
-      problems.push(`console errors: ${consoleErrors.join(' | ')}`);
-    }
+    const problems = collectShotProblems(measured, width, height, fill, consoleErrors, args.subject);
     if (problems.length > 0) {
       console.error(styleText('red', 'Refusing to save a bad shot:'));
       for (const problem of problems) {

--- a/packages/site/src/demos/island-props/devalueTypeOf.ts
+++ b/packages/site/src/demos/island-props/devalueTypeOf.ts
@@ -1,3 +1,13 @@
+const INSTANCE_TYPES: Array<[new (...args: never[]) => object, string]> = [
+  [Date, 'Date'],
+  [RegExp, 'RegExp'],
+  [Map, 'Map'],
+  [Set, 'Set'],
+  [URL, 'URL'],
+  [URLSearchParams, 'URLSearchParams'],
+  [Uint8Array, 'Uint8Array'],
+];
+
 export function typeOf(v: unknown): string {
   if (v === undefined) {
     return 'undefined';
@@ -19,26 +29,10 @@ export function typeOf(v: unknown): string {
       return '-0';
     }
   }
-  if (v instanceof Date) {
-    return 'Date';
-  }
-  if (v instanceof RegExp) {
-    return 'RegExp';
-  }
-  if (v instanceof Map) {
-    return 'Map';
-  }
-  if (v instanceof Set) {
-    return 'Set';
-  }
-  if (v instanceof URL) {
-    return 'URL';
-  }
-  if (v instanceof URLSearchParams) {
-    return 'URLSearchParams';
-  }
-  if (v instanceof Uint8Array) {
-    return 'Uint8Array';
+  for (const [ctor, name] of INSTANCE_TYPES) {
+    if (v instanceof ctor) {
+      return name;
+    }
   }
   if (ArrayBuffer.isView(v)) {
     return (v as { constructor: { name: string } }).constructor.name;

--- a/scripts/check-llms.ts
+++ b/scripts/check-llms.ts
@@ -153,10 +153,7 @@ interface Failure {
   detail: string;
 }
 
-async function main() {
-  const { base, concurrency } = parseArgs(process.argv.slice(2));
-
-  const sitemapXml = await fetchText(`${base}/sitemap.xml`);
+function parseSitemapPages(sitemapXml: string, base: string): string[] {
   const pages: string[] = [];
   const locRe = /<loc>\s*([\s\S]*?)\s*<\/loc>/gi;
   let m: RegExpExecArray | null;
@@ -168,6 +165,142 @@ async function main() {
     }
     pages.push(rebased);
   }
+  return pages;
+}
+
+function buildDeclaredMap(indexJson: { docs: LlmsIndexEntry[]; demos: LlmsIndexEntry[] }, base: string): Map<string, Kind> {
+  const declared = new Map<string, Kind>();
+  for (const [kind, entries] of [
+    ['doc', indexJson.docs],
+    ['demo', indexJson.demos],
+  ] as const) {
+    for (const entry of entries ?? []) {
+      const url = rebase(entry.url, base);
+      if (url !== null) {
+        declared.set(url, kind);
+      }
+    }
+  }
+  return declared;
+}
+
+function slugFromLlmsUrl(url: string): string {
+  return (
+    new URL(url).pathname
+      .replace(/\/llms\.txt$/, '')
+      .split('/')
+      .pop() ?? ''
+  );
+}
+
+function buildTargets(expected: Map<string, Expected>, declared: Map<string, Kind>, base: string): Map<string, Expected> {
+  const targets = new Map<string, Expected>(expected);
+  for (const [url, kind] of declared) {
+    if (!targets.has(url)) {
+      targets.set(url, { url, kind, slug: slugFromLlmsUrl(url), page: '' });
+    }
+  }
+  for (const path of AGGREGATES) {
+    const url = `${base}${path}`;
+    targets.set(url, { url, kind: 'aggregate', slug: path, page: '' });
+  }
+  return targets;
+}
+
+function checkLlmsBody(target: Expected, body: string, contentType: string, suspect: Failure[]): void {
+  const isJson = target.url.endsWith('.json');
+  const isMarkdown = target.url.endsWith('.md');
+  if (isJson ? !contentType.includes('application/json') : !isMarkdown && !contentType.includes('text/plain')) {
+    suspect.push({ url: target.url, detail: `content-type is '${contentType}'` });
+  }
+  if (body.trim().length === 0) {
+    suspect.push({ url: target.url, detail: 'empty body' });
+    return;
+  }
+  if (!isJson && body.trimStart().startsWith('<')) {
+    suspect.push({ url: target.url, detail: 'body looks like HTML — an error page served with a 200?' });
+    return;
+  }
+  if (target.kind === 'demo') {
+    if (!body.startsWith(`## Demo: ${target.slug}`)) {
+      suspect.push({ url: target.url, detail: `expected a '## Demo: ${target.slug}' header, got '${body.slice(0, 40).split('\n')[0]}'` });
+    }
+    // A files.ts path that doesn't exist on disk is only logged server-side and silently dropped from the bundle, so count the fences that survived.
+    const fences = (body.match(/^```/gm) ?? []).length;
+    if (fences < 2) {
+      suspect.push({ url: target.url, detail: 'no fenced source blocks — every declared file was dropped?' });
+    }
+  }
+  if (target.kind === 'doc' && body.length < 100) {
+    suspect.push({ url: target.url, detail: `only ${body.length} bytes` });
+  }
+}
+
+function findMissingFromFull(fullTxt: string | undefined, declared: Map<string, Kind>): Failure[] {
+  const missing: Failure[] = [];
+  if (fullTxt === undefined) {
+    return missing;
+  }
+  for (const [url, kind] of declared) {
+    if (kind !== 'demo') {
+      continue;
+    }
+    const slug = slugFromLlmsUrl(url);
+    if (!fullTxt.includes(`## Demo: ${slug}`)) {
+      missing.push({ url, detail: `demo '${slug}' has no '## Demo: ${slug}' section in /llms-full.txt` });
+    }
+  }
+  return missing;
+}
+
+function findMissingFromIndex(indexTxt: string | undefined, declared: Map<string, Kind>, base: string): Failure[] {
+  const missing: Failure[] = [];
+  if (indexTxt === undefined) {
+    return missing;
+  }
+  const listed = new Set<string>();
+  const linkRe = /\]\((https?:\/\/[^)\s]+)\)/g;
+  let link: RegExpExecArray | null;
+  while ((link = linkRe.exec(indexTxt)) !== null) {
+    const url = rebase(link[1], base);
+    if (url !== null) {
+      listed.add(url);
+    }
+  }
+  for (const url of declared.keys()) {
+    if (!listed.has(url)) {
+      missing.push({ url, detail: 'declared in llms.json but not linked from /llms.txt' });
+    }
+  }
+  return missing;
+}
+
+function reportFindings(groups: { label: string; items: Failure[] }[], targetsSize: number, declaredSize: number): void {
+  const total = groups.reduce((sum, g) => sum + g.items.length, 0);
+  if (total === 0) {
+    console.log(styleText('green', `✓ All ${targetsSize} llms.txt sources OK (${AGGREGATES.length} aggregate, ${declaredSize} per-page).`));
+    process.exit(0);
+  }
+  for (const group of groups) {
+    if (group.items.length === 0) {
+      continue;
+    }
+    console.log(styleText('red', `✗ ${group.items.length} ${group.label}:\n`));
+    for (const f of group.items.sort((a, z) => a.url.localeCompare(z.url))) {
+      console.log(`  ${styleText('bold', f.url)}`);
+      console.log(styleText('dim', `      ${f.detail}`));
+    }
+    console.log('');
+  }
+  console.log(styleText('red', `${total} finding(s) across ${targetsSize} checked sources.`));
+  process.exit(1);
+}
+
+async function main() {
+  const { base, concurrency } = parseArgs(process.argv.slice(2));
+
+  const sitemapXml = await fetchText(`${base}/sitemap.xml`);
+  const pages = parseSitemapPages(sitemapXml, base);
   if (pages.length === 0) {
     console.error(styleText('red', `No <loc> entries in ${base}/sitemap.xml`));
     process.exit(2);
@@ -182,18 +315,7 @@ async function main() {
   }
 
   const indexJson: { docs: LlmsIndexEntry[]; demos: LlmsIndexEntry[] } = JSON.parse(await fetchText(`${base}/llms.json`));
-  const declared = new Map<string, Kind>();
-  for (const [kind, entries] of [
-    ['doc', indexJson.docs],
-    ['demo', indexJson.demos],
-  ] as const) {
-    for (const entry of entries ?? []) {
-      const url = rebase(entry.url, base);
-      if (url !== null) {
-        declared.set(url, kind);
-      }
-    }
-  }
+  const declared = buildDeclaredMap(indexJson, base);
 
   console.log(styleText('dim', `${pages.length} pages in sitemap.xml, ${declared.size} sources in llms.json — checking ${base} …\n`));
 
@@ -217,21 +339,7 @@ async function main() {
     }
   }
 
-  const targets = new Map<string, Expected>(expected);
-  for (const [url, kind] of declared) {
-    if (!targets.has(url)) {
-      const slug =
-        new URL(url).pathname
-          .replace(/\/llms\.txt$/, '')
-          .split('/')
-          .pop() ?? '';
-      targets.set(url, { url, kind, slug, page: '' });
-    }
-  }
-  for (const path of AGGREGATES) {
-    const url = `${base}${path}`;
-    targets.set(url, { url, kind: 'aggregate', slug: path, page: '' });
-  }
+  const targets = buildTargets(expected, declared, base);
 
   const broken: Failure[] = [];
   const suspect: Failure[] = [];
@@ -257,75 +365,13 @@ async function main() {
 
     const body = await res.text();
     bodies.set(target.url, body);
-    const contentType = res.headers.get('content-type') ?? '';
-    const isJson = target.url.endsWith('.json');
-    const isMarkdown = target.url.endsWith('.md');
-    if (isJson ? !contentType.includes('application/json') : !isMarkdown && !contentType.includes('text/plain')) {
-      suspect.push({ url: target.url, detail: `content-type is '${contentType}'` });
-    }
-    if (body.trim().length === 0) {
-      suspect.push({ url: target.url, detail: 'empty body' });
-      return;
-    }
-    if (!isJson && body.trimStart().startsWith('<')) {
-      suspect.push({ url: target.url, detail: 'body looks like HTML — an error page served with a 200?' });
-      return;
-    }
-    if (target.kind === 'demo') {
-      if (!body.startsWith(`## Demo: ${target.slug}`)) {
-        suspect.push({ url: target.url, detail: `expected a '## Demo: ${target.slug}' header, got '${body.slice(0, 40).split('\n')[0]}'` });
-      }
-      // A files.ts path that doesn't exist on disk is only logged server-side and
-      // silently dropped from the bundle, so count the fences that survived.
-      const fences = (body.match(/^```/gm) ?? []).length;
-      if (fences < 2) {
-        suspect.push({ url: target.url, detail: 'no fenced source blocks — every declared file was dropped?' });
-      }
-    }
-    if (target.kind === 'doc' && body.length < 100) {
-      suspect.push({ url: target.url, detail: `only ${body.length} bytes` });
-    }
+    checkLlmsBody(target, body, res.headers.get('content-type') ?? '', suspect);
   });
 
-  // Every declared demo must also survive into the /llms-full.txt bundle, which
-  // is built by a separate code path from the per-demo routes.
-  const missingFromFull: Failure[] = [];
-  const fullTxt = bodies.get(`${base}/llms-full.txt`);
-  if (fullTxt !== undefined) {
-    for (const [url, kind] of declared) {
-      if (kind !== 'demo') {
-        continue;
-      }
-      const slug =
-        new URL(url).pathname
-          .replace(/\/llms\.txt$/, '')
-          .split('/')
-          .pop() ?? '';
-      if (!fullTxt.includes(`## Demo: ${slug}`)) {
-        missingFromFull.push({ url, detail: `demo '${slug}' has no '## Demo: ${slug}' section in /llms-full.txt` });
-      }
-    }
-  }
-
+  // Every declared demo must also survive into the /llms-full.txt bundle, which is built by a separate code path from the per-demo routes.
+  const missingFromFull = findMissingFromFull(bodies.get(`${base}/llms-full.txt`), declared);
   // The /llms.txt index is what an agent actually reads to discover the rest.
-  const missingFromIndex: Failure[] = [];
-  const indexTxt = bodies.get(`${base}/llms.txt`);
-  if (indexTxt !== undefined) {
-    const listed = new Set<string>();
-    const linkRe = /\]\((https?:\/\/[^)\s]+)\)/g;
-    let link: RegExpExecArray | null;
-    while ((link = linkRe.exec(indexTxt)) !== null) {
-      const url = rebase(link[1], base);
-      if (url !== null) {
-        listed.add(url);
-      }
-    }
-    for (const url of declared.keys()) {
-      if (!listed.has(url)) {
-        missingFromIndex.push({ url, detail: 'declared in llms.json but not linked from /llms.txt' });
-      }
-    }
-  }
+  const missingFromIndex = findMissingFromIndex(bodies.get(`${base}/llms.txt`), declared, base);
 
   const groups: { label: string; items: Failure[] }[] = [
     { label: `unregistered — page exists, llms.txt was never routed (this is a 404)`, items: unregistered },
@@ -336,25 +382,7 @@ async function main() {
     { label: `orphaned — declared in llms.json with no page in sitemap.xml`, items: orphaned },
   ];
 
-  const total = groups.reduce((sum, g) => sum + g.items.length, 0);
-  if (total === 0) {
-    console.log(styleText('green', `✓ All ${targets.size} llms.txt sources OK (${AGGREGATES.length} aggregate, ${declared.size} per-page).`));
-    process.exit(0);
-  }
-
-  for (const group of groups) {
-    if (group.items.length === 0) {
-      continue;
-    }
-    console.log(styleText('red', `✗ ${group.items.length} ${group.label}:\n`));
-    for (const f of group.items.sort((a, z) => a.url.localeCompare(z.url))) {
-      console.log(`  ${styleText('bold', f.url)}`);
-      console.log(styleText('dim', `      ${f.detail}`));
-    }
-    console.log('');
-  }
-  console.log(styleText('red', `${total} finding(s) across ${targets.size} checked sources.`));
-  process.exit(1);
+  reportFindings(groups, targets.size, declared.size);
 }
 
 main();

--- a/scripts/site-health.ts
+++ b/scripts/site-health.ts
@@ -76,6 +76,12 @@ const parseArgs = (argv: string[]): Args => {
       positional.push(a);
     }
   }
+  const base = (positional[0] ?? 'https://mochi.fast').replace(/\/+$/, '');
+  validateParsedArgs(concurrency, timeout, base);
+  return { base, concurrency, report, timeout };
+};
+
+function validateParsedArgs(concurrency: number, timeout: number, base: string): void {
   if (!Number.isFinite(concurrency) || concurrency < 1) {
     console.error('--concurrency must be a positive number');
     process.exit(2);
@@ -84,13 +90,11 @@ const parseArgs = (argv: string[]): Args => {
     console.error('--timeout must be at least 1000 (ms)');
     process.exit(2);
   }
-  const base = (positional[0] ?? 'https://mochi.fast').replace(/\/+$/, '');
   if (!URL.canParse(base) || !['http:', 'https:'].includes(new URL(base).protocol)) {
     console.error(`base must be an http(s) origin, got: ${base}`);
     process.exit(2);
   }
-  return { base, concurrency, report, timeout };
-};
+}
 
 /**
  * Console output that must not fail the run: third-party noise we don't control,


### PR DESCRIPTION
**Stacked on #335** (base branch is `chore/oxlint-hybrid`, not `main`). Review/merge #335 first.

## What

Follow-up to the complexity check added in #335. Purely **structural** refactors to bring 46 of the 47 functions flagged by oxlint `complexity: ["warn", 15]` under the threshold. **No logic or semantic changes** — extract module-private helpers, guard clauses, and dispatch tables.

## Result

- **47 → 1** complexity warnings. `oxlint | grep -c complexity` = 1.
- 31 files changed (+2232 / −1789).

Hotspots decomposed: `ComponentRegistry` `renderComponent` (54), `compileAll` (51), `buildClientBundle` (30), `fromManifest` (26); `svelteAstPreprocess` `Component` (54) & `preprocessHydratable` (46); `devWatcher` `applyRouteChanges` (40); plus ~35 smaller ones across `cli/`, `image/`, `captcha/`, `runtime/`, `web-components/`, `scripts/`.

## The one left: `Mochi.serve` (138 → 100, intentional)

Reduced by extracting the side-effect-free boot validation (bun-key guard, queue/storage + cron resolution) into pure helpers. The residual ~500-line sequential boot orchestrator shares ~30 interdependent closure variables (server, registry, route maps, option-derived consts); threading those through further extractions is exactly the contorted/risky change this refactor avoids. Left as one readable top-to-bottom sequence. **Recommend accepting it above the threshold** (it's warn-only anyway).

## Verification

- `bun run checks` green — typecheck 0 errors; tests mochi **182/182**, site **14/14**, support **3/3**, all other packages exit 0. Run independently a second time to confirm.
- **Browser-verified** the riskiest compile-core refactors: homepage + a hydration demo load with zero console errors, all island bundles 200, and a `mochi:defer` server-island endpoint fetches encrypted props with 200 — SSR, hydration, client bundling, and defer-fetch all intact.
- **Adversarial behavior-preservation review** of all 31 files (high-risk files traced line-by-line): no observable behavior change found. Two benign nuances confirmed non-divergent — a duplicate-`$props.id()` ordering case that Svelte itself rejects (`props_duplicate`), and a `devWatcher` log that now reads `result.type` where `result.type === type` always holds.