### PR TITLE
feat: Mochi sync — reflectdb-backed realtime data sync over WebSocket

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -122,6 +122,7 @@
         "mitt": "^3.0.1",
         "negotiator": "^1.0.0",
         "nodemailer": "^9.0.3",
+        "reflectdb": "0.1.3",
         "zimmerframe": "^1.1.4",
       },
       "devDependencies": {
@@ -1349,6 +1350,8 @@
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
+
+    "reflectdb": ["reflectdb@0.1.3", "", { "peerDependencies": { "drizzle-orm": ">=0.40.0", "react": ">=18.0.0", "typescript": ">=4.5.0" }, "optionalPeers": ["drizzle-orm", "react", "typescript"] }, "sha512-MpIbpqCeow6GXLIxyUTU1knr5fsm6xGkkWuzzzqf1hCrXtalmvA+A+ySVFmuqf+7e73ORld91hNJKhUiI7HPJg=="],
 
     "regex": ["regex@6.1.0", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg=="],
 

--- a/packages/docs/119-sync.md
+++ b/packages/docs/119-sync.md
@@ -1,0 +1,175 @@
+---
+title: 'Sync'
+slug: sync
+ogTitle: 'Realtime data sync with Mochi.serve({ sync })'
+description: 'Realtime, server-authoritative data sync for Svelte islands — a typed schema, sync() runes in the browser, pluggable auth, over WebSocket, backed by reflectdb.'
+---
+
+<script>
+  import Callout from './_components/Callout.svelte';
+  import SeeItInAction from './_components/SeeItInAction.svelte';
+  import VersionNote from './_components/VersionNote.svelte';
+</script>
+
+## Sync
+
+<VersionNote since="0.10.0" message="Mochi sync is new in 0.10.0." />
+
+Keep a dataset live across every browser tab. Declare a typed schema once, implement `query`/`mutate` on the server, and read and write rows from a hydrated island with a runes-backed `sync()`. The server is authoritative, client writes are optimistic, and updates fan out to every subscriber over one WebSocket. Backed by [reflectdb](https://github.com/TimMikeladze/reflectdb).
+
+<Callout type="warning">
+
+Sync is **WebSocket-only** in v1 and ships JavaScript to the browser, so it works in hydrated islands (`mochi:hydrate*`), not in server-only rendering. An island shows empty rows during SSR and fills in after it connects.
+
+</Callout>
+
+### Shared schema
+
+The schema is isomorphic — the same file is imported by your server routes and your islands. Import it from `mochi-framework/sync`, which carries only the schema helpers (no runtime).
+
+```ts
+// schema.ts
+import { defineSyncQueries, t } from 'mochi-framework/sync';
+
+export type Todo = { id: string; text: string; done: boolean };
+
+export const queries = defineSyncQueries({
+  todos: { row: t<Todo>() },
+});
+```
+
+`t<T>()` is a phantom type helper — it declares the row shape with no runtime value.
+
+### Server config
+
+Pass `sync: defineSync({ … })` to `Mochi.serve()`. Each table gets a `query` (read) and, to allow writes, a `mutate`. Both receive the `db` handle you thread in, so the same store answers reads and takes writes.
+
+```ts
+import { defineSync } from 'mochi-framework/sync';
+import { queries, type Todo } from './schema';
+
+const todos = new Map<string, Todo>();
+
+Mochi.serve({
+  sync: defineSync({
+    queries,
+    db: todos, // threaded untouched to every query/mutate
+    tables: {
+      todos: {
+        query: (ctx, db) => [...db.values()],
+        mutate: async (op, ctx, db) => {
+          if (op.type === 'delete') return void db.delete(op.rowId);
+          db.set(op.rowId, { id: op.rowId, ...op.payload } as Todo);
+        },
+      },
+    },
+  }),
+});
+```
+
+`op` is `{ type: 'insert' | 'update' | 'delete', rowId, payload }`. `ctx` is `{ auth, params }`.
+
+<Callout type="danger">
+
+`t<Todo>()` types the payload at compile time only — it does **no runtime validation**. A client can send any JSON. Validate `op.payload` inside `mutate` before you persist it.
+
+</Callout>
+
+<Callout type="info">
+
+reflectdb runs your `query` only when a `db` is present. Mochi defaults `db` to `{}` when you omit it, so a query that closes over its own store still runs — but pass your real handle whenever you have one.
+
+</Callout>
+
+Other `tables` options mirror reflectdb: `authorize`, `serverSet`, `room`, `broadcast`, `count`, `groupBy`. Top-level options: `views` (read-only `view()` queries), `rooms` (access-control callbacks by pattern), and `rateLimit` (global and per-table write limits).
+
+### Storage
+
+Where the op log lives. Give sync its **own** file — never share the queue's.
+
+| `storage`                       | Backing                                        |
+| ------------------------------- | ---------------------------------------------- |
+| `'memory'` (default)            | reflectdb's in-process op log; lost on restart |
+| `{ sqlite: '.db/sync.sqlite' }` | SQLite file (`bun:sqlite`)                     |
+| `{ postgres: url }`             | Postgres, for multi-instance / HA              |
+
+<Callout type="info">
+
+Under a Postgres connection pool, reflectdb's cross-instance advisory locks are best-effort (they are session-level, and a pool hands out different sessions). This matches `pg.Pool` and is reflectdb's documented behavior.
+
+</Callout>
+
+### Auth
+
+Sync auth is pluggable through a signed-ticket bridge. reflectdb only ever sees a bearer token, so Mochi exposes a token endpoint where the full request context is available: your `auth(req)` runs there, reads cookies via `getRequestContext()`, and Mochi mints a short-lived HMAC ticket (signed with the framework `secretKey`) that reflectdb re-verifies per operation batch. When a ticket expires, reflectdb asks the client to refetch — transparently.
+
+```ts
+defineSync({
+  queries,
+  auth: (req) => {
+    const userId = getRequestContext().cookies.get('user');
+    return userId ? { userId } : null; // null rejects the connection
+  },
+  tables: {/* … */},
+  ticketTtlMs: 600_000, // default: 10 minutes
+});
+```
+
+Omit `auth` to serve anonymous clients. The token endpoint (`<assetPrefix>/sync/token`) is POST-only and JSON-only, so it is CSRF-safe by construction.
+
+### `sync()` in islands
+
+Inside a hydrated island, `sync<Row>(table)` returns a reactive handle. `rows`, `status`, `pending`, and `total` are `$state`-backed; the mutators update optimistically and sync to the server.
+
+```svelte
+<script lang="ts">
+  import { sync } from 'mochi-framework';
+  import type { Todo } from './schema';
+
+  const todos = sync<Todo>('todos');
+
+  let text = $state('');
+</script>
+
+<p>{todos.status}{todos.pending ? ` · ${todos.pending} pending` : ''}</p>
+
+<ul>
+  {#each todos.rows as todo (todo.id)}
+    <li>
+      <input type="checkbox" checked={todo.done} onchange={() => todos.update(todo.id, { done: !todo.done })} />
+      {todo.text}
+      <button onclick={() => todos.remove(todo.id)}>×</button>
+    </li>
+  {/each}
+</ul>
+
+<button
+  onclick={() => {
+    todos.insert({ text, done: false });
+    text = '';
+  }}>Add</button
+>
+```
+
+`insert(payload, id?)` returns the row id. The handle also exposes `loadMore(count)` for windowed queries and `destroy()` (called automatically on component teardown). One client is shared per tab across every island.
+
+<Callout type="warning">
+
+reflectdb keys subscriptions by table name, so a table has **one params set per tab** — the last `sync(table, params)` wins for that table. Split by table for independent parameterized views.
+
+</Callout>
+
+### Server-side writes
+
+`Mochi.sync()` returns the live reflectdb server for out-of-band writes. When your data lives in your own store, write it and then broadcast the diff:
+
+```ts
+todos.set(id, { id, text: 'from the server', done: false });
+await Mochi.sync().notifyChange('todos'); // re-runs query, fans the diff out
+```
+
+`emit(table, payload)` / `applyServerOp(...)` write reflectdb's own mirror instead — use them when the mirror is your source of truth, not when a `query` reads an external store. `Mochi.sync()` throws a clear error if `sync` was never configured.
+
+<SeeItInAction
+demos={[{ href: "/demos/sync/", title: "Realtime sync", hook: "How Mochi sync works — two islands share one live todo list, server-authoritative, over WebSocket." }]}
+/>

--- a/packages/docs/119-sync.md
+++ b/packages/docs/119-sync.md
@@ -151,13 +151,43 @@ Inside a hydrated island, `sync<Row>(table)` returns a reactive handle. `rows`, 
 >
 ```
 
-`insert(payload, id?)` returns the row id. The handle also exposes `loadMore(count)` for windowed queries and `destroy()` (called automatically on component teardown). One client is shared per tab across every island.
+`insert(payload, id?)` returns the row id. The handle also exposes `loadMore(count)` for windowed queries and `destroy()` (called automatically on component teardown).
 
 <Callout type="warning">
 
-reflectdb keys subscriptions by table name, so a table has **one params set per tab** — the last `sync(table, params)` wins for that table. Split by table for independent parameterized views.
+reflectdb keys subscriptions by table name, so a table has **one params set per connection** — the last `sync(table, params)` wins for that table. Split by table for independent parameterized views.
 
 </Callout>
+
+### Connections
+
+Every island shares one connection by default (`'default'`) — one client, one socket, one local store per tab. Pass `{ connection }` to put an island on its own named connection, so two islands can hold **independent** state (each has its own client, socket, and local store):
+
+```ts
+const todos = sync<Todo>('todos', undefined, { connection: 'island-a' });
+```
+
+Connections are shared per name per tab, so two islands naming the same connection stay together.
+
+### Offline & resync
+
+`syncConnection(name?)` returns a control handle for a named connection (default `'default'`), with reactive `online`, `status`, and `pending`:
+
+```svelte
+<script lang="ts">
+  import { sync, syncConnection } from 'mochi-framework';
+
+  const todos = sync<Todo>('todos', undefined, { connection: 'island-a' });
+  const conn = syncConnection('island-a');
+</script>
+
+<button onclick={() => conn.setOnline(!conn.online)}>
+  {conn.online ? 'Go offline' : 'Go online'}
+</button>
+<p>{conn.status}{conn.pending ? ` · ${conn.pending} queued` : ''}</p>
+```
+
+`setOnline(false)` drops the socket while keeping local rows; writes made offline queue locally (watch `pending` climb) and stop reaching the server or other connections. `setOnline(true)` reconnects, resyncs a fresh snapshot, and pushes the queued writes — every side converges.
 
 ### Server-side writes
 

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -54,6 +54,12 @@
       "svelte": "./src/components/index.ts",
       "default": "./src/components/index.ts"
     },
+    "./sync": {
+      "types": "./src/sync/index.ts",
+      "svelte": "./src/sync/index.ts",
+      "bun": "./src/sync/index.ts",
+      "default": "./src/sync/index.ts"
+    },
     "./highlight": {
       "types": "./src/highlight.ts",
       "bun": "./src/highlight.ts",
@@ -117,6 +123,7 @@
     "mitt": "^3.0.1",
     "negotiator": "^1.0.0",
     "nodemailer": "^9.0.3",
+    "reflectdb": "0.1.3",
     "zimmerframe": "^1.1.4"
   },
   "devDependencies": {

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -130,6 +130,11 @@ import { resolveProtectionOptions, PROTECTION_SHELL_COMPONENT } from './protecti
 import { mintClearanceToken } from './protection/clearance';
 import { verifyCaptcha } from './captcha/captcha';
 import { getCaptchaRuntime } from './captcha/config';
+import { closeSyncRuntime, requireSyncServer, resolveSyncOptions, setSyncRuntime, validateSyncOptions } from './sync/config';
+import { createSyncTokenHandler, createSyncWsHandlers, startSyncRuntime } from './sync/server';
+import type { MochiSyncWsData } from './sync/server';
+import type { SyncQueryMap } from 'reflectdb';
+import type { TypedSyncServer } from 'reflectdb/server';
 
 const DEFAULT_HTML_SHELL = await Bun.file(new URL('./templates/default-shell.html', import.meta.url)).text();
 
@@ -280,6 +285,15 @@ export class Mochi {
   }
 
   /**
+   * The live reflectdb sync server behind `Mochi.serve({ sync })` — the escape hatch for out-of-band server writes:
+   * `.emit(table, payload)`, `.applyServerOp(...)`, `.notifyChange(...)`, `.tx(...)`, and the rest of the typed server
+   * surface. Throws with a clear message when `sync` was never configured.
+   */
+  static sync<TQueries extends SyncQueryMap = SyncQueryMap>(): TypedSyncServer<TQueries> {
+    return requireSyncServer() as unknown as TypedSyncServer<TQueries>;
+  }
+
+  /**
    * Send a transactional email, configured under `Mochi.serve({ email })`. The body is `html`, `text`, or a Svelte
    * `component` rendered to HTML with its scoped CSS inlined. Callable from any server-side code — route actions,
    * API handlers, or queue jobs.
@@ -303,9 +317,11 @@ export class Mochi {
       /** Reads the current speculation rules (reassigned on dev entry edits). */
       getSpeculationRules: () => SpeculationRules | undefined;
       fontPreload: boolean;
+      /** `window.__mochi_sync` endpoint bootstrap, injected ahead of island bundles when `sync` is configured. */
+      syncScript: string;
     },
   ): (result: RenderResult, opts?: { debugInfo?: DebugBarData; pageEntry?: string }) => string {
-    const { serverIslandClientJs, liveReloadClientJs, logLevel, getTemplate, getSpeculationRules, fontPreload } = config;
+    const { serverIslandClientJs, liveReloadClientJs, logLevel, getTemplate, getSpeculationRules, fontPreload, syncScript } = config;
 
     const logLevelScript = logLevel === DEFAULT_LOG_LEVEL ? '' : `<script>window.__mochi_log_level=${JSON.stringify(logLevel)}</script>`;
     // Feeds the debug bar's Warnings panel. When the debug bar is off the
@@ -355,6 +371,7 @@ export class Mochi {
       const css = cssStylePrefix + cssLinks;
       const body = result.body + debugInfoScript + pageEntryScript + toolbarDiv;
       const script =
+        syncScript +
         (bootstrapUrl ? `<script type="module" src="${bootstrapUrl}"></script>` : '') +
         (result.hasServerIslands ? serverIslandScript : '') +
         (debugBarUrl ? `<script type="module" src="${debugBarUrl}"></script><script>window.__mochi_asset_prefix=${assetPrefixJson}</script>` : '') +
@@ -457,6 +474,12 @@ export class Mochi {
     const cronStorage = options.cronStorage ?? 'memory';
     if (declaredCron.length > 0 && !isValidQueueStorage(cronStorage)) {
       throw new Error(`Mochi.serve({ cronStorage }): expected 'memory', { sqlite: 'path/to.db' }, { postgres: url }, or { pglite: instance }.`);
+    }
+
+    // Same fail-fast rule for sync: an empty schema, bad storage shape, unsupported transport, or a tables/views key
+    // that doesn't match the schema rejects here, before the config singleton pins and the socket binds.
+    if (options.sync !== undefined) {
+      validateSyncOptions(options.sync, queueStorage !== 'memory' && 'sqlite' in queueStorage ? queueStorage.sqlite : undefined);
     }
 
     // Same fail-fast rule: an unmountable prefix rejects here rather than 404ing at runtime.
@@ -676,6 +699,10 @@ export class Mochi {
 
     // Precompute request-invariant shell fragments once; `getTemplate` reads the
     // live `shellTemplate` so dev shell edits (reloadShell) are picked up.
+    const syncTokenPath = `${registry.assetPrefix}/sync/token`;
+    const syncWsPattern = `${registry.assetPrefix}/sync/ws`;
+    const syncScript = options.sync ? `<script>window.__mochi_sync=${JSON.stringify({ t: syncTokenPath, w: syncWsPattern })}</script>` : '';
+
     const renderShell = Mochi.createShellRenderer(registry, {
       serverIslandClientJs,
       liveReloadClientJs,
@@ -683,6 +710,7 @@ export class Mochi {
       getTemplate: () => shellTemplate,
       getSpeculationRules: () => speculationRules,
       fontPreload: options.fonts?.preload !== false,
+      syncScript,
     });
 
     // The interstitial renders through the app shell like error pages do, so a custom `protection.page`
@@ -1526,6 +1554,44 @@ export class Mochi {
     // After the mirroring pass on purpose: a `/*` pattern must not be mirrored to `/*\/`.
     registerStaticDirRoutes(bunRoutes, staticDirMounts);
 
+    // Start the sync runtime before its WS/token routes are wired: a mid-boot failure closes storage and rethrows,
+    // failing the serve rather than leaving a half-started server listening. Registered before the baseBunRoutes
+    // snapshot below so the dev-watcher rebuild preserves both routes across reloads.
+    const syncRuntime = options.sync ? await startSyncRuntime(resolveSyncOptions(options.sync)) : undefined;
+    if (syncRuntime) {
+      setSyncRuntime(syncRuntime);
+      const syncTokenHandler = createSyncTokenHandler(syncRuntime, syncTokenPath, buildRequestContext);
+      bunRoutes[syncTokenPath] = syncTokenHandler;
+      bunRoutes[`${syncTokenPath}/`] = syncTokenHandler;
+
+      // Bridge reflectdb's Bun WS handlers onto Mochi's shared dispatcher (keyed by `__mochiRoutePattern`).
+      wsHandlersMap.set(syncWsPattern, createSyncWsHandlers(syncRuntime) as MochiWsHandlers<unknown>);
+      const syncWsUpgrade = (async (req: Request, server: Server<undefined>) => {
+        const setup = await buildRequestContext(req, server, { kind: 'ws', pattern: syncWsPattern });
+        if ('earlyResponse' in setup) {
+          return setup.earlyResponse;
+        }
+        const { start, requestId, url } = setup;
+        const wsPath = url.pathname + url.search;
+        const success = (server as unknown as { upgrade: (req: Request, opts: Record<string, unknown>) => boolean }).upgrade(req, {
+          data: {
+            __mochiRoutePattern: syncWsPattern,
+            __mochiOpenedAt: performance.now(),
+            __mochiPath: wsPath,
+            user: { id: crypto.randomUUID(), req } satisfies MochiSyncWsData,
+          } satisfies MochiWsData<MochiSyncWsData>,
+        });
+        if (!success) {
+          mochiEvents.emit('request', { requestId, kind: 'error', method: req.method, path: wsPath, status: 500, duration: performance.now() - start });
+          return new Response('WebSocket upgrade failed', { status: 500 });
+        }
+        mochiEvents.emit('ws:open', { path: wsPath, duration: performance.now() - start });
+        return undefined;
+      }) as unknown as BunRouteValue;
+      bunRoutes[syncWsPattern] = syncWsUpgrade;
+      bunRoutes[`${syncWsPattern}/`] = syncWsUpgrade;
+    }
+
     // Register server island endpoint
     bunRoutes[`${registry.assetPrefix}/island/:componentName`] = withHead(async (req: Request, server: Server<undefined>): Promise<Response> => {
       const setup = await buildRequestContext(req, server, {
@@ -2021,6 +2087,7 @@ export class Mochi {
           await stopCronRuntime();
           stopEmailBadgeBroadcast?.();
           await closeEmailTransport();
+          await closeSyncRuntime();
           for (const store of rateLimitStores) {
             // Per-store guard: one failing shutdown must not skip the rest.
             try {

--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
@@ -131,6 +131,8 @@ export function memoryStore() { __serverOnly("memoryStore()"); }
 export function sqliteStore() { __serverOnly("sqliteStore()"); }
 export function postgresStore() { __serverOnly("postgresStore()"); }
 export { enhance, deserialize } from "__MOCHI_ENHANCE_CLIENT__";
+// The real runes-backed sync client — ships only in island bundles.
+export { sync } from "__MOCHI_SYNC_CLIENT__";
 // Constant by construction: client bundles are built only for islands, so
 // every component that executes in the browser is part of a hydrating (or
 // client-only mounting) subtree. No context lookup needed.

--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.client.js
@@ -132,7 +132,7 @@ export function sqliteStore() { __serverOnly("sqliteStore()"); }
 export function postgresStore() { __serverOnly("postgresStore()"); }
 export { enhance, deserialize } from "__MOCHI_ENHANCE_CLIENT__";
 // The real runes-backed sync client — ships only in island bundles.
-export { sync } from "__MOCHI_SYNC_CLIENT__";
+export { sync, syncConnection } from "__MOCHI_SYNC_CLIENT__";
 // Constant by construction: client bundles are built only for islands, so
 // every component that executes in the browser is part of a hydrating (or
 // client-only mounting) subtree. No context lookup needed.

--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
@@ -74,7 +74,7 @@ export { deferReloadState, DeferReloadState } from "__MOCHI_DEFER_REACTIVE__";
 export { enhance, deserialize } from "__MOCHI_ENHANCE_SSR__";
 // `sync()` in an island runs during SSR too — the server export is an inert stub
 // (empty rows, no-op mutators). The real reactive client ships only to the browser.
-export { sync } from "__MOCHI_SYNC_SSR__";
+export { sync, syncConnection } from "__MOCHI_SYNC_SSR__";
 // Rate-limit stores — server-only (bun:sqlite / Bun SQL).
 export { memoryStore, sqliteStore, postgresStore } from "__MOCHI_RATE_LIMIT__";
 // The built-in protection interstitial's absolute path — lets a docs/tooling

--- a/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
+++ b/packages/mochi/src/compiler/virtual-modules/mochi-env.server.js
@@ -72,6 +72,9 @@ export { deferReloadState, DeferReloadState } from "__MOCHI_DEFER_REACTIVE__";
 // Svelte never invokes actions during SSR, so these stubs only fire
 // if user code calls them on the server — which is a usage error.
 export { enhance, deserialize } from "__MOCHI_ENHANCE_SSR__";
+// `sync()` in an island runs during SSR too — the server export is an inert stub
+// (empty rows, no-op mutators). The real reactive client ships only to the browser.
+export { sync } from "__MOCHI_SYNC_SSR__";
 // Rate-limit stores — server-only (bun:sqlite / Bun SQL).
 export { memoryStore, sqliteStore, postgresStore } from "__MOCHI_RATE_LIMIT__";
 // The built-in protection interstitial's absolute path — lets a docs/tooling

--- a/packages/mochi/src/compiler/virtualModuleTemplate.ts
+++ b/packages/mochi/src/compiler/virtualModuleTemplate.ts
@@ -44,6 +44,7 @@ export function renderMochiEnvServer(development: boolean): string {
     __MOCHI_DEFER_API__: frameworkFile('islands/deferInvalidation.ts'),
     __MOCHI_DEFER_REACTIVE__: frameworkFile('islands/deferReloadState.svelte.ts'),
     __MOCHI_ENHANCE_SSR__: frameworkFile('runtime/enhance.ssr.ts'),
+    __MOCHI_SYNC_SSR__: frameworkFile('sync/sync.ssr.ts'),
     __MOCHI_RATE_LIMIT__: frameworkFile('runtime/rateLimit.ts'),
     // A baked literal, not a module re-export: config.ts computes the path off `import.meta.url`,
     // which inside a compiled SSR chunk would point into the build dir instead of the framework src.
@@ -62,5 +63,6 @@ export function renderMochiEnvClient(development: boolean, cookiesClientPath: st
     __MOCHI_DEFER_API__: frameworkFile('islands/deferInvalidation.ts'),
     __MOCHI_DEFER_REACTIVE__: frameworkFile('islands/deferReloadState.svelte.ts'),
     __MOCHI_ENHANCE_CLIENT__: enhanceClientPath,
+    __MOCHI_SYNC_CLIENT__: frameworkFile('sync/sync.client.svelte.ts'),
   });
 }

--- a/packages/mochi/src/dev/consoleLogger.ts
+++ b/packages/mochi/src/dev/consoleLogger.ts
@@ -129,6 +129,32 @@ export function consoleLogger(options: ConsoleLoggerOptions = {}): void {
     neutral: true,
   }));
 
+  subscribe('sync:open', (payload) => ({
+    label: 'SYNC',
+    path: payload.clientId,
+    note: styleText('cyan', 'open'),
+  }));
+
+  subscribe('sync:op', (payload) => ({
+    label: 'SYNC',
+    path: payload.clientId,
+    note: `${styleText('cyan', 'ops')} ${styleText('green', `+${payload.accepted}`)} ${payload.rejected > 0 ? styleText('red', `-${payload.rejected}`) : styleText('dim', '-0')}`,
+  }));
+
+  subscribe('sync:close', (payload) => ({
+    label: 'SYNC',
+    path: payload.clientId,
+    note: styleText('dim', 'close'),
+    neutral: true,
+  }));
+
+  subscribe('sync:error', (payload) => ({
+    label: 'SYNC',
+    path: payload.clientId ?? '-',
+    note: `${styleText('red', payload.reason)}${payload.error ? ' ' + styleText('dim', payload.error) : ''}`,
+    level: 'warn',
+  }));
+
   subscribe('server:start', ({ port, hostname, development, routes }) => {
     const where = `${hostname ?? 'localhost'}:${port}`;
     const mode = styleText('dim', development ? 'dev' : 'prod');

--- a/packages/mochi/src/events.ts
+++ b/packages/mochi/src/events.ts
@@ -52,6 +52,32 @@ export interface MochiSseMessageEvent {
   event?: string;
 }
 
+export interface MochiSyncOpenEvent {
+  /** reflectdb client id of the socket that just connected. */
+  clientId: string;
+}
+
+export interface MochiSyncCloseEvent {
+  clientId: string;
+}
+
+export interface MochiSyncOpEvent {
+  clientId: string;
+  /** Ops the server accepted in this batch. */
+  accepted: number;
+  /** Ops the server rejected (conflict, rate limit, validation). */
+  rejected: number;
+}
+
+export interface MochiSyncErrorEvent {
+  /** Absent for connection-independent failures (e.g. an eager-flush error). */
+  clientId?: string;
+  /** The reflectdb `SyncEvent` type that produced this — `auth_failed`, `message_invalid`, `query_error`, `queue_overflow`, `eager_flush_failed`. */
+  reason: string;
+  /** Error message, when the underlying event carried one. */
+  error?: string;
+}
+
 export type MochiFileChangeType = 'add' | 'change' | 'unlink' | 'addDir' | 'unlinkDir';
 
 export interface MochiFileChangeEvent {
@@ -429,6 +455,10 @@ export type MochiEventMap = {
   'sse:open': MochiSseOpenEvent;
   'sse:message': MochiSseMessageEvent;
   'sse:close': MochiSseCloseEvent;
+  'sync:open': MochiSyncOpenEvent;
+  'sync:close': MochiSyncCloseEvent;
+  'sync:op': MochiSyncOpEvent;
+  'sync:error': MochiSyncErrorEvent;
   'file:change': MochiFileChangeEvent;
   'island:error': MochiIslandErrorEvent;
   'captcha:verify': MochiCaptchaVerifyEvent;

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -151,8 +151,8 @@ export type { MochiCaptchaOptions, CaptchaResult, CaptchaFailureReason, NonceSto
 export { PROTECTION_CLEARANCE_COOKIE, DEFAULT_PROTECTION_MAX_AGE_MS, DEFAULT_PROTECTION_MAX_ATTEMPTS, PROTECTION_SHELL_COMPONENT } from './protection/config';
 export type { MochiProtectionOptions, MochiProtectionContext, MochiProtectionKind, MochiProtectionPageProps } from './protection/types';
 export { enhance, deserialize } from './runtime/enhance.ssr';
-export { sync } from './sync/sync.ssr';
-export type { MochiSyncOptions, MochiSyncStorage, MochiSyncAuthFn, MochiSyncHandle } from './sync/types';
+export { sync, syncConnection } from './sync/sync.ssr';
+export type { MochiSyncOptions, MochiSyncStorage, MochiSyncAuthFn, MochiSyncHandle, MochiSyncConnection } from './sync/types';
 export { isFormContentType, DEFAULT_FORM_CONTENT_TYPES, DEFAULT_PROTECTED_METHODS } from './runtime/csrf';
 export { DEFAULT_COMPRESS_MIN_BYTES, encryptPayload, decryptPayload } from './islands/payloadCrypto';
 export { DEFAULT_INLINE_BUDGET } from './islands/inlineServerIslands';

--- a/packages/mochi/src/index.ts
+++ b/packages/mochi/src/index.ts
@@ -67,6 +67,10 @@ export type {
   MochiSseOpenEvent,
   MochiSseMessageEvent,
   MochiSseCloseEvent,
+  MochiSyncOpenEvent,
+  MochiSyncCloseEvent,
+  MochiSyncOpEvent,
+  MochiSyncErrorEvent,
   MochiFileChangeEvent,
   MochiFileChangeType,
   MochiIslandErrorEvent,
@@ -147,6 +151,8 @@ export type { MochiCaptchaOptions, CaptchaResult, CaptchaFailureReason, NonceSto
 export { PROTECTION_CLEARANCE_COOKIE, DEFAULT_PROTECTION_MAX_AGE_MS, DEFAULT_PROTECTION_MAX_ATTEMPTS, PROTECTION_SHELL_COMPONENT } from './protection/config';
 export type { MochiProtectionOptions, MochiProtectionContext, MochiProtectionKind, MochiProtectionPageProps } from './protection/types';
 export { enhance, deserialize } from './runtime/enhance.ssr';
+export { sync } from './sync/sync.ssr';
+export type { MochiSyncOptions, MochiSyncStorage, MochiSyncAuthFn, MochiSyncHandle } from './sync/types';
 export { isFormContentType, DEFAULT_FORM_CONTENT_TYPES, DEFAULT_PROTECTED_METHODS } from './runtime/csrf';
 export { DEFAULT_COMPRESS_MIN_BYTES, encryptPayload, decryptPayload } from './islands/payloadCrypto';
 export { DEFAULT_INLINE_BUDGET } from './islands/inlineServerIslands';

--- a/packages/mochi/src/sync/config.test.ts
+++ b/packages/mochi/src/sync/config.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'bun:test';
+import { defineSyncQueries, presence, t, view } from 'reflectdb';
+import { isValidSyncStorage, resolveSyncOptions, validateSyncOptions } from './config';
+import type { MochiSyncOptions } from './types';
+
+type Todo = { id: string; text: string; done: boolean };
+
+const queries = defineSyncQueries({
+  todos: { row: t<Todo>() },
+});
+
+function baseOptions(overrides: Partial<MochiSyncOptions> = {}): MochiSyncOptions {
+  return {
+    queries,
+    tables: { todos: { query: () => [] } },
+    ...overrides,
+  } as MochiSyncOptions;
+}
+
+describe('isValidSyncStorage', () => {
+  test('accepts the three valid shapes', () => {
+    expect(isValidSyncStorage('memory')).toBe(true);
+    expect(isValidSyncStorage({ sqlite: '.db/sync.sqlite' })).toBe(true);
+    expect(isValidSyncStorage({ postgres: 'postgres://localhost/db' })).toBe(true);
+  });
+
+  test('rejects empty or malformed shapes', () => {
+    expect(isValidSyncStorage({ sqlite: '' })).toBe(false);
+    expect(isValidSyncStorage({ postgres: '' })).toBe(false);
+    expect(isValidSyncStorage({ sqlite: 'a', postgres: 'b' } as never)).toBe(false);
+    expect(isValidSyncStorage({} as never)).toBe(false);
+    expect(isValidSyncStorage('disk' as never)).toBe(false);
+  });
+});
+
+describe('resolveSyncOptions', () => {
+  test('fills defaults', () => {
+    const resolved = resolveSyncOptions(baseOptions());
+    expect(resolved.storage).toBe('memory');
+    expect(resolved.ticketTtlMs).toBe(600_000);
+    expect(resolved.transport).toBe('ws');
+  });
+
+  test('preserves explicit values', () => {
+    const resolved = resolveSyncOptions(baseOptions({ storage: { sqlite: '.db/s.sqlite' }, ticketTtlMs: 5000 }));
+    expect(resolved.storage).toEqual({ sqlite: '.db/s.sqlite' });
+    expect(resolved.ticketTtlMs).toBe(5000);
+  });
+});
+
+describe('validateSyncOptions', () => {
+  test('accepts a valid config', () => {
+    expect(() => validateSyncOptions(baseOptions())).not.toThrow();
+  });
+
+  test('rejects an empty schema', () => {
+    expect(() => validateSyncOptions(baseOptions({ queries: {} as never, tables: {} as never }))).toThrow(/non-empty schema/);
+  });
+
+  test('rejects a bad storage shape', () => {
+    expect(() => validateSyncOptions(baseOptions({ storage: { sqlite: '' } as never }))).toThrow(/storage/);
+  });
+
+  test('rejects an unsupported transport', () => {
+    expect(() => validateSyncOptions(baseOptions({ transport: 'sse' as never }))).toThrow(/not supported yet/);
+  });
+
+  test('rejects a tables key with no schema entry', () => {
+    expect(() => validateSyncOptions(baseOptions({ tables: { todos: { query: () => [] }, ghost: { query: () => [] } } as never }))).toThrow(/no matching entry/);
+  });
+
+  test('rejects a missing table implementation', () => {
+    const q = defineSyncQueries({ todos: { row: t<Todo>() }, notes: { row: t<Todo>() } });
+    expect(() => validateSyncOptions({ queries: q, tables: { todos: { query: () => [] } } } as never)).toThrow(/has no implementation/);
+  });
+
+  test('rejects a view() entry implemented under tables', () => {
+    const q = defineSyncQueries({ todos: { row: t<Todo>() }, summary: view({ row: t<Todo>() }) });
+    expect(() => validateSyncOptions({ queries: q, tables: { todos: { query: () => [] }, summary: { query: () => [] } } } as never)).toThrow(/is a view\(\)/);
+  });
+
+  test('rejects a presence() entry implemented under tables', () => {
+    const q = defineSyncQueries({ todos: { row: t<Todo>() }, cursors: presence({ state: t<{ x: number }>() }) });
+    expect(() => validateSyncOptions({ queries: q, tables: { todos: { query: () => [] }, cursors: { query: () => [] } } } as never)).toThrow(/presence\(\) channel/);
+  });
+
+  test('rejects a non-view entry under views', () => {
+    expect(() => validateSyncOptions(baseOptions({ views: { todos: () => [] } as never }))).toThrow(/not a view\(\)/);
+  });
+});

--- a/packages/mochi/src/sync/config.ts
+++ b/packages/mochi/src/sync/config.ts
@@ -1,0 +1,158 @@
+import path from 'node:path';
+import type { ServerTransport, SyncPresenceDef, SyncQueryMap, SyncViewDef } from 'reflectdb';
+import type { TypedSyncServer } from 'reflectdb/server';
+import type { createBunWsServerTransport } from 'reflectdb/transport/bun-ws';
+import { logger } from '../utils/log';
+import { toPosixPath } from '../utils';
+import type { MochiSyncAuthFn, MochiSyncOptions, MochiSyncStorage } from './types';
+
+export const DEFAULT_TICKET_TTL_MS = 600_000;
+
+export interface ResolvedSyncOptions extends MochiSyncOptions {
+  storage: MochiSyncStorage;
+  ticketTtlMs: number;
+  transport: 'ws';
+}
+
+/** Fill sync defaults: `'memory'` storage, a 10-minute ticket TTL, WebSocket transport. */
+export function resolveSyncOptions(options: MochiSyncOptions): ResolvedSyncOptions {
+  return {
+    ...options,
+    storage: options.storage ?? 'memory',
+    ticketTtlMs: options.ticketTtlMs ?? DEFAULT_TICKET_TTL_MS,
+    transport: options.transport ?? 'ws',
+  };
+}
+
+const storageChecks: Record<string, (value: unknown) => boolean> = {
+  sqlite: (value) => typeof value === 'string' && value.length > 0,
+  postgres: (value) => typeof value === 'string' && value.length > 0,
+};
+
+/** Runtime-validates the storage shape, since `sync` config often arrives from untyped JS callers. */
+export function isValidSyncStorage(storage: MochiSyncStorage): boolean {
+  if (storage === 'memory') {
+    return true;
+  }
+  if (typeof storage !== 'object' || storage === null) {
+    return false;
+  }
+  const [entry, ...extra] = Object.entries(storageChecks).filter(([key]) => key in storage);
+  if (!entry || extra.length > 0) {
+    return false;
+  }
+  const [key, check] = entry;
+  return check((storage as unknown as Record<string, unknown>)[key]);
+}
+
+function isView(entry: unknown): entry is SyncViewDef {
+  return typeof entry === 'object' && entry !== null && (entry as { __view?: boolean }).__view === true;
+}
+
+function isPresence(entry: unknown): entry is SyncPresenceDef {
+  return typeof entry === 'object' && entry !== null && (entry as { __presence?: boolean }).__presence === true;
+}
+
+/**
+ * Fail-fast validation for `Mochi.serve({ sync })`, run before the config singleton pins. Rejects an empty schema,
+ * a bad storage shape, a non-`'ws'` transport, `tables` keys that aren't regular queries, regular queries missing a
+ * `tables` implementation, and `views` keys that aren't `view()` entries. Warns on a sqlite path shared with the queue.
+ */
+export function validateSyncOptions(sync: MochiSyncOptions, queueSqlitePath?: string): void {
+  const queries = sync.queries;
+  if (typeof queries !== 'object' || queries === null || Object.keys(queries).length === 0) {
+    throw new Error(`Mochi.serve({ sync }): "queries" must be a non-empty schema built with defineSyncQueries({ … }).`);
+  }
+
+  const storage = sync.storage ?? 'memory';
+  if (!isValidSyncStorage(storage)) {
+    throw new Error(`Mochi.serve({ sync }): "storage" must be 'memory', { sqlite: 'path/to.db' }, or { postgres: url }.`);
+  }
+
+  if (sync.transport !== undefined && sync.transport !== 'ws') {
+    throw new Error(`Mochi.serve({ sync }): transport '${String(sync.transport)}' is not supported yet — only 'ws' (WebSocket) is available.`);
+  }
+
+  const map = queries as SyncQueryMap;
+  const tables = (sync.tables ?? {}) as Record<string, unknown>;
+  const views = (sync.views ?? {}) as Record<string, unknown>;
+
+  for (const name of Object.keys(tables)) {
+    const def = map[name];
+    if (def === undefined) {
+      throw new Error(`Mochi.serve({ sync }): tables["${name}"] has no matching entry in the schema.`);
+    }
+    if (isView(def)) {
+      throw new Error(`Mochi.serve({ sync }): "${name}" is a view() — implement it under "views", not "tables".`);
+    }
+    if (isPresence(def)) {
+      throw new Error(`Mochi.serve({ sync }): "${name}" is a presence() channel and cannot be implemented under "tables".`);
+    }
+  }
+
+  for (const name of Object.keys(views)) {
+    const def = map[name];
+    if (def === undefined) {
+      throw new Error(`Mochi.serve({ sync }): views["${name}"] has no matching entry in the schema.`);
+    }
+    if (!isView(def)) {
+      throw new Error(`Mochi.serve({ sync }): "${name}" is not a view() entry — only view() queries go under "views".`);
+    }
+  }
+
+  for (const [name, def] of Object.entries(map)) {
+    if (isView(def) || isPresence(def)) {
+      continue;
+    }
+    if (!(name in tables)) {
+      throw new Error(`Mochi.serve({ sync }): the "${name}" query has no implementation — add tables["${name}"] with a query (and optional mutate).`);
+    }
+  }
+
+  if (storage !== 'memory' && 'sqlite' in storage && queueSqlitePath) {
+    if (path.resolve(storage.sqlite) === path.resolve(queueSqlitePath)) {
+      logger.warn(`Mochi.serve({ sync }): the sync sqlite store (${toPosixPath(storage.sqlite)}) is the same file as queueStorage — give sync its own file to avoid table churn.`);
+    }
+  }
+}
+
+export interface SyncRuntime {
+  server: TypedSyncServer<SyncQueryMap>;
+  websocket: ReturnType<typeof createBunWsServerTransport>['websocket'];
+  transport: ServerTransport;
+  auth?: MochiSyncAuthFn;
+  ticketTtlMs: number;
+  close(): Promise<void>;
+}
+
+// Pinned on globalThis like `__mochi_config__` / `__mochi_email_runtime__`: compiled Svelte bundles each get their own
+// copy of this module yet must share one runtime instance.
+const GLOBAL_KEY = '__mochi_sync_runtime__';
+
+export function setSyncRuntime(runtime: SyncRuntime): void {
+  (globalThis as unknown as Record<string, unknown>)[GLOBAL_KEY] = runtime;
+}
+
+export function getSyncRuntime(): SyncRuntime | undefined {
+  return (globalThis as unknown as Record<string, unknown>)[GLOBAL_KEY] as SyncRuntime | undefined;
+}
+
+/** The live typed sync server, or a clear throw when `Mochi.serve({ sync })` was never configured. */
+export function requireSyncServer(): TypedSyncServer<SyncQueryMap> {
+  const runtime = getSyncRuntime();
+  if (!runtime) {
+    throw new Error('Mochi.sync() requires Mochi.serve({ sync }) to be configured.');
+  }
+  return runtime.server;
+}
+
+/** Idempotently close the sync runtime and clear the global pin. */
+export async function closeSyncRuntime(): Promise<void> {
+  const g = globalThis as unknown as Record<string, unknown>;
+  const runtime = g[GLOBAL_KEY] as SyncRuntime | undefined;
+  if (!runtime) {
+    return;
+  }
+  g[GLOBAL_KEY] = undefined;
+  await runtime.close();
+}

--- a/packages/mochi/src/sync/defineSync.ts
+++ b/packages/mochi/src/sync/defineSync.ts
@@ -1,0 +1,11 @@
+import type { SyncQueryMap } from 'reflectdb';
+import type { MochiSyncOptions } from './types';
+
+/**
+ * Identity helper for `Mochi.serve({ sync })`. Preserves full query-map and db inference at the call site — so
+ * `tables`/`views` callbacks are typed against the schema — while erasing the generics to the base
+ * `MochiSyncOptions` that `MochiServeOptions.sync` stores, keeping that option non-generic.
+ */
+export function defineSync<TQueries extends SyncQueryMap, TDb = unknown>(options: MochiSyncOptions<TQueries, TDb>): MochiSyncOptions {
+  return options as unknown as MochiSyncOptions;
+}

--- a/packages/mochi/src/sync/index.ts
+++ b/packages/mochi/src/sync/index.ts
@@ -1,0 +1,10 @@
+/**
+ * `mochi-framework/sync` — the isomorphic entry point shared by server routes and islands. Pure re-exports only
+ * (schema helpers + types), so importing it from a hydrated island never pulls the reflectdb server or client
+ * runtime into the browser bundle.
+ */
+export { defineSyncQueries, t, view, presence } from 'reflectdb';
+export type { SyncQueryMap, SyncQueryDef, SyncViewDef, SyncPresenceDef, InferRow, InferParams, InferWritableRow, ConflictPolicy, AuthContext } from 'reflectdb';
+
+export { defineSync } from './defineSync';
+export type { MochiSyncOptions, MochiSyncStorage, MochiSyncAuthFn, MochiSyncHandle } from './types';

--- a/packages/mochi/src/sync/server.ts
+++ b/packages/mochi/src/sync/server.ts
@@ -1,0 +1,228 @@
+import type { Server, ServerWebSocket } from 'bun';
+import type { AuthContext, SyncQueryMap } from 'reflectdb';
+import { createSyncServer } from 'reflectdb/server';
+import type { ImplementOptions, RoomCallback, SyncEvent } from 'reflectdb/server';
+import { createBunWsServerTransport } from 'reflectdb/transport/bun-ws';
+import { mochiEvents } from '../events';
+import { finalizeCookieHeaders } from '../runtime/cookies';
+import { requestContext } from '../runtime/requestContext';
+import type { RequestContextBuilder } from '../runtime/requestSetup';
+import type { MochiWsData, MochiWsHandlers } from '../types';
+import type { ResolvedSyncOptions, SyncRuntime } from './config';
+import { createSyncStorage } from './storage';
+import { mintSyncTicket, verifySyncTicket } from './ticket';
+
+/** Payload carried on the Bun socket's `data.user` for a sync connection. */
+export interface MochiSyncWsData {
+  id: string;
+  req?: Request;
+}
+
+function errString(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function emitSyncEvent(event: SyncEvent): void {
+  switch (event.type) {
+    case 'client_connected':
+      mochiEvents.emit('sync:open', { clientId: event.clientId });
+      break;
+    case 'client_disconnected':
+      mochiEvents.emit('sync:close', { clientId: event.clientId });
+      break;
+    case 'ops_processed':
+      mochiEvents.emit('sync:op', { clientId: event.clientId, accepted: event.accepted, rejected: event.rejected });
+      break;
+    case 'auth_failed':
+      mochiEvents.emit('sync:error', { clientId: event.clientId, reason: 'auth_failed', error: errString(event.error) });
+      break;
+    case 'message_invalid':
+      mochiEvents.emit('sync:error', { clientId: event.clientId, reason: 'message_invalid', error: event.error });
+      break;
+    case 'query_error':
+      mochiEvents.emit('sync:error', { clientId: event.clientId, reason: 'query_error', error: errString(event.error) });
+      break;
+    case 'queue_overflow':
+      mochiEvents.emit('sync:error', { clientId: event.clientId, reason: 'queue_overflow' });
+      break;
+    case 'eager_flush_failed':
+      mochiEvents.emit('sync:error', { reason: 'eager_flush_failed', error: errString(event.error) });
+      break;
+  }
+}
+
+/**
+ * Boot the reflectdb sync server on a Bun WebSocket transport. When `auth` is configured, reflectdb verifies each
+ * connection's bearer token as a Mochi-minted ticket (re-checked per ops batch); otherwise it serves anonymous
+ * clients. Table/view/room/rate-limit registrations come straight from the resolved options. On any mid-boot throw,
+ * the storage handle is closed before rethrowing so a failed boot leaks nothing.
+ */
+export async function startSyncRuntime(resolved: ResolvedSyncOptions): Promise<SyncRuntime> {
+  const storage = createSyncStorage(resolved.storage);
+  try {
+    const { transport, websocket } = createBunWsServerTransport();
+    const server = createSyncServer<SyncQueryMap>({
+      queries: resolved.queries,
+      // reflectdb skips query execution entirely when its `db` is falsy (snapshots come back empty, nothing
+      // broadcasts). Default to `{}` so queries run even when the app closes over its own store instead of threading
+      // a handle — `db` stays genuinely optional.
+      db: resolved.db ?? {},
+      transport,
+      storage: storage.adapter,
+      allowAnonymous: !resolved.auth,
+      onEvent: emitSyncEvent,
+    });
+
+    if (resolved.auth) {
+      server.auth(async (req) => {
+        const header = req.headers.get('authorization') ?? '';
+        const token = header.startsWith('Bearer ') ? header.slice('Bearer '.length) : header;
+        const auth = verifySyncTicket(token);
+        if (!auth) {
+          throw new Error('invalid or expired sync ticket');
+        }
+        return auth;
+      });
+    }
+
+    const tables = resolved.tables as Record<string, ImplementOptions<SyncQueryMap, string, AuthContext, unknown>>;
+    for (const [name, impl] of Object.entries(tables)) {
+      server.implement(name, impl);
+    }
+
+    const views = (resolved.views ?? {}) as Record<string, (ctx: never, db: never) => unknown>;
+    for (const [name, fn] of Object.entries(views)) {
+      // Cast: with the base (non-generic) SyncQueryMap, reflectdb's `ViewKeys` narrows to `never`, so the typed
+      // `view()` rejects a plain string name. The runtime resolves the entry by name and guards the view marker.
+      server.view(name as never, fn as never);
+    }
+
+    const rooms = (resolved.rooms ?? {}) as Record<string, RoomCallback>;
+    for (const [pattern, callback] of Object.entries(rooms)) {
+      server.room(pattern, callback);
+    }
+
+    if (resolved.rateLimit) {
+      server.rateLimit(resolved.rateLimit);
+    }
+
+    return {
+      server,
+      websocket,
+      transport,
+      auth: resolved.auth,
+      ticketTtlMs: resolved.ticketTtlMs,
+      close: async () => {
+        // server.close() closes the transport; the storage handle is ours to close.
+        await server.close();
+        await storage.close();
+      },
+    };
+  } catch (err) {
+    await storage.close();
+    throw err;
+  }
+}
+
+/** Bun ServerWebSocket subset reflectdb's bun-ws transport reads off each socket. */
+interface ReflectSocket {
+  data: MochiSyncWsData;
+  send(data: string): void;
+  close(): void;
+  readyState?: number;
+  getBufferedAmount?: () => number;
+  ping?: (data?: string) => void;
+}
+
+/**
+ * Bridge reflectdb's Bun WebSocket handlers onto Mochi's WS dispatcher. Mochi's socket carries its bookkeeping on
+ * `ws.data` and the sync payload on `ws.data.user`, but reflectdb expects `ws.data.{id,req}` directly — so each socket
+ * gets a thin adapter (memoized in a WeakMap) exposing exactly what the transport reads. `send` deliberately forwards
+ * without a try/catch: reflectdb's `TransportSendError` contract needs a failed send to reject, not be swallowed.
+ */
+export function createSyncWsHandlers(runtime: SyncRuntime): MochiWsHandlers<MochiSyncWsData> {
+  const websocket = runtime.websocket;
+  const adapters = new WeakMap<object, ReflectSocket>();
+
+  function adapterFor(ws: ServerWebSocket<MochiWsData<MochiSyncWsData>>): ReflectSocket {
+    let adapter = adapters.get(ws);
+    if (!adapter) {
+      const user = ws.data.user;
+      adapter = {
+        data: { id: user.id, req: user.req },
+        send: (data: string) => ws.send(data),
+        close: () => ws.close(),
+        get readyState() {
+          return ws.readyState;
+        },
+        getBufferedAmount: () => ws.getBufferedAmount(),
+        ping: (data?: string) => ws.ping(data),
+      };
+      adapters.set(ws, adapter);
+    }
+    return adapter;
+  }
+
+  return {
+    open(ws) {
+      websocket.open(adapterFor(ws) as never);
+    },
+    message(ws, message) {
+      websocket.message(adapterFor(ws) as never, message);
+    },
+    close(ws) {
+      websocket.close(adapterFor(ws) as never);
+      adapters.delete(ws);
+    },
+  };
+}
+
+/**
+ * The token endpoint handler: runs the configured `auth(req)` with full request context, then mints a signed ticket
+ * the client presents to reflectdb. POST-only (405 otherwise) and JSON-only (415 otherwise) so it is CSRF-safe by
+ * construction. Anonymous when no `auth` is configured. Modeled on Mochi's protection-verify handler.
+ */
+export function createSyncTokenHandler(
+  runtime: SyncRuntime,
+  tokenPath: string,
+  buildRequestContext: RequestContextBuilder,
+): (req: Request, server: Server<undefined>) => Promise<Response> {
+  return async (req, server) => {
+    if (req.method !== 'POST') {
+      return new Response('Method Not Allowed', { status: 405, headers: { Allow: 'POST' } });
+    }
+    if (!(req.headers.get('content-type') ?? '').toLowerCase().includes('application/json')) {
+      return new Response('Unsupported Media Type', { status: 415 });
+    }
+
+    const setup = await buildRequestContext(req, server, { kind: 'api', pattern: tokenPath, skipProtection: true });
+    if ('earlyResponse' in setup) {
+      return setup.earlyResponse;
+    }
+    const { ctx, start, requestId, url } = setup;
+
+    let response: Response;
+    if (!runtime.auth) {
+      response = Response.json({ token: 'anonymous', ttlMs: runtime.ticketTtlMs }, { headers: { 'Cache-Control': 'no-store' } });
+    } else {
+      const authFn = runtime.auth;
+      const auth = await requestContext.run(ctx, () => authFn(req));
+      if (!auth) {
+        response = Response.json({ error: 'unauthorized' }, { status: 401, headers: { 'Cache-Control': 'no-store' } });
+      } else {
+        response = Response.json({ token: mintSyncTicket(auth, runtime.ticketTtlMs), ttlMs: runtime.ticketTtlMs }, { headers: { 'Cache-Control': 'no-store' } });
+      }
+    }
+
+    const final = finalizeCookieHeaders(response, ctx.cookies);
+    mochiEvents.emit('request', {
+      requestId,
+      kind: 'api',
+      method: req.method,
+      path: url.pathname + url.search,
+      status: final.status,
+      duration: performance.now() - start,
+    });
+    return final;
+  };
+}

--- a/packages/mochi/src/sync/storage.ts
+++ b/packages/mochi/src/sync/storage.ts
@@ -1,0 +1,49 @@
+import { SQL } from 'bun';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+import { createPostgresStorage, createSqliteStorage } from 'reflectdb/server';
+import type { StorageAdapter } from 'reflectdb/server';
+import type { MochiSyncStorage } from './types';
+
+export interface SyncStorageHandle {
+  /** `undefined` for `'memory'` — reflectdb keeps its op log in-process. */
+  adapter: StorageAdapter | undefined;
+  close(): Promise<void>;
+}
+
+/**
+ * Build the reflectdb storage adapter for the configured store. `'memory'` uses reflectdb's built-in in-process log
+ * (no adapter). A sqlite file's parent directory is created first, mirroring the queue's `constructBoss`. Postgres is
+ * fed a Bun `SQL` connection adapted to reflectdb's `$1`-placeholder `PostgresClient` interface.
+ */
+export function createSyncStorage(storage: MochiSyncStorage): SyncStorageHandle {
+  if (storage === 'memory') {
+    return { adapter: undefined, close: async () => {} };
+  }
+
+  if ('sqlite' in storage) {
+    const file = storage.sqlite;
+    mkdirSync(path.dirname(path.resolve(file)), { recursive: true });
+    const adapter = createSqliteStorage({ path: file });
+    return {
+      adapter,
+      close: async () => {
+        adapter.close();
+      },
+    };
+  }
+
+  const sql = new SQL(storage.postgres);
+  const adapter = createPostgresStorage({
+    client: {
+      query: async (text: string, values?: unknown[]) => ({ rows: (await sql.unsafe(text, values ?? [])) as unknown as never[] }),
+    },
+  });
+  return {
+    adapter,
+    close: async () => {
+      adapter.close();
+      await sql.close();
+    },
+  };
+}

--- a/packages/mochi/src/sync/sync.client.svelte.ts
+++ b/packages/mochi/src/sync/sync.client.svelte.ts
@@ -24,17 +24,27 @@ function wsUrl(path: string): string {
   return `${proto}//${location.host}${path}`;
 }
 
+// crypto.randomUUID only exists in secure contexts (https/localhost); plain-http LAN dev needs the getRandomValues path.
+function randomId(): string {
+  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  const bytes = crypto.getRandomValues(new Uint8Array(16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x40;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
 function loadClientId(): string {
   try {
     const key = '__mochi_sync_client_id__';
     let id = localStorage.getItem(key);
     if (!id) {
-      id = crypto.randomUUID();
+      id = randomId();
       localStorage.setItem(key, id);
     }
     return id;
   } catch {
-    return crypto.randomUUID();
+    return randomId();
   }
 }
 
@@ -211,7 +221,7 @@ class SyncManager {
         return state.total;
       },
       insert: (payload, id) => {
-        const rowId = id ?? crypto.randomUUID();
+        const rowId = id ?? randomId();
         this.mutate((client) => client.insert(table, rowId, payload as Record<string, unknown>), table, true);
         return rowId;
       },

--- a/packages/mochi/src/sync/sync.client.svelte.ts
+++ b/packages/mochi/src/sync/sync.client.svelte.ts
@@ -1,0 +1,256 @@
+import { onDestroy } from 'svelte';
+import { SyncClient, pushSafely } from 'reflectdb/client';
+import type { SyncClientState } from 'reflectdb/client';
+import { createWsClientTransport } from 'reflectdb/transport/ws';
+import { pinGlobal } from '../utils/globalState';
+import type { MochiSyncHandle } from './types';
+
+type Status = MochiSyncHandle<unknown>['status'];
+
+interface SyncEndpoints {
+  /** Token endpoint. */
+  t: string;
+  /** WebSocket path. */
+  w: string;
+}
+
+function endpoints(): SyncEndpoints {
+  const cfg = (window as unknown as { __mochi_sync?: SyncEndpoints }).__mochi_sync;
+  return cfg ?? { t: '/_mochi/sync/token', w: '/_mochi/sync/ws' };
+}
+
+function wsUrl(path: string): string {
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  return `${proto}//${location.host}${path}`;
+}
+
+function loadClientId(): string {
+  try {
+    const key = '__mochi_sync_client_id__';
+    let id = localStorage.getItem(key);
+    if (!id) {
+      id = crypto.randomUUID();
+      localStorage.setItem(key, id);
+    }
+    return id;
+  } catch {
+    return crypto.randomUUID();
+  }
+}
+
+async function fetchTicket(): Promise<string> {
+  const res = await fetch(endpoints().t, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'same-origin',
+    body: '{}',
+  });
+  if (!res.ok) {
+    throw new Error(`sync token request failed: ${res.status}`);
+  }
+  const data = (await res.json()) as { token: string };
+  return data.token;
+}
+
+function mapStatus(state: SyncClientState): Status {
+  switch (state) {
+    case 'connected':
+      return 'connected';
+    case 'synced':
+      return 'synced';
+    case 'disconnected':
+      return 'disconnected';
+    default:
+      return 'connecting';
+  }
+}
+
+class TableState {
+  rows = $state<Record<string, unknown>[]>([]);
+  status = $state<Status>('connecting');
+  pending = $state(0);
+  total = $state<number | null>(null);
+  refs = 0;
+  unsub: (() => void) | null = null;
+}
+
+class SyncManager {
+  private clientId = loadClientId();
+  private client: SyncClient | null = null;
+  private ready: Promise<SyncClient> | null = null;
+  private tables = new Map<string, TableState>();
+
+  private ensureReady(): Promise<SyncClient> {
+    if (this.ready) {
+      return this.ready;
+    }
+    this.ready = (async () => {
+      const token = await fetchTicket();
+      const transport = createWsClientTransport({ url: wsUrl(endpoints().w) });
+      const client = new SyncClient({
+        clientId: this.clientId,
+        transport,
+        token,
+        onReauth: fetchTicket,
+        onError: () => this.markError(),
+        onSync: () => this.refreshAll(),
+      });
+      await client.init();
+      await client.connect();
+      this.client = client;
+      this.refreshStatus();
+      return client;
+    })();
+    return this.ready;
+  }
+
+  private refreshTable(table: string): void {
+    const state = this.tables.get(table);
+    if (!state || !this.client) {
+      return;
+    }
+    state.rows = this.client.getRows(table);
+    state.total = this.client.getTotalCount(table);
+    state.status = mapStatus(this.client.getState());
+    state.pending = this.client.getPendingCount();
+  }
+
+  private refreshStatus(): void {
+    if (!this.client) {
+      return;
+    }
+    const status = mapStatus(this.client.getState());
+    const pending = this.client.getPendingCount();
+    for (const state of this.tables.values()) {
+      state.status = status;
+      state.pending = pending;
+    }
+  }
+
+  private refreshAll(): void {
+    for (const table of this.tables.keys()) {
+      this.refreshTable(table);
+    }
+  }
+
+  private markError(): void {
+    for (const state of this.tables.values()) {
+      state.status = 'error';
+    }
+  }
+
+  private acquire(table: string, params?: Record<string, unknown>): TableState {
+    let state = this.tables.get(table);
+    if (!state) {
+      state = new TableState();
+      this.tables.set(table, state);
+    }
+    state.refs++;
+    const current = state;
+    this.ensureReady()
+      .then(async (client) => {
+        if (!current.unsub) {
+          const unsubTable = client.subscribeTable(table, () => this.refreshTable(table));
+          const unsubGlobal = client.subscribe(() => this.refreshStatus());
+          current.unsub = () => {
+            unsubTable();
+            unsubGlobal();
+          };
+        }
+        await client.sync(table, params);
+        // sync() only declares the subscription; the snapshot arrives on bootstrap. scheduleBootstrap coalesces
+        // multiple table subscriptions in the same tick into one bootstrap.
+        client.scheduleBootstrap();
+        this.refreshTable(table);
+      })
+      .catch(() => this.markError());
+    return state;
+  }
+
+  private release(table: string): void {
+    const state = this.tables.get(table);
+    if (!state) {
+      return;
+    }
+    state.refs--;
+    if (state.refs <= 0) {
+      state.unsub?.();
+      state.unsub = null;
+      this.tables.delete(table);
+      this.client?.unsync(table).catch(() => {});
+    }
+  }
+
+  private mutate(fn: (client: SyncClient) => void, table: string, push: boolean): void {
+    this.ensureReady()
+      .then((client) => {
+        fn(client);
+        if (push) {
+          // insert/update/delete only queue a pending op locally — pushSafely transmits it (and coalesces bursts).
+          void pushSafely(client);
+        }
+        this.refreshTable(table);
+      })
+      .catch(() => this.markError());
+  }
+
+  sync<Row>(table: string, params?: Record<string, unknown>): MochiSyncHandle<Row> {
+    const state = this.acquire(table, params);
+    let released = false;
+    return {
+      get rows() {
+        return state.rows as unknown as Row[];
+      },
+      get status() {
+        return state.status;
+      },
+      get pending() {
+        return state.pending;
+      },
+      get total() {
+        return state.total;
+      },
+      insert: (payload, id) => {
+        const rowId = id ?? crypto.randomUUID();
+        this.mutate((client) => client.insert(table, rowId, payload as Record<string, unknown>), table, true);
+        return rowId;
+      },
+      update: (id, payload) => {
+        this.mutate((client) => client.update(table, id, payload as Record<string, unknown>), table, true);
+      },
+      remove: (id) => {
+        this.mutate((client) => client.delete(table, id), table, true);
+      },
+      loadMore: (count) => {
+        this.mutate((client) => void client.loadMore(table, count), table, false);
+      },
+      destroy: () => {
+        if (!released) {
+          released = true;
+          this.release(table);
+        }
+      },
+    };
+  }
+}
+
+function manager(): SyncManager {
+  return pinGlobal('__mochi_sync_client__', () => new SyncManager());
+}
+
+/**
+ * Subscribe an island to a live sync table. Returns a reactive handle whose `rows`/`status`/`pending`/`total` update
+ * as the shared per-tab client syncs, plus optimistic `insert`/`update`/`remove`/`loadMore` mutators.
+ *
+ * v1 limitation: reflectdb keys subscriptions by table name, so one params set per table per tab — the last `sync()`
+ * call for a table wins its params.
+ */
+export function sync<Row = Record<string, unknown>>(table: string, params?: Record<string, unknown>): MochiSyncHandle<Row> {
+  const handle = manager().sync<Row>(table, params);
+  try {
+    onDestroy(() => handle.destroy());
+  } catch {
+    // Called outside a component init — the caller owns destroy().
+  }
+  return handle;
+}

--- a/packages/mochi/src/sync/sync.client.svelte.ts
+++ b/packages/mochi/src/sync/sync.client.svelte.ts
@@ -1,9 +1,10 @@
 import { onDestroy } from 'svelte';
 import { SyncClient, pushSafely } from 'reflectdb/client';
 import type { SyncClientState } from 'reflectdb/client';
+import type { ClientMessage, ClientTransport, ServerMessage } from 'reflectdb';
 import { createWsClientTransport } from 'reflectdb/transport/ws';
 import { pinGlobal } from '../utils/globalState';
-import type { MochiSyncHandle } from './types';
+import type { MochiSyncConnection, MochiSyncHandle, MochiSyncOptions_Client } from './types';
 
 type Status = MochiSyncHandle<unknown>['status'];
 
@@ -26,7 +27,9 @@ function wsUrl(path: string): string {
 
 // crypto.randomUUID only exists in secure contexts (https/localhost); plain-http LAN dev needs the getRandomValues path.
 function randomId(): string {
-  if (typeof crypto.randomUUID === 'function') return crypto.randomUUID();
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
   const bytes = crypto.getRandomValues(new Uint8Array(16));
   bytes[6] = (bytes[6]! & 0x0f) | 0x40;
   bytes[8] = (bytes[8]! & 0x3f) | 0x80;
@@ -34,7 +37,7 @@ function randomId(): string {
   return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
 }
 
-function loadClientId(): string {
+function baseClientId(): string {
   try {
     const key = '__mochi_sync_client_id__';
     let id = localStorage.getItem(key);
@@ -75,6 +78,62 @@ function mapStatus(state: SyncClientState): Status {
   }
 }
 
+/**
+ * A client transport whose socket can be dropped and recreated on demand. Going offline closes and discards the
+ * underlying `createWsClientTransport` (so the server session ends and no deltas arrive) without feeding the
+ * SyncClient a `disconnect` message — that would trigger reflectdb's own backoff reconnect and fight this control.
+ * While offline `send` throws, so `doPush` clears its in-flight marks and the ops stay cleanly pending for the next
+ * push after reconnect.
+ */
+class ManagedTransport implements ClientTransport {
+  private inner: (ClientTransport & { getSocket(): WebSocket | null }) | null = null;
+  private handler: ((message: ServerMessage) => void) | null = null;
+  online = true;
+
+  constructor(private url: string) {}
+
+  private ensureInner(): ClientTransport {
+    if (!this.inner) {
+      this.inner = createWsClientTransport({ url: this.url });
+      if (this.handler) {
+        this.inner.subscribe(this.handler);
+      }
+    }
+    return this.inner;
+  }
+
+  setOnline(value: boolean): void {
+    if (value === this.online) {
+      return;
+    }
+    this.online = value;
+    if (!value) {
+      void this.inner?.close();
+      this.inner = null;
+    }
+  }
+
+  async send(message: ClientMessage): Promise<void> {
+    if (!this.online) {
+      throw new Error('sync connection is offline');
+    }
+    return this.ensureInner().send(message);
+  }
+
+  subscribe(handler: (message: ServerMessage) => void): void {
+    this.handler = handler;
+    if (this.inner) {
+      this.inner.subscribe(handler);
+    }
+  }
+
+  async close(): Promise<void> {
+    this.online = false;
+    await this.inner?.close();
+    this.inner = null;
+  }
+}
+
 class TableState {
   rows = $state<Record<string, unknown>[]>([]);
   status = $state<Status>('connecting');
@@ -84,11 +143,26 @@ class TableState {
   unsub: (() => void) | null = null;
 }
 
-class SyncManager {
-  private clientId = loadClientId();
+/**
+ * One named sync connection: its own SyncClient, WebSocket, clientId, and per-table state. Two connections in the
+ * same tab are fully independent, so one can be taken offline and diverge from the other before resyncing.
+ */
+class SyncConnection {
+  private clientId: string;
+  private transport: ManagedTransport;
   private client: SyncClient | null = null;
   private ready: Promise<SyncClient> | null = null;
   private tables = new Map<string, TableState>();
+
+  online = $state(true);
+  connStatus = $state<Status>('connecting');
+  connPending = $state(0);
+
+  constructor(name: string) {
+    // Namespace the clientId per connection so reflectdb server sessions and client stores never collide.
+    this.clientId = `${baseClientId()}:${name}`;
+    this.transport = new ManagedTransport(wsUrl(endpoints().w));
+  }
 
   private ensureReady(): Promise<SyncClient> {
     if (this.ready) {
@@ -96,10 +170,9 @@ class SyncManager {
     }
     this.ready = (async () => {
       const token = await fetchTicket();
-      const transport = createWsClientTransport({ url: wsUrl(endpoints().w) });
       const client = new SyncClient({
         clientId: this.clientId,
-        transport,
+        transport: this.transport,
         token,
         onReauth: fetchTicket,
         onError: () => this.markError(),
@@ -114,6 +187,13 @@ class SyncManager {
     return this.ready;
   }
 
+  private statusOf(): Status {
+    if (!this.online) {
+      return 'disconnected';
+    }
+    return this.client ? mapStatus(this.client.getState()) : 'connecting';
+  }
+
   private refreshTable(table: string): void {
     const state = this.tables.get(table);
     if (!state || !this.client) {
@@ -121,16 +201,15 @@ class SyncManager {
     }
     state.rows = this.client.getRows(table);
     state.total = this.client.getTotalCount(table);
-    state.status = mapStatus(this.client.getState());
+    state.status = this.statusOf();
     state.pending = this.client.getPendingCount();
   }
 
   private refreshStatus(): void {
-    if (!this.client) {
-      return;
-    }
-    const status = mapStatus(this.client.getState());
-    const pending = this.client.getPendingCount();
+    const status = this.statusOf();
+    const pending = this.client?.getPendingCount() ?? 0;
+    this.connStatus = status;
+    this.connPending = pending;
     for (const state of this.tables.values()) {
       state.status = status;
       state.pending = pending;
@@ -141,9 +220,14 @@ class SyncManager {
     for (const table of this.tables.keys()) {
       this.refreshTable(table);
     }
+    this.refreshStatus();
   }
 
   private markError(): void {
+    if (!this.online) {
+      return;
+    }
+    this.connStatus = 'error';
     for (const state of this.tables.values()) {
       state.status = 'error';
     }
@@ -195,13 +279,64 @@ class SyncManager {
     this.ensureReady()
       .then((client) => {
         fn(client);
-        if (push) {
-          // insert/update/delete only queue a pending op locally — pushSafely transmits it (and coalesces bursts).
+        // insert/update/delete only queue a pending op locally — pushSafely transmits it. Skip the push while offline
+        // (the send would throw and reflectdb would log it); the queued op ships on the reconnect re-push instead.
+        if (push && this.online) {
           void pushSafely(client);
         }
         this.refreshTable(table);
       })
       .catch(() => this.markError());
+  }
+
+  setOnline(value: boolean): void {
+    if (value === this.online) {
+      return;
+    }
+    if (!value) {
+      this.transport.setOnline(false);
+      this.online = false;
+      this.refreshStatus();
+      return;
+    }
+
+    this.transport.setOnline(true);
+    this.online = true;
+    this.refreshStatus();
+    // Drive reflectdb's reconnect sequence explicitly: reconnect, re-declare every subscription, pull a fresh
+    // snapshot, and push the ops queued while offline. A fresh push (in-flight marks were cleared on the failed
+    // offline sends) re-sends everything pending.
+    void (async () => {
+      const client = this.client ?? (await this.ensureReady());
+      try {
+        await client.connect();
+        await Promise.allSettled([...this.tables.keys()].map((table) => client.sync(table)));
+        client.scheduleBootstrap();
+        await client.push();
+      } catch {
+        this.markError();
+      }
+      this.refreshAll();
+    })();
+  }
+
+  connection(): MochiSyncConnection {
+    // Reactive getters over the connection's $state, plus the offline/online control.
+    const self = this;
+    return {
+      get online() {
+        return self.online;
+      },
+      get status() {
+        return self.connStatus;
+      },
+      get pending() {
+        return self.connPending;
+      },
+      setOnline(value: boolean) {
+        self.setOnline(value);
+      },
+    };
   }
 
   sync<Row>(table: string, params?: Record<string, unknown>): MochiSyncHandle<Row> {
@@ -244,23 +379,47 @@ class SyncManager {
   }
 }
 
-function manager(): SyncManager {
-  return pinGlobal('__mochi_sync_client__', () => new SyncManager());
+class SyncRegistry {
+  private connections = new Map<string, SyncConnection>();
+
+  get(name: string): SyncConnection {
+    let connection = this.connections.get(name);
+    if (!connection) {
+      connection = new SyncConnection(name);
+      this.connections.set(name, connection);
+    }
+    return connection;
+  }
+}
+
+function registry(): SyncRegistry {
+  return pinGlobal('__mochi_sync_client__', () => new SyncRegistry());
 }
 
 /**
  * Subscribe an island to a live sync table. Returns a reactive handle whose `rows`/`status`/`pending`/`total` update
- * as the shared per-tab client syncs, plus optimistic `insert`/`update`/`remove`/`loadMore` mutators.
+ * as the connection syncs, plus optimistic `insert`/`update`/`remove`/`loadMore` mutators.
  *
- * v1 limitation: reflectdb keys subscriptions by table name, so one params set per table per tab — the last `sync()`
- * call for a table wins its params.
+ * Pass `{ connection }` to ride a named connection (each name has its own client, socket, and local store, shared per
+ * name per tab); omit it for the shared `'default'` connection. reflectdb keys subscriptions by table name, so one
+ * params set per table per connection — the last `sync()` call for a table wins its params.
  */
-export function sync<Row = Record<string, unknown>>(table: string, params?: Record<string, unknown>): MochiSyncHandle<Row> {
-  const handle = manager().sync<Row>(table, params);
+export function sync<Row = Record<string, unknown>>(table: string, params?: Record<string, unknown>, opts?: MochiSyncOptions_Client): MochiSyncHandle<Row> {
+  const handle = registry()
+    .get(opts?.connection ?? 'default')
+    .sync<Row>(table, params);
   try {
     onDestroy(() => handle.destroy());
   } catch {
     // Called outside a component init — the caller owns destroy().
   }
   return handle;
+}
+
+/**
+ * Control handle for a named sync connection (default `'default'`). Reactive `online`/`status`/`pending`, plus
+ * `setOnline(false)` to drop the socket while queuing local writes and `setOnline(true)` to reconnect and resync.
+ */
+export function syncConnection(name = 'default'): MochiSyncConnection {
+  return registry().get(name).connection();
 }

--- a/packages/mochi/src/sync/sync.ssr.ts
+++ b/packages/mochi/src/sync/sync.ssr.ts
@@ -1,0 +1,20 @@
+import type { MochiSyncHandle } from './types';
+
+/**
+ * Server-side inert stub for `sync()`. Islands run their top-level code during SSR, so this must never throw — it
+ * returns an empty, frozen handle. The real reactive client only runs after hydration in the browser (see
+ * `sync.client.svelte.ts`), so an island shows empty rows server-side until it connects.
+ */
+export function sync<Row = Record<string, unknown>>(_table: string, _params?: Record<string, unknown>): MochiSyncHandle<Row> {
+  return {
+    rows: [] as Row[],
+    status: 'connecting',
+    pending: 0,
+    total: null,
+    insert: () => crypto.randomUUID(),
+    update: () => {},
+    remove: () => {},
+    loadMore: () => {},
+    destroy: () => {},
+  };
+}

--- a/packages/mochi/src/sync/sync.ssr.ts
+++ b/packages/mochi/src/sync/sync.ssr.ts
@@ -1,11 +1,11 @@
-import type { MochiSyncHandle } from './types';
+import type { MochiSyncConnection, MochiSyncHandle, MochiSyncOptions_Client } from './types';
 
 /**
- * Server-side inert stub for `sync()`. Islands run their top-level code during SSR, so this must never throw — it
- * returns an empty, frozen handle. The real reactive client only runs after hydration in the browser (see
- * `sync.client.svelte.ts`), so an island shows empty rows server-side until it connects.
+ * Server-side inert stubs for `sync()` / `syncConnection()`. Islands run their top-level code during SSR, so these
+ * must never throw — they return empty, inert handles. The real reactive client only runs after hydration in the
+ * browser (see `sync.client.svelte.ts`), so an island shows empty rows server-side until it connects.
  */
-export function sync<Row = Record<string, unknown>>(_table: string, _params?: Record<string, unknown>): MochiSyncHandle<Row> {
+export function sync<Row = Record<string, unknown>>(_table: string, _params?: Record<string, unknown>, _opts?: MochiSyncOptions_Client): MochiSyncHandle<Row> {
   return {
     rows: [] as Row[],
     status: 'connecting',
@@ -16,5 +16,14 @@ export function sync<Row = Record<string, unknown>>(_table: string, _params?: Re
     remove: () => {},
     loadMore: () => {},
     destroy: () => {},
+  };
+}
+
+export function syncConnection(_name = 'default'): MochiSyncConnection {
+  return {
+    online: true,
+    status: 'connecting',
+    pending: 0,
+    setOnline: () => {},
   };
 }

--- a/packages/mochi/src/sync/ticket.test.ts
+++ b/packages/mochi/src/sync/ticket.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, test } from 'bun:test';
+import { mintSyncTicket, verifySyncTicket } from './ticket';
+
+const GLOBAL_CONFIG_KEY = '__mochi_config__';
+
+function installConfig(secret = 'test-key-for-sync-tickets-32byte'): void {
+  (globalThis as unknown as Record<string, unknown>)[GLOBAL_CONFIG_KEY] = {
+    options: {},
+    secretKey: Buffer.from(secret),
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as unknown as Record<string, unknown>)[GLOBAL_CONFIG_KEY];
+});
+
+describe('mintSyncTicket + verifySyncTicket', () => {
+  test('round-trips an auth context', () => {
+    installConfig();
+    const token = mintSyncTicket({ userId: 'alice', role: 'admin' }, 60_000);
+    const auth = verifySyncTicket(token);
+    expect(auth).toEqual({ userId: 'alice', role: 'admin' });
+  });
+
+  test('rejects an expired ticket', () => {
+    installConfig();
+    const token = mintSyncTicket({ userId: 'bob' }, -1);
+    expect(verifySyncTicket(token)).toBeNull();
+  });
+
+  test('rejects a tampered signature', () => {
+    installConfig();
+    const token = mintSyncTicket({ userId: 'carol' }, 60_000);
+    const [payload] = token.split('.');
+    const forged = `${payload}.${Buffer.from('not-the-real-signature').toString('base64url')}`;
+    expect(verifySyncTicket(forged)).toBeNull();
+  });
+
+  test('rejects a tampered payload', () => {
+    installConfig();
+    const token = mintSyncTicket({ userId: 'dave' }, 60_000);
+    const [, sig] = token.split('.');
+    const forgedPayload = Buffer.from(JSON.stringify({ auth: { userId: 'evil' }, exp: Date.now() + 60_000 }), 'utf-8').toString('base64url');
+    expect(verifySyncTicket(`${forgedPayload}.${sig}`)).toBeNull();
+  });
+
+  test('rejects a ticket minted under a different key', () => {
+    installConfig('key-one-for-sync-tickets-32byte!');
+    const token = mintSyncTicket({ userId: 'erin' }, 60_000);
+    installConfig('key-two-for-sync-tickets-32byte!');
+    expect(verifySyncTicket(token)).toBeNull();
+  });
+
+  test('rejects a malformed token', () => {
+    installConfig();
+    expect(verifySyncTicket('')).toBeNull();
+    expect(verifySyncTicket('no-dot')).toBeNull();
+    expect(verifySyncTicket('.onlysig')).toBeNull();
+  });
+
+  test('rejects a payload missing userId', () => {
+    installConfig();
+    const forgedPayload = Buffer.from(JSON.stringify({ auth: { notUserId: 'x' }, exp: Date.now() + 60_000 }), 'utf-8').toString('base64url');
+    // Sign it correctly so only the shape check can reject it.
+    const token = mintSyncTicket({ userId: 'placeholder' }, 60_000);
+    const [, realSig] = token.split('.');
+    // The real signature won't match the forged payload, so this also fails on signature — assert null regardless.
+    expect(verifySyncTicket(`${forgedPayload}.${realSig}`)).toBeNull();
+  });
+});

--- a/packages/mochi/src/sync/ticket.ts
+++ b/packages/mochi/src/sync/ticket.ts
@@ -1,0 +1,71 @@
+/**
+ * Signed short-lived tickets bridging Mochi's request-context auth to reflectdb's bearer-token auth callback.
+ *
+ * reflectdb only ever hands its `auth()` callback a synthesized Request carrying `Authorization: Bearer <token>` — it
+ * never sees the real cookies. So Mochi mints a ticket at a token endpoint (where full request context is available),
+ * and reflectdb verifies it as the bearer token, re-checking per ops batch. The signing key derives from the framework
+ * `secretKey`, so no separate secret is needed.
+ *
+ *   ticket = base64url(json{ auth, exp }) + '.' + base64url(HMAC-SHA256(key, payloadPart))
+ *
+ * A ticket may be honored slightly past `exp` on reflectdb's ops path, bounded by reflectdb's internal auth-cache TTL;
+ * expiry ultimately triggers reflectdb's `reauth`, and the client refetches a fresh ticket.
+ */
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import type { AuthContext } from 'reflectdb';
+import { getMochiConfig } from '../mochiConfig';
+
+interface TicketPayload {
+  auth: AuthContext;
+  exp: number;
+}
+
+// Memoized per secret — the derivation is pure in `secretKey`, and re-keying on the secret handles tests that
+// reconfigure. Mirrors `sivKey()` in `islands/payloadCrypto.ts`.
+let cachedKey: { secret: Buffer; key: Buffer } | undefined;
+function ticketKey(): Buffer {
+  const secret = getMochiConfig().secretKey;
+  if (!cachedKey || cachedKey.secret !== secret) {
+    cachedKey = { secret, key: createHmac('sha512', secret).update('mochi-sync-ticket-v1').digest() };
+  }
+  return cachedKey.key;
+}
+
+function sign(payloadPart: string): string {
+  return createHmac('sha256', ticketKey()).update(payloadPart).digest('base64url');
+}
+
+/** Mint a ticket for `auth`, valid for `ttlMs` from now. */
+export function mintSyncTicket(auth: AuthContext, ttlMs: number): string {
+  const payload: TicketPayload = { auth, exp: Date.now() + ttlMs };
+  const payloadPart = Buffer.from(JSON.stringify(payload), 'utf-8').toString('base64url');
+  return `${payloadPart}.${sign(payloadPart)}`;
+}
+
+/** Verify a ticket, returning its `AuthContext` or `null` on bad signature, malformed shape, or expiry. */
+export function verifySyncTicket(token: string): AuthContext | null {
+  const dot = token.indexOf('.');
+  if (dot <= 0) {
+    return null;
+  }
+  const payloadPart = token.slice(0, dot);
+  const sig = token.slice(dot + 1);
+  const expected = sign(payloadPart);
+  const sigBuf = Buffer.from(sig, 'base64url');
+  const expectedBuf = Buffer.from(expected, 'base64url');
+  if (sigBuf.length !== expectedBuf.length || !timingSafeEqual(sigBuf, expectedBuf)) {
+    return null;
+  }
+  try {
+    const payload = JSON.parse(Buffer.from(payloadPart, 'base64url').toString('utf-8')) as TicketPayload;
+    if (typeof payload?.exp !== 'number' || Date.now() > payload.exp) {
+      return null;
+    }
+    if (!payload.auth || typeof payload.auth.userId !== 'string') {
+      return null;
+    }
+    return payload.auth;
+  } catch {
+    return null;
+  }
+}

--- a/packages/mochi/src/sync/types.ts
+++ b/packages/mochi/src/sync/types.ts
@@ -93,3 +93,28 @@ export interface MochiSyncHandle<Row> {
   /** Release this handle's subscription (refcounted; the shared client stays up for other handles). */
   destroy(): void;
 }
+
+/** Options for `sync(table, params?, opts?)`. */
+export interface MochiSyncOptions_Client {
+  /**
+   * Which named connection this subscription rides. Each name gets its own client, WebSocket, and local store, so two
+   * connections can diverge (e.g. one taken offline). Shared per name per tab. Default: `'default'`.
+   */
+  connection?: string;
+}
+
+/**
+ * A control handle for one named sync connection, from `syncConnection(name)`. `online`, `status`, and `pending` are
+ * reactive ($state-backed); `setOnline(false)` drops the socket while keeping local rows and queuing writes locally,
+ * and `setOnline(true)` reconnects and resyncs, delivering the queued writes.
+ */
+export interface MochiSyncConnection {
+  /** `false` while the connection is held offline via `setOnline(false)`. */
+  readonly online: boolean;
+  /** Connection status (`'disconnected'` while offline). */
+  readonly status: MochiSyncHandle<unknown>['status'];
+  /** Ops queued locally but not yet acknowledged by the server. */
+  readonly pending: number;
+  /** Take the connection offline (`false`) or bring it back online and resync (`true`). */
+  setOnline(value: boolean): void;
+}

--- a/packages/mochi/src/sync/types.ts
+++ b/packages/mochi/src/sync/types.ts
@@ -1,0 +1,95 @@
+import type { AuthContext, InferParams, InferRow, RateLimitConfig, SyncPresenceDef, SyncQueryMap, SyncViewDef } from 'reflectdb';
+import type { ImplementOptions, RoomCallback } from 'reflectdb/server';
+
+/**
+ * A read-only view implementation. Mirrors reflectdb's (unexported) `ViewFn`: returns the view's rows for the given
+ * auth/params. `params` collapses to a loose record when the schema declares none.
+ */
+export type MochiSyncViewFn<TQueries extends SyncQueryMap, K extends keyof TQueries, TDb> = (
+  ctx: { auth: AuthContext; params: InferParams<TQueries, K> extends undefined ? Record<string, unknown> : InferParams<TQueries, K> },
+  db: TDb,
+) => InferRow<TQueries, K>[] | Promise<InferRow<TQueries, K>[]>;
+
+/**
+ * Where the sync op log lives: `'memory'` (reflectdb's built-in in-memory log, lost on restart), a SQLite file, or a
+ * Postgres database. Mirrors `MochiQueueStorage`, minus the queue-only `pglite` shape.
+ */
+export type MochiSyncStorage = 'memory' | { sqlite: string } | { postgres: string };
+
+/**
+ * Resolves the current request's identity for a sync connection. Runs at the Mochi token endpoint with full
+ * request context (cookies, locals) available via `getRequestContext()`. Return `null` to reject the connection;
+ * an `AuthContext` (`{ userId, … }`) to accept. Omit `auth` entirely to serve anonymous clients.
+ */
+export type MochiSyncAuthFn = (req: Request) => AuthContext | null | Promise<AuthContext | null>;
+
+/** Keys of a query map whose entry is a regular (writable) query — not a `view()` or `presence()` entry. */
+export type SyncRegularKeys<TQueries extends SyncQueryMap> = {
+  [K in keyof TQueries]: TQueries[K] extends SyncViewDef | SyncPresenceDef ? never : K;
+}[keyof TQueries];
+
+/** Keys of a query map whose entry is a `view()` (read-only computed query). */
+export type SyncViewKeys<TQueries extends SyncQueryMap> = {
+  [K in keyof TQueries]: TQueries[K] extends SyncViewDef ? K : never;
+}[keyof TQueries];
+
+/**
+ * Server-side sync configuration passed to `Mochi.serve({ sync: defineSync({ … }) })`.
+ *
+ * Generic over the query map and the (optional) database handle threaded into `query`/`mutate`. `defineSync()` keeps
+ * these generics for full inference at the call site while erasing them to the base shape stored on `MochiServeOptions`.
+ */
+export interface MochiSyncOptions<TQueries extends SyncQueryMap = SyncQueryMap, TDb = unknown> {
+  /** The shared schema built with `defineSyncQueries({ … })`. Imported by both server routes and islands. */
+  queries: TQueries;
+  /**
+   * Resolve the request's identity. Omit to serve anonymous clients (reflectdb's `allowAnonymous`). When present,
+   * a connection must present a valid ticket minted for a non-null `auth` result.
+   */
+  auth?: MochiSyncAuthFn;
+  /** Op-log storage. Default: `'memory'`. */
+  storage?: MochiSyncStorage;
+  /** Optional database handle, passed untouched to every `query`/`mutate`/`authorize`/`count`. */
+  db?: TDb;
+  /** Per-table implementations: `query` (read) plus optional `mutate`/`authorize`/`room`/`serverSet`/`broadcast`. */
+  tables: {
+    [K in SyncRegularKeys<TQueries> & string]: ImplementOptions<TQueries, K, AuthContext, TDb>;
+  };
+  /** Read-only computed queries declared with `view()` in the schema. */
+  views?: {
+    [K in SyncViewKeys<TQueries> & string]: MochiSyncViewFn<TQueries, K, TDb>;
+  };
+  /** Room access-control callbacks keyed by pattern (e.g. `'org/:orgId'`). */
+  rooms?: Record<string, RoomCallback>;
+  /** Global and per-table write rate limits. */
+  rateLimit?: RateLimitConfig;
+  /** Transport. Only `'ws'` is supported in v1; `'sse'` is reserved. Default: `'ws'`. */
+  transport?: 'ws';
+  /** Lifetime of a minted auth ticket in ms. Default: `600_000` (10 minutes). */
+  ticketTtlMs?: number;
+}
+
+/**
+ * The live handle returned by `sync<Row>(table)` inside an island. `rows`/`status`/`pending`/`total` are reactive
+ * ($state-backed) getters; the mutators optimistically update locally and sync to the server.
+ */
+export interface MochiSyncHandle<Row> {
+  /** The current rows for this table, reactive. */
+  readonly rows: Row[];
+  /** Connection status of the shared per-tab client. */
+  readonly status: 'connecting' | 'connected' | 'synced' | 'disconnected' | 'error';
+  /** Ops not yet acknowledged by the server. */
+  readonly pending: number;
+  /** Total server-side row count for windowed queries, or `null` when unknown. */
+  readonly total: number | null;
+  /** Optimistically insert a row; returns the generated (or supplied) row id. */
+  insert(payload: Partial<Row>, id?: string): string;
+  /** Optimistically patch a row by id. */
+  update(id: string, payload: Partial<Row>): void;
+  /** Optimistically delete a row by id. */
+  remove(id: string): void;
+  /** Grow a windowed subscription by `count` rows. */
+  loadMore(count: number): void;
+  /** Release this handle's subscription (refcounted; the shared client stays up for other handles). */
+  destroy(): void;
+}

--- a/packages/mochi/src/syncServe.test.ts
+++ b/packages/mochi/src/syncServe.test.ts
@@ -1,0 +1,187 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { defineSyncQueries, t } from 'reflectdb';
+import { createSyncClient } from 'reflectdb/client';
+import type { TypedSyncClient } from 'reflectdb/client';
+import { createWsClientTransport } from 'reflectdb/transport/ws';
+import { Mochi } from './Mochi';
+import { defineSync } from './sync/index';
+import { getRequestContext } from './runtime/requestContext';
+import { mochiEvents } from './events';
+
+type Todo = { id: string; text: string; done: boolean };
+
+const queries = defineSyncQueries({ todos: { row: t<Todo>() } });
+
+async function waitFor(fn: () => boolean, timeoutMs = 4000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+describe('Mochi.serve({ sync }) — authenticated, memory storage', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+  let wsUrl: string;
+  const store = new Map<string, Todo>();
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-sync-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      proxy: { hostHeader: 'host' },
+      sync: defineSync({
+        queries,
+        auth: () => {
+          const user = getRequestContext().cookies.get('mochi-sync-user');
+          return user ? { userId: user } : null;
+        },
+        tables: {
+          todos: {
+            query: () => [...store.values()],
+            mutate: async (op) => {
+              if (op.type === 'delete') {
+                store.delete(op.rowId);
+                return;
+              }
+              const payload = op.payload ?? {};
+              const existing = store.get(op.rowId) ?? { id: op.rowId, text: '', done: false };
+              store.set(op.rowId, { ...existing, ...payload, id: op.rowId } as Todo);
+            },
+          },
+        },
+      }),
+      routes: {
+        '/health': Mochi.api(async () => Response.json({ ok: true })),
+      },
+    });
+    base = `http://localhost:${server.port}`;
+    wsUrl = `ws://localhost:${server.port}/_mochi/sync/ws`;
+  });
+
+  afterAll(async () => {
+    await server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  async function fetchToken(cookie?: string): Promise<Response> {
+    return fetch(`${base}/_mochi/sync/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: base, ...(cookie ? { cookie } : {}) },
+      body: '{}',
+    });
+  }
+
+  test('token endpoint rejects a request without the auth cookie', async () => {
+    const res = await fetchToken();
+    expect(res.status).toBe(401);
+  });
+
+  test('token endpoint mints a ticket with the auth cookie', async () => {
+    const res = await fetchToken('mochi-sync-user=alice');
+    expect(res.status).toBe(200);
+    expect(res.headers.get('cache-control')).toBe('no-store');
+    const body = (await res.json()) as { token: string; ttlMs: number };
+    expect(typeof body.token).toBe('string');
+    expect(body.token.length).toBeGreaterThan(0);
+    expect(body.ttlMs).toBe(600_000);
+  });
+
+  test('token endpoint is POST-only and JSON-only', async () => {
+    const get = await fetch(`${base}/_mochi/sync/token`, { method: 'GET' });
+    expect(get.status).toBe(405);
+    const wrongType = await fetch(`${base}/_mochi/sync/token`, { method: 'POST', headers: { 'content-type': 'text/plain', origin: base }, body: 'x' });
+    expect(wrongType.status).toBe(415);
+  });
+
+  async function connectClient(clientId: string): Promise<TypedSyncClient<typeof queries>> {
+    const getTicket = async (): Promise<string> => {
+      const res = await fetchToken('mochi-sync-user=alice');
+      return ((await res.json()) as { token: string }).token;
+    };
+    const token = await getTicket();
+    const client = createSyncClient({
+      queries,
+      clientId,
+      transport: createWsClientTransport({ url: wsUrl }),
+      token,
+      onReauth: getTicket,
+    });
+    await client.init();
+    await client.connect();
+    await client.sync('todos');
+    client.scheduleBootstrap();
+    return client;
+  }
+
+  test('two clients sync inserts and server-side emits over the live socket', async () => {
+    const events: string[] = [];
+    mochiEvents.setHandler('test:sync-open', 'sync:open', () => events.push('open'));
+    mochiEvents.setHandler('test:sync-op', 'sync:op', (e) => events.push(`op:${e.accepted}`));
+
+    const a = await connectClient('client-a');
+    const b = await connectClient('client-b');
+
+    // Insert on A → server Map updated → B sees the delta. insert() only queues the op; push() transmits it.
+    const id = crypto.randomUUID();
+    a.insert('todos', id, { text: 'buy milk', done: false });
+    await a.push();
+
+    await waitFor(() => store.has(id));
+    expect(store.get(id)).toMatchObject({ text: 'buy milk', done: false });
+
+    await waitFor(() => b.getRows('todos').some((r) => r.id === id));
+    expect(b.getRows('todos').find((r) => r.id === id)).toMatchObject({ text: 'buy milk' });
+
+    // Server-side out-of-band write: update the store, then notifyChange re-runs the query and broadcasts the diff
+    // to every subscriber. (This is the primitive for an external-store app; emit()/applyServerOp write reflectdb's
+    // own mirror instead, which a store-backed query wouldn't observe.)
+    store.set('server-row', { id: 'server-row', text: 'from server', done: true });
+    await Mochi.sync<typeof queries>().notifyChange('todos');
+
+    await waitFor(() => a.getRows('todos').some((r) => r.id === 'server-row'));
+    await waitFor(() => b.getRows('todos').some((r) => r.id === 'server-row'));
+
+    expect(events).toContain('open');
+    expect(events.some((e) => e.startsWith('op:'))).toBe(true);
+
+    mochiEvents.removeHandler('test:sync-open');
+    mochiEvents.removeHandler('test:sync-op');
+    await a.close();
+    await b.close();
+  });
+
+  test('a garbage token is rejected by the server', async () => {
+    let rejected = false;
+    const client = createSyncClient({
+      queries,
+      clientId: 'client-bad',
+      transport: createWsClientTransport({ url: wsUrl }),
+      token: 'not-a-valid-ticket',
+      onError: () => {
+        rejected = true;
+      },
+    });
+    await client.init();
+    await client.connect().catch(() => {
+      rejected = true;
+    });
+    await client.sync('todos').catch(() => {
+      rejected = true;
+    });
+    // Give the server a beat to reject the handshake / auth.
+    await waitFor(() => rejected || client.getState() === 'disconnected', 3000).catch(() => {});
+    expect(rejected || client.getState() === 'disconnected').toBe(true);
+    await client.close();
+  });
+});

--- a/packages/mochi/src/syncServeAnonymous.test.ts
+++ b/packages/mochi/src/syncServeAnonymous.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { defineSyncQueries, t } from 'reflectdb';
+import { createSyncClient } from 'reflectdb/client';
+import { createWsClientTransport } from 'reflectdb/transport/ws';
+import { Mochi } from './Mochi';
+import { defineSync } from './sync/index';
+
+type Todo = { id: string; text: string; done: boolean };
+const queries = defineSyncQueries({ todos: { row: t<Todo>() } });
+
+async function waitFor(fn: () => boolean, timeoutMs = 4000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+describe('Mochi.serve({ sync }) — anonymous (no auth)', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+  let wsUrl: string;
+  const store = new Map<string, Todo>();
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-sync-anon-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      proxy: { hostHeader: 'host' },
+      sync: defineSync({
+        queries,
+        db: store,
+        tables: {
+          todos: {
+            query: (_ctx, db) => [...(db as Map<string, Todo>).values()],
+            mutate: async (op, _ctx, db) => {
+              const map = db as Map<string, Todo>;
+              if (op.type === 'delete') {
+                map.delete(op.rowId);
+                return;
+              }
+              map.set(op.rowId, { id: op.rowId, ...op.payload } as Todo);
+            },
+          },
+        },
+      }),
+      routes: { '/health': Mochi.api(async () => Response.json({ ok: true })) },
+    });
+    base = `http://localhost:${server.port}`;
+    wsUrl = `ws://localhost:${server.port}/_mochi/sync/ws`;
+  });
+
+  afterAll(async () => {
+    await server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('the token endpoint returns an anonymous token', async () => {
+    const res = await fetch(`${base}/_mochi/sync/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: base },
+      body: '{}',
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    expect(body.token).toBe('anonymous');
+  });
+
+  test('an anonymous client connects and syncs', async () => {
+    const client = createSyncClient({
+      queries,
+      clientId: 'anon-client',
+      transport: createWsClientTransport({ url: wsUrl }),
+      token: 'anonymous',
+    });
+    await client.init();
+    await client.connect();
+    await client.sync('todos');
+    client.scheduleBootstrap();
+
+    const id = crypto.randomUUID();
+    client.insert('todos', id, { text: 'anon todo', done: false });
+    await client.push();
+
+    await waitFor(() => store.has(id));
+    expect(store.get(id)).toMatchObject({ text: 'anon todo' });
+    await client.close();
+  });
+});

--- a/packages/mochi/src/syncServeOffline.test.ts
+++ b/packages/mochi/src/syncServeOffline.test.ts
@@ -1,0 +1,179 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { defineSyncQueries, t } from 'reflectdb';
+import { createSyncClient } from 'reflectdb/client';
+import type { TypedSyncClient } from 'reflectdb/client';
+import type { ClientMessage, ClientTransport, ServerMessage } from 'reflectdb';
+import { createWsClientTransport } from 'reflectdb/transport/ws';
+import { Mochi } from './Mochi';
+import { defineSync } from './sync/index';
+
+type Todo = { id: string; text: string; done: boolean };
+const queries = defineSyncQueries({ todos: { row: t<Todo>() } });
+
+async function waitFor(fn: () => boolean, timeoutMs = 4000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+/**
+ * Mirrors the framework's `ManagedTransport` (sync.client.svelte.ts): a client transport whose socket can be dropped
+ * and recreated so a connection can be taken offline and later reconnected — the mechanism behind `syncConnection`.
+ */
+class ManagedTransport implements ClientTransport {
+  private inner: (ClientTransport & { getSocket(): WebSocket | null }) | null = null;
+  private handler: ((message: ServerMessage) => void) | null = null;
+  online = true;
+  constructor(private url: string) {}
+  private ensureInner(): ClientTransport {
+    if (!this.inner) {
+      this.inner = createWsClientTransport({ url: this.url });
+      if (this.handler) {
+        this.inner.subscribe(this.handler);
+      }
+    }
+    return this.inner;
+  }
+  setOnline(value: boolean): void {
+    if (value === this.online) {
+      return;
+    }
+    this.online = value;
+    if (!value) {
+      void this.inner?.close();
+      this.inner = null;
+    }
+  }
+  async send(message: ClientMessage): Promise<void> {
+    if (!this.online) {
+      throw new Error('offline');
+    }
+    return this.ensureInner().send(message);
+  }
+  subscribe(handler: (message: ServerMessage) => void): void {
+    this.handler = handler;
+    if (this.inner) {
+      this.inner.subscribe(handler);
+    }
+  }
+  async close(): Promise<void> {
+    this.online = false;
+    await this.inner?.close();
+    this.inner = null;
+  }
+}
+
+describe('Mochi.serve({ sync }) — named connections + offline/reconnect', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let wsUrl: string;
+  const store = new Map<string, Todo>();
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-sync-offline-'));
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      proxy: { hostHeader: 'host' },
+      sync: defineSync({
+        queries,
+        db: store,
+        tables: {
+          todos: {
+            query: (_ctx, db) => [...(db as Map<string, Todo>).values()],
+            mutate: async (op, _ctx, db) => {
+              const map = db as Map<string, Todo>;
+              if (op.type === 'delete') {
+                map.delete(op.rowId);
+                return;
+              }
+              map.set(op.rowId, { id: op.rowId, ...op.payload } as Todo);
+            },
+          },
+        },
+      }),
+      routes: { '/health': Mochi.api(async () => Response.json({ ok: true })) },
+    });
+    wsUrl = `ws://localhost:${server.port}/_mochi/sync/ws`;
+  });
+
+  afterAll(async () => {
+    await server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  function ids(client: TypedSyncClient<typeof queries>): string[] {
+    return client
+      .getRows('todos')
+      .map((r) => r.id)
+      .sort();
+  }
+
+  async function connect(clientId: string, transport: ClientTransport): Promise<TypedSyncClient<typeof queries>> {
+    const client = createSyncClient({ queries, clientId, transport, token: 'anonymous' });
+    await client.init();
+    await client.connect();
+    await client.sync('todos');
+    client.scheduleBootstrap();
+    return client;
+  }
+
+  test('two connections diverge while one is offline, then converge after reconnect', async () => {
+    const aTransport = new ManagedTransport(wsUrl);
+    const a = await connect('conn-a', aTransport);
+    const b = await connect('conn-b', new ManagedTransport(wsUrl));
+
+    // Online: A's write reaches the server and B.
+    a.insert('todos', 'r1', { text: 'online', done: false });
+    await a.push();
+    await waitFor(() => store.has('r1'));
+    await waitFor(() => b.getRows('todos').some((r) => r.id === 'r1'));
+
+    // A goes offline — its socket drops, but local state survives.
+    aTransport.setOnline(false);
+    await new Promise((r) => setTimeout(r, 100));
+
+    // A writes while offline — ops queue locally, never reaching the server.
+    a.insert('todos', 'r2', { text: 'offline-a', done: false });
+    await a.push().catch(() => {});
+    await new Promise((r) => setTimeout(r, 100));
+    expect(a.getPendingCount()).toBe(1);
+    expect(store.has('r2')).toBe(false);
+    expect(ids(a)).toEqual(['r1', 'r2']);
+
+    // B writes while A is offline — A must NOT see it yet.
+    b.insert('todos', 'r3', { text: 'from-b', done: false });
+    await b.push();
+    await waitFor(() => store.has('r3'));
+    expect(a.getRows('todos').some((r) => r.id === 'r3')).toBe(false);
+
+    // A comes back online: reconnect, re-declare, bootstrap, push the queued op.
+    aTransport.setOnline(true);
+    await a.connect();
+    await a.sync('todos');
+    a.scheduleBootstrap();
+    await a.push();
+
+    // The offline op lands on the server, and A converges with B.
+    await waitFor(() => store.has('r2'));
+    await waitFor(() => a.getRows('todos').some((r) => r.id === 'r3'));
+    await waitFor(() => ids(a).join() === ids(b).join());
+
+    expect(a.getPendingCount()).toBe(0);
+    expect(ids(a)).toEqual(['r1', 'r2', 'r3']);
+    expect(ids(b)).toEqual(['r1', 'r2', 'r3']);
+    expect([...store.keys()].sort()).toEqual(['r1', 'r2', 'r3']);
+
+    await a.close();
+    await b.close();
+  });
+});

--- a/packages/mochi/src/syncServeSqlite.test.ts
+++ b/packages/mochi/src/syncServeSqlite.test.ts
@@ -1,0 +1,99 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { defineSyncQueries, t } from 'reflectdb';
+import { createSyncClient } from 'reflectdb/client';
+import { createWsClientTransport } from 'reflectdb/transport/ws';
+import { Mochi } from './Mochi';
+import { defineSync } from './sync/index';
+
+type Todo = { id: string; text: string; done: boolean };
+const queries = defineSyncQueries({ todos: { row: t<Todo>() } });
+
+async function waitFor(fn: () => boolean, timeoutMs = 4000): Promise<void> {
+  const start = Date.now();
+  while (!fn()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('waitFor timed out');
+    }
+    await new Promise((r) => setTimeout(r, 20));
+  }
+}
+
+describe('Mochi.serve({ sync }) — sqlite op-log storage', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let sqlitePath: string;
+  let base: string;
+  let wsUrl: string;
+  const store = new Map<string, Todo>();
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-sync-sqlite-'));
+    // Nested under a not-yet-created .db/ dir to exercise the parent-mkdir path.
+    sqlitePath = path.join(outDir, '.db', 'sync.sqlite');
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      logger: { enabled: false },
+      outDir,
+      proxy: { hostHeader: 'host' },
+      sync: defineSync({
+        queries,
+        db: store,
+        storage: { sqlite: sqlitePath },
+        tables: {
+          todos: {
+            query: (_ctx, db) => [...(db as Map<string, Todo>).values()],
+            mutate: async (op, _ctx, db) => {
+              (db as Map<string, Todo>).set(op.rowId, { id: op.rowId, ...op.payload } as Todo);
+            },
+          },
+        },
+      }),
+      routes: { '/health': Mochi.api(async () => Response.json({ ok: true })) },
+    });
+    base = `http://localhost:${server.port}`;
+    wsUrl = `ws://localhost:${server.port}/_mochi/sync/ws`;
+  });
+
+  afterAll(async () => {
+    await server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  test('creates the parent directory and the op-log file', async () => {
+    // The file is created eagerly when the storage adapter is built at boot.
+    expect(existsSync(sqlitePath)).toBe(true);
+  });
+
+  test('persists an insert to the op log', async () => {
+    const res = await fetch(`${base}/_mochi/sync/token`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', origin: base },
+      body: '{}',
+    });
+    const { token } = (await res.json()) as { token: string };
+    const client = createSyncClient({
+      queries,
+      clientId: 'sqlite-client',
+      transport: createWsClientTransport({ url: wsUrl }),
+      token,
+    });
+    await client.init();
+    await client.connect();
+    await client.sync('todos');
+    client.scheduleBootstrap();
+
+    const id = crypto.randomUUID();
+    client.insert('todos', id, { text: 'persisted', done: false });
+    await client.push();
+
+    await waitFor(() => store.has(id));
+    expect(existsSync(sqlitePath)).toBe(true);
+    // The op-log path must render with forward slashes on every platform.
+    expect(sqlitePath.split(path.sep).join('/')).not.toContain('\\');
+    await client.close();
+  });
+});

--- a/packages/mochi/src/types.ts
+++ b/packages/mochi/src/types.ts
@@ -11,6 +11,7 @@ import type { MochiProtectionOptions } from './protection/types';
 import type { MochiCronHandler, MochiCronRuntimeOptions } from './cron';
 import type { MochiProcessor, MochiQueueListeners, MochiQueueRuntimeOptions, MochiQueueStorage } from './queue';
 import type { MochiRateLimitOptions } from './runtime/rateLimit';
+import type { MochiSyncOptions } from './sync/types';
 import type { MochiSvelteCompiler } from './compiler/svelteCompilerBackend';
 import type { SpeculationRules } from './runtime/speculationRules';
 
@@ -680,6 +681,13 @@ export interface MochiServeOptions {
    * function for HTTP email APIs, or the default `log` transport, which logs in place of sending. See `MochiEmailOptions`.
    */
   email?: MochiEmailOptions;
+  /**
+   * Realtime data sync (reflectdb-backed): declare typed queries once with `defineSyncQueries`, implement
+   * `query`/`mutate` per table, and read/write live rows from islands with `sync()`. Auth is pluggable via a
+   * signed-ticket bridge; storage is `'memory'`, `{ sqlite }`, or `{ postgres }`; transport is WebSocket. Build the
+   * value with `defineSync({ … })`. See `MochiSyncOptions`. Default: disabled.
+   */
+  sync?: MochiSyncOptions;
   /**
    * Slide-to-verify captcha backing `mintCaptcha()` / `verifyCaptcha()` and the `<MochiCaptcha>` component, tuning proof-of-work
    * difficulty, the token timing floor and expiry, and the one-time nonce store used for replay protection. See `MochiCaptchaOptions`.

--- a/packages/site/src/demos/sync/SyncDemo.svelte
+++ b/packages/site/src/demos/sync/SyncDemo.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import DemoPage from '../../components/DemoPage.svelte';
+  import TodoList from './TodoList.svelte';
+  import { loadSources } from '../../components/utils.ts';
+  import { files } from './files.ts';
+
+  const sources = await loadSources(files);
+</script>
+
+<DemoPage
+  title="Realtime sync"
+  description="Two independent islands share one live todo list over a WebSocket. Add or toggle a todo in one and it appears in the other — the server is authoritative, writes are optimistic, and every tab stays in sync."
+  {sources}
+>
+  <div class="sync-grid">
+    <TodoList label="Island A" mochi:hydrate />
+    <TodoList label="Island B" mochi:hydrate />
+  </div>
+</DemoPage>
+
+<style>
+  .sync-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1rem;
+  }
+  @media (max-width: 640px) {
+    .sync-grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/packages/site/src/demos/sync/SyncDemo.svelte
+++ b/packages/site/src/demos/sync/SyncDemo.svelte
@@ -9,12 +9,12 @@
 
 <DemoPage
   title="Realtime sync"
-  description="Two independent islands share one live todo list over a WebSocket. Add or toggle a todo in one and it appears in the other — the server is authoritative, writes are optimistic, and every tab stays in sync."
+  description="Two islands, each on its own connection, share one live todo list over a WebSocket. Add or toggle a todo in one and it appears in the other. Take an island offline to watch it diverge — its writes queue locally — then bring it back online to reconnect and converge."
   {sources}
 >
   <div class="sync-grid">
-    <TodoList label="Island A" mochi:hydrate />
-    <TodoList label="Island B" mochi:hydrate />
+    <TodoList label="Island A" connection="island-a" mochi:hydrate />
+    <TodoList label="Island B" connection="island-b" mochi:hydrate />
   </div>
 </DemoPage>
 

--- a/packages/site/src/demos/sync/TodoList.svelte
+++ b/packages/site/src/demos/sync/TodoList.svelte
@@ -141,6 +141,7 @@
     align-items: center;
     gap: 0.5rem;
     font-size: 0.8rem;
+    min-height: 1.5rem;
   }
   .status {
     font-variant-numeric: tabular-nums;

--- a/packages/site/src/demos/sync/TodoList.svelte
+++ b/packages/site/src/demos/sync/TodoList.svelte
@@ -1,12 +1,15 @@
 <script lang="ts">
-  import { sync } from 'mochi-framework';
+  import { sync, syncConnection } from 'mochi-framework';
   import type { Todo } from './schema';
 
-  let { label = 'Client' } = $props();
+  let { label = 'Client', connection = 'default' } = $props();
 
-  const todos = sync<Todo>('todos');
+  const todos = sync<Todo>('todos', undefined, { connection });
+  const conn = syncConnection(connection);
 
   let text = $state('');
+  let editingId = $state<string | null>(null);
+  let editText = $state('');
 
   function add() {
     const value = text.trim();
@@ -16,12 +19,37 @@
     todos.insert({ text: value, done: false });
     text = '';
   }
+
+  function startEdit(id: string, current: string) {
+    editingId = id;
+    editText = current;
+  }
+
+  function commitEdit() {
+    if (editingId === null) {
+      return;
+    }
+    const value = editText.trim();
+    if (value) {
+      todos.update(editingId, { text: value });
+    }
+    editingId = null;
+  }
 </script>
 
-<div class="todo-island">
+<div class="todo-island" class:offline={!conn.online}>
   <div class="head">
     <strong>{label}</strong>
-    <span class="status" data-status={todos.status}>{todos.status}{todos.pending > 0 ? ` · ${todos.pending} pending` : ''}</span>
+    <button type="button" class="toggle" data-online={conn.online} onclick={() => conn.setOnline(!conn.online)}>
+      {conn.online ? 'Go offline' : 'Go online'}
+    </button>
+  </div>
+
+  <div class="status-line">
+    <span class="status" data-status={conn.status}>{conn.status}</span>
+    {#if conn.pending > 0}
+      <span class="pending">{conn.pending} queued</span>
+    {/if}
   </div>
 
   <form
@@ -37,11 +65,33 @@
   <ul>
     {#each todos.rows as todo (todo.id)}
       <li>
-        <label>
-          <input type="checkbox" checked={todo.done} onchange={() => todos.update(todo.id, { done: !todo.done })} />
-          <span class:done={todo.done}>{todo.text}</span>
-        </label>
-        <button class="remove" onclick={() => todos.remove(todo.id)} aria-label="Delete todo">×</button>
+        {#if editingId === todo.id}
+          <input
+            class="edit"
+            type="text"
+            bind:value={editText}
+            aria-label="Edit todo text"
+            onblur={commitEdit}
+            onkeydown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                commitEdit();
+              } else if (e.key === 'Escape') {
+                editingId = null;
+              }
+            }}
+            {@attach (node) => {
+              node.focus();
+              node.select();
+            }}
+          />
+        {:else}
+          <label>
+            <input type="checkbox" checked={todo.done} onchange={() => todos.update(todo.id, { done: !todo.done })} />
+            <button type="button" class="text" class:done={todo.done} onclick={() => startEdit(todo.id, todo.text)} title="Click to edit">{todo.text}</button>
+          </label>
+          <button class="remove" onclick={() => todos.remove(todo.id)} aria-label="Delete todo">×</button>
+        {/if}
       </li>
     {:else}
       <li class="empty">No todos yet.</li>
@@ -56,15 +106,43 @@
     padding: 1rem;
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
+    gap: 0.6rem;
+    transition: opacity 0.15s;
+  }
+  .todo-island.offline {
+    opacity: 0.85;
+    border-style: dashed;
   }
   .head {
     display: flex;
     align-items: center;
     justify-content: space-between;
   }
-  .status {
+  .toggle {
+    padding: 0.3rem 0.7rem;
+    border-radius: 6px;
+    border: 1px solid var(--border, #d0d0d0);
+    cursor: pointer;
+    font-size: 0.85rem;
+    font-weight: 600;
+  }
+  .toggle[data-online='true'] {
+    background: #16a34a;
+    border-color: #16a34a;
+    color: #fff;
+  }
+  .toggle[data-online='false'] {
+    background: #dc2626;
+    border-color: #dc2626;
+    color: #fff;
+  }
+  .status-line {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
     font-size: 0.8rem;
+  }
+  .status {
     font-variant-numeric: tabular-nums;
     opacity: 0.7;
   }
@@ -77,6 +155,13 @@
   .status[data-status='disconnected'] {
     color: #dc2626;
     opacity: 1;
+  }
+  .pending {
+    padding: 0.05rem 0.45rem;
+    border-radius: 999px;
+    background: #f59e0b;
+    color: #fff;
+    font-variant-numeric: tabular-nums;
   }
   form {
     display: flex;
@@ -112,11 +197,30 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex: 1;
     cursor: pointer;
+  }
+  .text {
+    flex: 1;
+    text-align: left;
+    padding: 0.1rem 0.25rem;
+    border: 1px solid transparent;
+    border-radius: 4px;
+    background: none;
+    cursor: text;
+  }
+  .text:hover {
+    border-color: var(--border, #d0d0d0);
   }
   .done {
     text-decoration: line-through;
     opacity: 0.6;
+  }
+  input.edit {
+    flex: 1;
+    padding: 0.3rem 0.5rem;
+    border: 1px solid var(--border, #d0d0d0);
+    border-radius: 6px;
   }
   .empty {
     opacity: 0.5;

--- a/packages/site/src/demos/sync/TodoList.svelte
+++ b/packages/site/src/demos/sync/TodoList.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { sync } from 'mochi-framework';
+  import type { Todo } from './schema';
+
+  let { label = 'Client' } = $props();
+
+  const todos = sync<Todo>('todos');
+
+  let text = $state('');
+
+  function add() {
+    const value = text.trim();
+    if (!value) {
+      return;
+    }
+    todos.insert({ text: value, done: false });
+    text = '';
+  }
+</script>
+
+<div class="todo-island">
+  <div class="head">
+    <strong>{label}</strong>
+    <span class="status" data-status={todos.status}>{todos.status}{todos.pending > 0 ? ` · ${todos.pending} pending` : ''}</span>
+  </div>
+
+  <form
+    onsubmit={(e) => {
+      e.preventDefault();
+      add();
+    }}
+  >
+    <input type="text" bind:value={text} placeholder="Add a todo…" aria-label="Todo text" />
+    <button type="submit">Add</button>
+  </form>
+
+  <ul>
+    {#each todos.rows as todo (todo.id)}
+      <li>
+        <label>
+          <input type="checkbox" checked={todo.done} onchange={() => todos.update(todo.id, { done: !todo.done })} />
+          <span class:done={todo.done}>{todo.text}</span>
+        </label>
+        <button class="remove" onclick={() => todos.remove(todo.id)} aria-label="Delete todo">×</button>
+      </li>
+    {:else}
+      <li class="empty">No todos yet.</li>
+    {/each}
+  </ul>
+</div>
+
+<style>
+  .todo-island {
+    border: 1px solid var(--border, #d0d0d0);
+    border-radius: 8px;
+    padding: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+  }
+  .head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .status {
+    font-size: 0.8rem;
+    font-variant-numeric: tabular-nums;
+    opacity: 0.7;
+  }
+  .status[data-status='synced'],
+  .status[data-status='connected'] {
+    color: #16a34a;
+    opacity: 1;
+  }
+  .status[data-status='error'],
+  .status[data-status='disconnected'] {
+    color: #dc2626;
+    opacity: 1;
+  }
+  form {
+    display: flex;
+    gap: 0.5rem;
+  }
+  input[type='text'] {
+    flex: 1;
+    padding: 0.4rem 0.6rem;
+    border: 1px solid var(--border, #d0d0d0);
+    border-radius: 6px;
+  }
+  button {
+    padding: 0.4rem 0.8rem;
+    border-radius: 6px;
+    border: 1px solid var(--border, #d0d0d0);
+    cursor: pointer;
+  }
+  ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+  li {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+  li label {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    cursor: pointer;
+  }
+  .done {
+    text-decoration: line-through;
+    opacity: 0.6;
+  }
+  .empty {
+    opacity: 0.5;
+    font-style: italic;
+  }
+  .remove {
+    padding: 0.1rem 0.5rem;
+    line-height: 1;
+  }
+</style>

--- a/packages/site/src/demos/sync/files.ts
+++ b/packages/site/src/demos/sync/files.ts
@@ -1,0 +1,9 @@
+import type { SourceSpec } from '../../components/utils.ts';
+
+export const files: SourceSpec[] = [
+  { label: 'schema.ts', path: './src/demos/sync/schema.ts' },
+  { label: 'TodoList.svelte', path: './src/demos/sync/TodoList.svelte' },
+  { label: 'SyncDemo.svelte', path: './src/demos/sync/SyncDemo.svelte' },
+  { label: 'routes.ts', path: './src/demos/sync/routes.ts' },
+  { label: 'index.ts', path: './src/demoIndex.ts' },
+];

--- a/packages/site/src/demos/sync/routes.ts
+++ b/packages/site/src/demos/sync/routes.ts
@@ -1,0 +1,59 @@
+import { Mochi, getRequestContext } from 'mochi-framework';
+import { defineSync } from 'mochi-framework/sync';
+import type { MochiRouteValue } from 'mochi-framework';
+import { queries, type Todo } from './schema';
+
+// A per-server in-memory store keyed by table. Real apps back this with a database; a Map keeps the demo self-contained.
+const todos = new Map<string, Todo>();
+
+function isValidTodo(payload: Record<string, unknown> | null): payload is Partial<Todo> {
+  if (!payload) {
+    return false;
+  }
+  if ('text' in payload && typeof payload.text !== 'string') {
+    return false;
+  }
+  if ('done' in payload && typeof payload.done !== 'boolean') {
+    return false;
+  }
+  return true;
+}
+
+export const sync = defineSync({
+  queries,
+  db: todos,
+  auth: (): { userId: string } | null => {
+    const userId = getRequestContext().cookies.get('mochi-sync-user');
+    return userId ? { userId } : null;
+  },
+  tables: {
+    todos: {
+      query: (_ctx, db) => [...db.values()],
+      mutate: async (op, _ctx, db) => {
+        if (op.type === 'delete') {
+          db.delete(op.rowId);
+          return;
+        }
+        // `t<Todo>()` is compile-time only — validate the payload before writing.
+        if (!isValidTodo(op.payload)) {
+          return;
+        }
+        const existing = db.get(op.rowId) ?? { id: op.rowId, text: '', done: false };
+        db.set(op.rowId, { ...existing, ...op.payload, id: op.rowId });
+      },
+    },
+  },
+});
+
+export const routes: Record<string, MochiRouteValue> = {
+  '/demos/sync': Mochi.page('./src/demos/sync/SyncDemo.svelte', {
+    serverProps: () => {
+      // Assign a stable per-visitor id so the sync auth callback has a cookie to read.
+      const { cookies } = getRequestContext();
+      if (!cookies.get('mochi-sync-user')) {
+        cookies.set('mochi-sync-user', crypto.randomUUID(), { path: '/', maxAge: 604800, sameSite: 'lax' });
+      }
+      return {};
+    },
+  }),
+};

--- a/packages/site/src/demos/sync/routes.ts
+++ b/packages/site/src/demos/sync/routes.ts
@@ -5,6 +5,13 @@ import { queries, type Todo } from './schema';
 
 // A per-server in-memory store keyed by table. Real apps back this with a database; a Map keeps the demo self-contained.
 const todos = new Map<string, Todo>();
+for (const todo of [
+  { id: 'seed-1', text: 'Try the offline toggle', done: false },
+  { id: 'seed-2', text: 'Add a todo in the other island', done: false },
+  { id: 'seed-3', text: 'Watch both islands stay in sync', done: true },
+] satisfies Todo[]) {
+  todos.set(todo.id, todo);
+}
 
 function isValidTodo(payload: Record<string, unknown> | null): payload is Partial<Todo> {
   if (!payload) {

--- a/packages/site/src/demos/sync/schema.ts
+++ b/packages/site/src/demos/sync/schema.ts
@@ -1,0 +1,7 @@
+import { defineSyncQueries, t } from 'mochi-framework/sync';
+
+export type Todo = { id: string; text: string; done: boolean };
+
+export const queries = defineSyncQueries({
+  todos: { row: t<Todo>() },
+});

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -15,7 +15,7 @@ import { handle as cookieVaryTestHandle } from './demos/cookie-vary-test/routes'
 import { handle as modeWatcherHandle } from './demos/mode-watcher/routes';
 import { handle as shotHandle } from './shot/routes';
 import { encodeDebugBarGlobals } from './lib/debugBarEncode';
-import { routes, queues, cron } from './routes';
+import { routes, queues, cron, sync } from './routes';
 
 const DEVELOPMENT = process.env.MODE === 'development';
 const IS_DOCKER = process.env.MOCHI_DOCKER === 'true';
@@ -250,6 +250,7 @@ await Mochi.serve({
   routes,
   queues,
   cron,
+  sync,
 });
 
 logger.info('Server running at ' + origin);

--- a/packages/site/src/lib/demoIcons.ts
+++ b/packages/site/src/lib/demoIcons.ts
@@ -8,6 +8,7 @@ import MessageCircle from '@lucide/svelte/icons/message-circle';
 import Webhook from '@lucide/svelte/icons/webhook';
 import Share2 from '@lucide/svelte/icons/share-2';
 import AudioWaveform from '@lucide/svelte/icons/audio-waveform';
+import RadioTower from '@lucide/svelte/icons/radio-tower';
 import ComponentIcon from '@lucide/svelte/icons/component';
 import Telescope from '@lucide/svelte/icons/telescope';
 import Package2 from '@lucide/svelte/icons/package-2';
@@ -86,6 +87,7 @@ export const demoIconFor: Record<string, DemoIconMeta> = {
   'Rate Limiting': { icon: Gauge, label: 'Per-route request throttling by IP' },
   'Shared State': { icon: Share2, label: 'Shared $state across islands' },
   'Real-time Streams': { icon: AudioWaveform, label: 'WebSocket + SSE streams' },
+  'Realtime sync': { icon: RadioTower, label: 'Live data sync across islands over WebSocket' },
   'Background jobs with queues': { icon: Inbox, label: 'Embedded job queue + worker' },
   'Scheduled jobs with cron': { icon: CalendarClock, label: 'Recurring job on a cron schedule' },
   'Static Directories': { icon: FolderOpen, label: 'Mount a directory tree with staticDirs' },

--- a/packages/site/src/lib/demos.ts
+++ b/packages/site/src/lib/demos.ts
@@ -55,6 +55,7 @@ import { files as serverProps } from '../demos/server-props/files.ts';
 import { files as sharedState } from '../demos/shared-state/files.ts';
 import { files as staticDirs } from '../demos/static-dirs/files.ts';
 import { files as streams } from '../demos/streams/files.ts';
+import { files as sync } from '../demos/sync/files.ts';
 import { files as tanstackTable } from '../demos/tanstack-table/files.ts';
 import { files as url } from '../demos/url/files.ts';
 import { files as varlock } from '../demos/varlock/files.ts';
@@ -293,6 +294,14 @@ export const demos: Demo[] = [
     files: streams,
     title: 'Real-time Streams',
     hook: 'How server-sent events and WebSocket streaming work — live SSE and WebSocket clocks, lazily hydrated via mochi:hydrate:visible.',
+    category: 'endpoints',
+  },
+  {
+    href: '/demos/sync/',
+    slug: 'sync',
+    files: sync,
+    title: 'Realtime sync',
+    hook: 'How Mochi sync works — declare a typed schema once, then read and write a live server-authoritative dataset from islands with a runes-backed sync() over WebSocket.',
     category: 'endpoints',
   },
   {

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -79,6 +79,7 @@ import { routes as serverPropsRoutes } from './demos/server-props/routes';
 import { routes as sharedStateRoutes } from './demos/shared-state/routes';
 import { routes as staticDirsRoutes } from './demos/static-dirs/routes';
 import { routes as streamsRoutes } from './demos/streams/routes';
+import { routes as syncRoutes, sync } from './demos/sync/routes';
 import { routes as tanstackTableRoutes } from './demos/tanstack-table/routes';
 import { routes as urlRoutes } from './demos/url/routes';
 import { routes as varlockRoutes } from './demos/varlock/routes';
@@ -402,6 +403,7 @@ export const routes: Record<string, MochiRouteValue> = {
   ...sharedStateRoutes,
   ...staticDirsRoutes,
   ...streamsRoutes,
+  ...syncRoutes,
   ...tanstackTableRoutes,
   ...urlRoutes,
   ...varlockRoutes,
@@ -415,3 +417,5 @@ export const queues: MochiQueueConfig[] = [...queueQueues];
 
 // Scheduled jobs, mounted in Mochi.serve({ cron }) (see src/index.ts).
 export const cron: MochiCronConfig[] = [...cronJobs];
+
+export { sync };


### PR DESCRIPTION
## Mochi sync — reflectdb-backed realtime data sync

Adds a first-class realtime data-sync subsystem: declare a typed schema once, implement `query`/`mutate` on the server, and read/write live rows from hydrated islands with a runes-backed `sync()`. The server is authoritative, client writes are optimistic, and updates fan out to every subscriber over one WebSocket. Backed by [reflectdb](https://github.com/TimMikeladze/reflectdb) v0.1.3 (exact-pinned, a hard dependency of `mochi-framework`).

### User API

**Shared schema** (`mochi-framework/sync` — isomorphic, imported by server routes *and* islands; pure re-exports, no runtime):
```ts
import { defineSyncQueries, t } from 'mochi-framework/sync';
export type Todo = { id: string; text: string; done: boolean };
export const queries = defineSyncQueries({ todos: { row: t<Todo>() } });
```

**Server** (`Mochi.serve({ sync })`):
```ts
import { defineSync } from 'mochi-framework/sync';
const todos = new Map<string, Todo>();
Mochi.serve({
  sync: defineSync({
    queries,
    db: todos,                                   // threaded to query/mutate
    auth: (req) => {                             // omit → anonymous
      const userId = getRequestContext().cookies.get('user');
      return userId ? { userId } : null;
    },
    storage: { sqlite: '.db/sync.sqlite' },       // 'memory' (default) | { sqlite } | { postgres }
    tables: {
      todos: {
        query: (ctx, db) => [...db.values()],
        mutate: async (op, ctx, db) => { /* validate + persist */ },
      },
    },
    // views?, rooms?, rateLimit?, ticketTtlMs? (default 600_000)
  }),
});
```

**Island** (Svelte 5 runes; SSR-safe inert stub server-side):
```ts
import { sync } from 'mochi-framework';
const todos = sync<Todo>('todos'); // { rows, status, pending, total, insert, update, remove, loadMore, destroy }
```

**Server writes:** `Mochi.sync()` returns the live typed reflectdb server (`.notifyChange()`, `.emit()`, `.applyServerOp()`, `.tx()`, …); throws clearly if `sync` was never configured.

### Auth design (signed HMAC ticket)

reflectdb's auth callback only ever sees a bearer token, never the real cookies. So Mochi mints a short-lived HMAC ticket at a dedicated token endpoint (`<assetPrefix>/sync/token`) where the full request context *is* available: the pluggable `auth(req)` runs there with cookies/locals, and Mochi signs `{auth, exp}` with the framework `secretKey` (`mochi-sync-ticket-v1` label, `timingSafeEqual` verify). reflectdb re-verifies the ticket as the bearer token per ops batch; expiry triggers its built-in `reauth` → the client transparently refetches. The token endpoint is POST-only (405) and JSON-only (415), so it is CSRF-safe by construction.

### Storage

`'memory'` (reflectdb's in-process op log, default) · `{ sqlite: path }` (parent dir auto-created, `bun:sqlite`) · `{ postgres: url }` (a Bun `SQL` connection adapted to reflectdb's `$1`-placeholder client, for HA). Mirrors `MochiQueueStorage` shape minus `pglite`.

### v1 limitations

- **WebSocket transport only** (`transport: 'ws'`; `'sse'` reserved, rejected with a clear message).
- **One params-set per table per tab** — reflectdb keys subscriptions by table name; the last `sync(table, params)` wins.
- **`t<Row>()` is compile-time only** — no runtime validation; validate `op.payload` inside `mutate`.

### Notable behavior discovered & handled

- reflectdb executes a `query` **only when its `db` is truthy** (otherwise snapshots come back empty and nothing broadcasts). Mochi defaults `db` to `{}` so a query that closes over its own store still runs — `db` stays genuinely optional.
- `emit()`/`applyServerOp()` write reflectdb's internal mirror, which a store-backed `query` won't observe. For external-store apps the server-write primitive is *write your store, then `notifyChange()`* — documented, and what the demo/tests use.

### Wiring

- `Mochi.ts`: fail-fast `validateSyncOptions` before config pins; `startSyncRuntime` + token route + WS-upgrade route (both slash forms, registered before the `baseBunRoutes` snapshot so dev-reload preserves them); shell injects `window.__mochi_sync` ahead of island bundles; `Mochi.sync()` static accessor; `closeSyncRuntime()` on shutdown.
- `sync()` client delivery uses the established `enhance` pattern — all four registration spots (server/client `mochi-env` templates + `virtualModuleTemplate.ts` + `index.ts`); SSR stub is inert, the real rune module ships only to the browser.
- Four new lifecycle events: `sync:open` / `sync:close` / `sync:op` / `sync:error`, logged by `consoleLogger()`.

### Risk that did NOT materialize

The SSR island build compiles `mochi-framework/sync` (reflectdb core) cleanly — no `external` entry, no phantom re-implementation fallback needed. Confirmed by the demo smoke test.

### Tests & verification

- `sync/ticket.test.ts` — mint/verify round-trip, expiry, sig/payload tamper, key-change invalidation, malformed tokens.
- `sync/config.test.ts` — `validateSyncOptions` / `isValidSyncStorage` accept/reject matrix (storage shapes, `sse`, view/presence/unknown/missing table keys).
- `syncServe.test.ts` (e2e, memory, cookie auth) — token 401/200, POST-only/JSON-only, two real reflectdb clients bootstrap + insert delta, server-side `notifyChange` reaches both, garbage token rejected, `sync:open`/`sync:op` events.
- `syncServeAnonymous.test.ts` — no `auth` → `'anonymous'` token, connect + sync.
- `syncServeSqlite.test.ts` — `{ sqlite }` parent-mkdir + op-log file, POSIX-path guard.
- Full suite green: **mochi-framework 187/187 files**, site 14/14, support 3/3; `bun run checks` and `bun run syncpack` exit 0.
- Browser smoke (`/demos/sync/`, chrome-devtools MCP): two `TodoList` islands hydrate clean, token POST 200, WS `sync:open` + `ops +1` in the log, a todo added in Island A appears live in Island B, console clean.

### Demo & docs

- `packages/site/src/demos/sync/` — two side-by-side `sync<Todo>('todos')` islands sharing a live todo list; cookie-seeded per-visitor auth; registered in `lib/demos.ts` + `lib/demoIcons.ts` (RadioTower).
- `packages/docs/119-sync.md` — schema / serve config / storage / auth / island `sync()` / server writes, with `VersionNote since="0.10.0"` (release-please treats the `feat:` commit as minor → 0.10.0).

Draft — not for merge.
