### PR TITLE
ci: test against Bun canary

### DIFF
--- a/.github/workflows/cli-regression-test.yml
+++ b/.github/workflows/cli-regression-test.yml
@@ -8,15 +8,26 @@ on:
 jobs:
   cli-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bun: [stable, canary]
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Set up Bun
+      - name: Set up Bun (stable)
+        if: matrix.bun == 'stable'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
+
+      - name: Set up Bun (canary)
+        if: matrix.bun == 'canary'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
 
       - name: Run CLI regression test
         run: bun run cli-test
@@ -35,7 +46,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: cli-regression-report
+          name: cli-regression-report-${{ matrix.bun }}
           path: cli-tests/*-report.md
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,19 +23,29 @@ jobs:
     # Fail fast on a hung step instead of burning the 6h account default (a
     # Windows Shiki-engine hang once ran for 6h before being cancelled).
     timeout-minutes: 20
+    # Canary is a moving upstream target; let its legs fail without turning CI red.
+    continue-on-error: ${{ matrix.bun == 'canary' }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        bun: [stable, canary]
 
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
 
-      - name: Set up Bun
+      - name: Set up Bun (stable)
+        if: matrix.bun == 'stable'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version-file: .bun-version
+
+      - name: Set up Bun (canary)
+        if: matrix.bun == 'canary'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: canary
 
       - name: Cache Bun dependencies
         uses: actions/cache@v6


### PR DESCRIPTION
## What

Adds Bun **canary** coverage to CI alongside the existing stable (1.4.0) testing.

### `test.yml` — per-PR/push, non-blocking
- Extends the `test-matrix` job with a `bun: [stable, canary]` dimension, keeping full 3-OS coverage (Linux/macOS/Windows) on both → 6 legs.
- Canary legs run `continue-on-error: ${{ matrix.bun == 'canary' }}`, so a broken upstream canary never fails a PR or the `test` gate, but its failures stay visible in the run.
- Bun is installed via two conditional steps: stable uses `bun-version-file: .bun-version`, canary uses `bun-version: canary`.

### `cli-regression-test.yml` — scheduled, stable + canary
- Adds a `bun: [stable, canary]` matrix (`fail-fast: false`) to the single scheduled `cli-test` job — one job covering both.
- No `continue-on-error` here: this daily job gates nothing, so a broken canary should surface as a red scheduled run.
- Uploaded artifact renamed to `cli-regression-report-${{ matrix.bun }}` (unique per leg, required by `upload-artifact@v4+`).

## Notes
- `setup-bun@v2` supports `bun-version: canary` directly — no manual `bun upgrade --canary` step needed.
- Dependency cache key is Bun-version-independent, so stable/canary legs of the same OS safely share it. No script or `.bun-version` changes.