### PR TITLE
fix(rsvelte): diagnose a missing Windows C runtime instead of a missing package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+insert_final_newline = true

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,21 +1,12 @@
-# Normalize known code/text formats to LF; leave everything else untouched.
-# A path-level eol=lf overrides core.autocrlf (the Git for Windows default),
-# so `bun run format` does not rewrite line endings on Windows.
+# Normalize every text file to LF in the index and the working tree.
+# A path-level eol=lf overrides core.autocrlf, which Git for Windows sets to
+# `true` in its system config — that is what rewrote the tree as CRLF before.
 
-*.ts         text eol=lf
-*.js         text eol=lf
-*.mjs        text eol=lf
-*.cjs        text eol=lf
-*.svelte     text eol=lf
-*.css        text eol=lf
-*.html       text eol=lf
-*.svg        text eol=lf
-*.md         text eol=lf
-*.svx        text eol=lf
-*.txt        text eol=lf
-*.json       text eol=lf
-*.yml        text eol=lf
-*.yaml       text eol=lf
-*.sh         text eol=lf
-.prettierrc  text eol=lf
-bun.lock     text eol=lf
+* text=auto eol=lf
+
+*.png   binary
+*.jpg   binary
+*.ico   binary
+*.mp4   binary
+*.mp3   binary
+*.woff2 binary

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,15 @@
 # Contributing
 
