### PR TITLE
fix(islands): scope props-ref lookup to enclosing server island

### DIFF
--- a/packages/mochi/src/web-components/HydratableIsland.ts
+++ b/packages/mochi/src/web-components/HydratableIsland.ts
@@ -8,6 +8,7 @@ import './IslandFailure';
 import { islandFailureStub } from './islandFailureStub';
 import { observeVisible } from './sharedVisibilityObserver';
 import { isLoadedCss, markLoadedCss } from './sharedCssTracker';
+import { resolveIslandProps } from './resolveIslandProps';
 
 const componentRegistry: Record<string, Component> = {};
 
@@ -73,7 +74,7 @@ class HydratableIsland extends HTMLElement {
     const propsRef = this.getAttribute('props-ref');
     let propsRaw: string | null;
     if (propsRef) {
-      propsRaw = document.getElementById(propsRef)?.textContent ?? null;
+      propsRaw = resolveIslandProps(this, propsRef);
     } else {
       propsRaw = this.getAttribute('props');
     }

--- a/packages/mochi/src/web-components/resolveIslandProps.test.ts
+++ b/packages/mochi/src/web-components/resolveIslandProps.test.ts
@@ -1,0 +1,61 @@
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+GlobalRegistrator.register({ url: 'http://localhost/' });
+
+import { afterEach, describe, expect, test } from 'bun:test';
+import { resolveIslandProps } from './resolveIslandProps';
+
+afterEach(() => {
+  document.body.innerHTML = '';
+});
+
+const island = (): Element => {
+  const el = document.createElement('mochi-hydratable-island');
+  el.setAttribute('props-ref', 'mochi-props-0');
+  return el;
+};
+
+const propsBlock = (payload: string): string => `<script type="application/json" id="mochi-props-0">${payload}</script>`;
+
+describe('resolveIslandProps', () => {
+  test('nested island reads its server island block, not the colliding page block', () => {
+    document.body.innerHTML = `
+      ${propsBlock('PAGE')}
+      <mochi-hydratable-island component-name="Page" props-ref="mochi-props-0"></mochi-hydratable-island>
+      <mochi-server-island>
+        ${propsBlock('ISLAND')}
+        <mochi-hydratable-island component-name="Nested" props-ref="mochi-props-0"></mochi-hydratable-island>
+      </mochi-server-island>`;
+
+    const [pageIsland, nestedIsland] = [...document.querySelectorAll('mochi-hydratable-island')];
+    expect(resolveIslandProps(nestedIsland!, 'mochi-props-0')).toBe('ISLAND');
+    expect(resolveIslandProps(pageIsland!, 'mochi-props-0')).toBe('PAGE');
+  });
+
+  test('page island with no enclosing server island resolves via the document', () => {
+    document.body.innerHTML = propsBlock('PAGE');
+    const el = island();
+    document.body.appendChild(el);
+    expect(resolveIslandProps(el, 'mochi-props-0')).toBe('PAGE');
+  });
+
+  test('nested server islands: the innermost scope wins', () => {
+    document.body.innerHTML = `
+      <mochi-server-island>
+        ${propsBlock('OUTER')}
+        <mochi-server-island>
+          ${propsBlock('INNER')}
+          <mochi-hydratable-island component-name="Deep" props-ref="mochi-props-0"></mochi-hydratable-island>
+        </mochi-server-island>
+      </mochi-server-island>`;
+
+    const deep = document.querySelector('mochi-hydratable-island')!;
+    expect(resolveIslandProps(deep, 'mochi-props-0')).toBe('INNER');
+  });
+
+  test('missing block returns null', () => {
+    const el = island();
+    document.body.appendChild(el);
+    expect(resolveIslandProps(el, 'mochi-props-0')).toBeNull();
+  });
+});

--- a/packages/mochi/src/web-components/resolveIslandProps.ts
+++ b/packages/mochi/src/web-components/resolveIslandProps.ts
@@ -1,0 +1,14 @@
+/// <reference lib="dom" />
+
+/**
+ * Resolve a hydratable island's `props-ref` block. Props ids (`mochi-props-N`) are numbered per
+ * render but a server island renders in its own request, so its counter restarts at 0 and collides
+ * with the page's ids. Scoping the lookup to the enclosing `<mochi-server-island>` — the render that
+ * emitted the block — keeps a nested island reading its own props; `closest` is `null` for an
+ * ordinary page island, so it falls back to the document and nothing else changes.
+ */
+export function resolveIslandProps(el: Element, propsRef: string): string | null {
+  const scope = el.closest('mochi-server-island');
+  const block = scope?.querySelector(`#${CSS.escape(propsRef)}`) ?? document.getElementById(propsRef);
+  return block?.textContent ?? null;
+}


### PR DESCRIPTION
## Problem

Island props blocks are numbered **per render** (`mochi-props-0`, `-1`, …) but looked up **per document**. A `mochi:defer` server island renders in its own request, so its counter restarts at `0` and its `<script id="mochi-props-0">` collides with the page's. On the client, `document.getElementById('mochi-props-0')` returns the **page's** block (first in tree order), so a `mochi:hydrate` island nested inside the server island hydrates with another island's props — the intended prop comes back `undefined` and consumers throw `Cannot read properties of undefined`.

It looks intermittent because a common consumer reads props as a fallback behind live data (`read() ?? fallback`); the corrupt fallback only bites when hydration wins the race.

- Emit site: `packages/mochi/src/islands/islandPropsRegistry.ts` — id is `mochi-props-${ctx.islandProps.size}`, request-scoped, so it restarts per island endpoint.
- Lookup site: `packages/mochi/src/web-components/HydratableIsland.ts` — `document.getElementById(propsRef)`, document-global.

## Fix

Scope the client lookup to the enclosing `<mochi-server-island>` (the render that emitted the block), falling back to the document for ordinary page islands. New framework-free helper `resolveIslandProps.ts`:

```ts
const scope = el.closest('mochi-server-island');
const block = scope?.querySelector(`#${CSS.escape(propsRef)}`) ?? document.getElementById(propsRef);
```

`closest` is `null` for a page island → document fallback, so page islands and the also-hydrate inline `props=` path are unaffected; nested server islands resolve to the innermost scope. **Client-lookup-only — the emitted HTML is unchanged.**

## Tests

New `resolveIslandProps.test.ts` (happy-dom): collision case (nested reads its own block, page reads the page's), page island with no server island, nested server islands (innermost wins), missing block → `null`.

## Verification

- `bun run checks` passes (lint, format, typecheck 0 errors, all tests).
- Browser smoke test of the `nested-islands` demo: with `mochi-props-0` present **twice** in the live DOM (collision condition), the nested counters correctly resolved their own props (`Alpha`/`Beta`/`Gamma`) and the console was clean.