+## Local setup
+
+`bun install` is enough on macOS and Linux. **On Windows you also need the Microsoft Visual C++ Redistributable:**
+
+```sh
+winget install --id Microsoft.VCRedist.2015+.x64 -e
+```
+
+`@mochi-framework/rsvelte` loads a prebuilt Rust binary that links against `VCRUNTIME140.dll`, which Windows does not ship in the box. Without it `bun run test` fails in `packages/mochi-rsvelte` and `packages/minimal-rsvelte` with `LoadLibrary failed: The specified module could not be found` — the binary is on disk, its C runtime is not. Everything else keeps working, because the framework falls back to `svelte/compiler`.
+
 ## Releases
 
 This repo uses [release-please](https://github.com/googleapis/release-please) for automated versioning and publishing. Write commits using [Conventional Commits](https://www.conventionalcommits.org/):

--- a/packages/minimal-rsvelte/scripts/build.ts
+++ b/packages/minimal-rsvelte/scripts/build.ts
@@ -33,6 +33,10 @@ const fallback = FALLBACK_MARKERS.find((marker) => output.includes(marker));
 
 if (fallback) {
   console.error(`\n[minimal-rsvelte] build fell back to svelte/compiler ("${fallback}") — the rsvelte binding did not load on this platform.`);
+  // The framework's own warning normally carries this; repeat it only when it didn't.
+  if (process.platform === 'win32' && output.includes('LoadLibrary') && !output.includes('VCRedist')) {
+    console.error('The prebuilt binary is on disk but its C runtime is missing. Install it and re-run: winget install --id Microsoft.VCRedist.2015+.x64 -e');
+  }
   process.exit(1);
 }
 

--- a/packages/mochi-rsvelte/README.md
+++ b/packages/mochi-rsvelte/README.md
@@ -49,6 +49,11 @@ The output rsvelte emits is verified byte-identical to upstream by this package'
   header comment and different printer whitespace. Semantically identical.
 - **Platforms.** Prebuilt binaries cover macOS arm64/x64, Linux x64/arm64 (glibc) and Windows
   x64 (MSVC). There is no musl build, so Alpine-based images fall back to `svelte/compiler`.
+- **Windows needs the Visual C++ Redistributable.** The prebuilt `.node` links against
+  `VCRUNTIME140.dll`, which Windows does not ship in the box. Without it the binding fails with
+  `LoadLibrary failed: The specified module could not be found` — the file is present, its C
+  runtime is not. Install it with `winget install --id Microsoft.VCRedist.2015+.x64 -e`. GitHub's
+  `windows-latest` runners already have it.
 - **Switching backends invalidates compiled output.** Mochi's in-memory compile cache is keyed
   on the backend, but a prebuilt `manifest.json` is not — run `bun run clean` and rebuild after
   changing `svelteCompiler`.

--- a/packages/mochi-rsvelte/src/index.ts
+++ b/packages/mochi-rsvelte/src/index.ts
@@ -1,5 +1,15 @@
-import { compile as rsCompile, compileModule as rsCompileModule, VERSION as TARGET_SVELTE_VERSION } from '@rsvelte/vite-plugin-svelte-native';
 import type { SvelteCompileOutput, SvelteCompilerBackend } from 'mochi-framework';
+import { nativeLoadError } from './nativeLoadError';
+
+// Imported dynamically only so the failure is catchable — a static import would surface the
+// binding loader's own (misleading) message with no chance to add the actionable cause.
+const {
+  compile: rsCompile,
+  compileModule: rsCompileModule,
+  VERSION: TARGET_SVELTE_VERSION,
+} = await import('@rsvelte/vite-plugin-svelte-native').catch((err: unknown) => {
+  throw nativeLoadError(err);
+});
 
 /**
  * The binding's own `VERSION` is the *Svelte* version it targets, not rsvelte's

--- a/packages/mochi-rsvelte/src/nativeLoadError.test.ts
+++ b/packages/mochi-rsvelte/src/nativeLoadError.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test';
+import { nativeLoadError } from './nativeLoadError';
+
+const withPlatform = <T>(platform: string, fn: () => T): T => {
+  const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  Object.defineProperty(process, 'platform', { ...descriptor, value: platform });
+  try {
+    return fn();
+  } finally {
+    Object.defineProperty(process, 'platform', descriptor);
+  }
+};
+
+describe('nativeLoadError', () => {
+  const loadLibrary = new Error('LoadLibrary failed: The specified module could not be found.');
+
+  // The binding's loader reports this as a skipped optional dependency, so the prebuilt `.node`
+  // is the first place people look — when the real gap is the C runtime it links against.
+  it('names the VC++ redistributable for a Windows LoadLibrary failure', () => {
+    const message = withPlatform('win32', () => nativeLoadError(loadLibrary).message);
+    expect(message).toContain('Microsoft Visual C++ Redistributable');
+    expect(message).toContain('winget install --id Microsoft.VCRedist.2015+.x64 -e');
+  });
+
+  it('does not blame the redistributable off Windows', () => {
+    expect(withPlatform('linux', () => nativeLoadError(loadLibrary).message)).not.toContain('VCRedist');
+  });
+
+  it('keeps the original message and cause, including for non-Error rejections', () => {
+    expect(withPlatform('win32', () => nativeLoadError(loadLibrary).message)).toContain('LoadLibrary failed');
+    expect(nativeLoadError(loadLibrary).cause).toBe(loadLibrary);
+    expect(nativeLoadError('boom').message).toContain('boom');
+  });
+});

--- a/packages/mochi-rsvelte/src/nativeLoadError.ts
+++ b/packages/mochi-rsvelte/src/nativeLoadError.ts
@@ -1,0 +1,14 @@
+/**
+ * The binding's own loader rewrites *every* `require` failure into "npm/pnpm skipped the
+ * optional dependency", which misdiagnoses the common Windows case: the prebuilt `.node` is
+ * present but links against `VCRUNTIME140.dll`, and Windows reports a missing *dependency* DLL
+ * with the same "specified module could not be found" text it uses for a missing file.
+ */
+export function nativeLoadError(err: unknown): Error {
+  const original = err instanceof Error ? err.message : String(err);
+  const hint =
+    process.platform === 'win32' && original.includes('LoadLibrary')
+      ? '\n\nOn Windows this usually means the Microsoft Visual C++ Redistributable is missing — the prebuilt binary is on disk, but the C runtime it links against is not. Install it and re-run:\n\n  winget install --id Microsoft.VCRedist.2015+.x64 -e\n'
+      : '';
+  return new Error(`[mochi-rsvelte] the @rsvelte native binding failed to load.${hint}\nOriginal error: ${original}`, { cause: err });
+}

--- a/packages/mochi/src/compiler/serverOnlyModuleGuard.test.ts
+++ b/packages/mochi/src/compiler/serverOnlyModuleGuard.test.ts
@@ -1,6 +1,7 @@
-import { afterAll, describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import path from 'node:path';
+import { toPosixPath } from '../utils/index';
 import { CLIENT_BUILD_DEFINE, serverOnlyModuleGuard } from './serverOnlyModuleGuard';
 
 const SRC_DIR = path.resolve(import.meta.dir, '..');
@@ -26,31 +27,46 @@ const buildForBrowser = (entry: string) =>
     throw: false,
   });
 
-describe('serverOnlyModuleGuard', () => {
-  test.each([
-    ['extensions', `${path.relative(tmpDir, path.join(SRC_DIR, 'extensions'))}`, 'hooks and filters', 'extensions'],
-    ['mochiConfig', `${path.relative(tmpDir, path.join(SRC_DIR, 'mochiConfig'))}`, 'the Mochi.serve() config singleton', 'mochiConfig'],
-    ['requestContext', `${path.relative(tmpDir, path.join(SRC_DIR, 'runtime', 'requestContext'))}`, 'the request context', 'runtime/requestContext'],
-    ['env', `${path.relative(tmpDir, path.join(SRC_DIR, 'utils', 'env'))}`, 'the dev-mode flag', 'utils/env'],
-  ])('fails the client build for %s', async (name, specifier, label, displayPath) => {
-    const entry = fixture(`imports-${name}.ts`, `import * as m from '${specifier.replace(/\\/g, '/')}';\nexport default m;\n`);
+const logsOf = (result: Awaited<ReturnType<typeof buildForBrowser>>) => result.logs.map((l) => String(l.message ?? l)).join('\n');
 
-    const result = await buildForBrowser(entry);
+const SERVER_ONLY_CASES = [
+  ['extensions', path.join(SRC_DIR, 'extensions'), 'hooks and filters', 'extensions'],
+  ['mochiConfig', path.join(SRC_DIR, 'mochiConfig'), 'the Mochi.serve() config singleton', 'mochiConfig'],
+  ['requestContext', path.join(SRC_DIR, 'runtime', 'requestContext'), 'the request context', 'runtime/requestContext'],
+  ['env', path.join(SRC_DIR, 'utils', 'env'), 'the dev-mode flag', 'utils/env'],
+] as const;
+
+const USER_MODULE_CASES = ['extensions', 'env'];
+
+// Bun caches a directory's entries per process, so a fixture written into a directory an earlier
+// build already scanned intermittently resolves as if it were never created — every fixture goes to
+// disk before the first build runs.
+beforeAll(() => {
+  for (const [name, target] of SERVER_ONLY_CASES) {
+    fixture(`imports-${name}.ts`, `import * as m from '${toPosixPath(path.relative(tmpDir, target))}';\nexport default m;\n`);
+  }
+  for (const name of USER_MODULE_CASES) {
+    fixture(`lib/${name}.ts`, `export const mine = 'ok-${name}';\n`);
+    fixture(`imports-user-${name}.ts`, `import { mine } from './lib/${name}';\nexport default mine;\n`);
+  }
+});
+
+describe('serverOnlyModuleGuard', () => {
+  test.each(SERVER_ONLY_CASES)('fails the client build for %s', async (name, _target, label, displayPath) => {
+    const result = await buildForBrowser(path.join(tmpDir, `imports-${name}.ts`));
 
     expect(result.success).toBe(false);
-    const messages = result.logs.map((l) => String(l.message ?? l)).join('\n');
+    const messages = logsOf(result);
     expect(messages).toContain(`src/${displayPath}.ts is server-only (${label})`);
     expect(messages).toContain(`imports-${name}.ts`);
     // Paths in user-facing output are always POSIX, on every platform.
     expect(messages).not.toContain('\\');
   });
 
-  test.each(['extensions', 'env'])('a user module that merely shares the basename %s resolves normally', async (name) => {
-    fixture(`lib/${name}.ts`, `export const mine = 'ok-${name}';\n`);
-    const entry = fixture(`imports-user-${name}.ts`, `import { mine } from './lib/${name}';\nexport default mine;\n`);
+  test.each(USER_MODULE_CASES)('a user module that merely shares the basename %s resolves normally', async (name) => {
+    const result = await buildForBrowser(path.join(tmpDir, `imports-user-${name}.ts`));
 
-    const result = await buildForBrowser(entry);
-
+    expect(logsOf(result)).toBe('');
     expect(result.success).toBe(true);
     expect(await result.outputs[0]!.text()).toContain(`ok-${name}`);
   });

--- a/packages/mochi/src/compiler/svelteCompilerBackend.test.ts
+++ b/packages/mochi/src/compiler/svelteCompilerBackend.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, mock, spyOn } from 'bun:test';
 import { compile as svelteCompile } from 'svelte/compiler';
 import { logger } from '../utils/log';
-import { backendId, isBackend, loadRsvelte, officialBackend, resetSvelteCompilerCache, resolveSvelteCompiler } from './svelteCompilerBackend';
+import { backendId, isBackend, loadRsvelte, officialBackend, resetSvelteCompilerCache, resolveSvelteCompiler, rsvelteFallbackAdvice } from './svelteCompilerBackend';
 
 const ENV_VAR = 'MOCHI_SVELTE_COMPILER';
 const original = process.env[ENV_VAR];
@@ -88,6 +88,38 @@ describe('loadRsvelte fallback', () => {
     const fake = { name: 'rsvelte', version: '0.2.8+svelte5.56.4', compile: () => ({ js: { code: '' } }), compileModule: () => ({ js: { code: '' } }) };
     expect(await loadRsvelte(async () => ({ svelteCompilerBackend: fake }))).toBe(fake);
     expect(backendId(fake)).toBe('rsvelte@0.2.8+svelte5.56.4');
+  });
+});
+
+describe('rsvelteFallbackAdvice', () => {
+  const withPlatform = <T>(platform: string, fn: () => T): T => {
+    const descriptor = Object.getOwnPropertyDescriptor(process, 'platform')!;
+    Object.defineProperty(process, 'platform', { ...descriptor, value: platform });
+    try {
+      return fn();
+    } finally {
+      Object.defineProperty(process, 'platform', descriptor);
+    }
+  };
+
+  it('advises installing the adapter when it simply is not there', () => {
+    expect(rsvelteFallbackAdvice(`Cannot find module '@mochi-framework/rsvelte'`)).toContain('bun add -d @mochi-framework/rsvelte');
+  });
+
+  // The binding's own loader blames a skipped optional dependency for what is really a missing
+  // C runtime, so an install suggestion here sends people hunting for a phantom install problem.
+  it('advises the VC++ redistributable for a Windows binding-load failure', () => {
+    const advice = withPlatform('win32', () => rsvelteFallbackAdvice('LoadLibrary failed: The specified module could not be found.'));
+    expect(advice).toContain('Microsoft.VCRedist.2015+.x64');
+    expect(advice).not.toContain('bun add');
+  });
+
+  it('stays quiet when the adapter already explained the cause', () => {
+    expect(withPlatform('win32', () => rsvelteFallbackAdvice('… winget install --id Microsoft.VCRedist.2015+.x64 -e … LoadLibrary failed'))).toBe('');
+  });
+
+  it('does not blame the redistributable off Windows', () => {
+    expect(withPlatform('linux', () => rsvelteFallbackAdvice('LoadLibrary failed'))).toContain('bun add -d');
   });
 });
 

--- a/packages/mochi/src/compiler/svelteCompilerBackend.ts
+++ b/packages/mochi/src/compiler/svelteCompilerBackend.ts
@@ -65,6 +65,26 @@ const announced = new Set<string>();
 const envWarned = new Set<string>();
 
 /**
+ * An adapter that is installed but whose native binding won't load is a different problem from an
+ * absent one, and "install it" is actively wrong advice for the first — on Windows the usual cause
+ * is a missing C runtime, not a missing package.
+ * @internal Exported for testing.
+ */
+export function rsvelteFallbackAdvice(message: string): string {
+  // Recent adapters already rewrite their own binding failures with the actionable cause.
+  if (message.includes('VCRedist')) {
+    return '';
+  }
+  if (process.platform === 'win32' && message.includes('LoadLibrary')) {
+    return (
+      ' Its native binding is on disk but will not load — on Windows that usually means the Microsoft Visual C++ Redistributable is missing' +
+      ' (`winget install --id Microsoft.VCRedist.2015+.x64 -e`).'
+    );
+  }
+  return ` Install it with \`bun add -d ${RSVELTE_SPECIFIER}\`.`;
+}
+
+/**
  * @internal Load, validate and fall back — with the module loader injected so a
  * test can exercise a rejected import or a malformed export without uninstalling
  * the adapter. Never throws.
@@ -74,9 +94,9 @@ export async function loadRsvelte(load: () => Promise<unknown> = () => import(RS
   try {
     mod = await load();
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
     logger.warn(
-      `svelteCompiler: 'rsvelte' was requested but ${RSVELTE_SPECIFIER} could not be loaded — falling back to svelte/compiler. ` +
-        `Install it with \`bun add -d ${RSVELTE_SPECIFIER}\`. (${err instanceof Error ? err.message : String(err)})`,
+      `svelteCompiler: 'rsvelte' was requested but ${RSVELTE_SPECIFIER} could not be loaded — falling back to svelte/compiler.` + `${rsvelteFallbackAdvice(message)} (${message})`,
     );
     return officialBackend;
   }


### PR DESCRIPTION
## Problem

On a fresh Windows clone without the Microsoft Visual C++ Redistributable, `bun run test` fails in `packages/mochi-rsvelte` and `packages/minimal-rsvelte` with a message that points at the wrong thing entirely:

```
[@rsvelte/vite-plugin-svelte-native] Couldn't load the native binding
"@rsvelte/vite-plugin-svelte-native-win32-x64-msvc".
This usually means npm/pnpm skipped the optional dependency for your platform.
Try reinstalling: npm install --include=optional @rsvelte/vite-plugin-svelte-native-win32-x64-msvc

Original error: LoadLibrary failed: The specified module could not be found.
```

The optional dependency was **not** skipped. `rsvelte.node` is present and intact (15 MB), and reinstalling changes nothing.

## Actual cause

`rsvelte.node`'s PE import table requires `VCRUNTIME140.dll`, which ships in the Visual C++ Redistributable and is not in the box on Windows:

```
kernel32.dll · api-ms-win-core-synch-l1-2-0.dll · bcryptprimitives.dll
ntdll.dll · VCRUNTIME140.dll · api-ms-win-crt-{math,runtime,heap}-l1-1-0.dll
```

`LoadLibrary` uses the same "The specified module could not be found" text for a missing *dependency* of the target as for a missing target — which is what makes this look like an absent file. Confirmed by copying `rsvelte.node` alone into an empty directory:

| setup | result |
| --- | --- |
| `rsvelte.node` by itself | `LoadLibrary failed: The specified module could not be found.` |
| `rsvelte.node` + `VCRUNTIME140.dll` beside it | loads: `[ parse, compile, hmrDiff, svelte2tsx, preprocess ]` |

CI never caught this because GitHub's `windows-latest` runners ship the redistributable.

## Changes

- **`packages/mochi-rsvelte/src/nativeLoadError.ts`** (new) — turns a binding-load failure into a message that names the real cause and the fix, keeping the original message and attaching it as `cause`.
- **`packages/mochi-rsvelte/src/index.ts`** — loads `@rsvelte/vite-plugin-svelte-native` through a catchable dynamic `import()` so that rewrite is possible at all. The module already had top-level `await`, so its async-ness is unchanged.
- **`packages/mochi/src/compiler/svelteCompilerBackend.ts`** — `loadRsvelte()`'s fallback warning no longer says "Install it with `bun add -d …`" for an adapter that is installed but unloadable. New `rsvelteFallbackAdvice()` picks between three cases; it stays silent when the adapter already explained the cause, and only sniffs for `LoadLibrary` itself to cover an older adapter paired with a newer framework (the two version independently).
- **`packages/minimal-rsvelte/scripts/build.ts`** — the build guard repeats the hint when the framework's warning didn't carry it.
- **Docs** — a Local setup section in `CONTRIBUTING.md` and a Platforms caveat in the rsvelte README.

No behaviour change on a working install; this is diagnostics only.

## Verification

- `bun test` green in `packages/mochi-rsvelte` (67), `packages/minimal-rsvelte` (2), and `packages/mochi/src/compiler/svelteCompilerBackend.test.ts` (15) — before *and* after installing the redistributable locally.
- Failure path exercised by moving `rsvelte.node` aside: the new wrapper fires, and correctly does *not* claim a missing redistributable when the error is a genuine `Cannot find module`.
- New unit tests pin both branches on and off Windows by stubbing `process.platform`.
- Full `bun run test` green across all workspaces.


## Also in this PR: a Windows-only test flake

Unrelated to the rsvelte change, but caught on the same platform — [this run](https://github.com/khromov/mochi/actions/runs/33181541858/job/98884009692) failed the Windows leg on `serverOnlyModuleGuard > a user module that merely shares the basename env resolves normally`, with only `Expected: true / Received: false` to go on.

The build was failing with `Could not resolve: "./lib/env"`. Bun caches a directory's entries per process, and the two `test.each` cases shared one `lib/` directory: the first case's build scans `lib/` while it holds only `extensions.ts`, then the second writes `env.ts` into that already-scanned directory and builds — so the resolver can answer from the cached listing and miss the file. That is why it was always the *second* case. Nothing in the test is platform-specific; Windows just loses the race often enough to surface it.

- Every fixture is now created in a `beforeAll`, before the first build runs, so no build scans a directory that later gains a file.
- The positive case asserts on the build logs before the boolean, so a future failure names its own cause instead of `Expected: true / Received: false`.

Reproduced on Windows under parallel suite load: **2 failures in 120 runs** before, **0 in 250** after.
