### PR TITLE
fix: resolve component-url against the page and keep SSR markup when hydration fails

### DIFF
--- a/packages/docs/135-error-boundaries.md
+++ b/packages/docs/135-error-boundaries.md
@@ -6,11 +6,12 @@ description: 'Hydratable islands are auto-wrapped in svelte:boundary, so one isl
 
 <script>
   import SeeItInAction from './_components/SeeItInAction.svelte';
+  import VersionNote from './_components/VersionNote.svelte';
 </script>
 
 ## Error boundaries
 
-Mochi auto-wraps every `mochi:hydrate` and `mochi:hydrate:visible` island in `<svelte:boundary>`. A throw inside one island no longer takes down the page render. Mochi replaces the failed island with a `<mochi-island-failure>` stub, and the rest of the page continues. No opt-in, no configuration.
+Mochi auto-wraps every `mochi:hydrate` and `mochi:hydrate:visible` island in `<svelte:boundary>`. A throw inside one island no longer takes down the page render. Mochi marks the failed island with a `<mochi-island-failure>` stub, and the rest of the page continues. No opt-in, no configuration.
 
 ### What is wrapped
 
@@ -30,7 +31,11 @@ A client-side throw logs to the browser console but does **not** emit `island:er
 
 ### Visual behavior
 
-In development, Mochi replaces the failed island with a dashed-red `<mochi-island-failure>` marker showing the component name and error message. In production, the element is hidden with `display: none`, so users see a clean gap.
+<VersionNote since="0.10.0" message="Before 0.10.0 a client-side hydration failure replaced the island's server-rendered markup with the marker." />
+
+In development, the `<mochi-island-failure>` marker is a dashed-red box showing the component name and error message. In production, it is hidden with `display: none`.
+
+What the marker replaces depends on where the failure happened. An SSR throw renders the marker instead of the island. A client-side failure — the bundle import, the CSS load, the props payload, or `hydrate()` itself — keeps the server-rendered markup and appends the marker after it. The static HTML stays on screen; it just never becomes interactive.
 
 ### Server islands (`mochi:defer`)
 

--- a/packages/docs/15-coming-from-sveltekit.md
+++ b/packages/docs/15-coming-from-sveltekit.md
@@ -808,7 +808,7 @@ Bun loads `.env` for you. To send an environment variable to the client, pass it
 
 ### `$app/paths` (`asset`, `base`, `resolve`)
 
-No equivalent. Mochi does not support sub-path deployments through configuration. Write your app links as absolute paths (`/about`). The `assetPrefix` option on `Mochi.serve()` rewrites the URL prefix for framework-internal bundles only (default `/_mochi`), not for your own routes or static files.
+No equivalent for app links: write them as absolute paths (`/about`) and prefix them yourself when hosting under a sub-path. Framework assets are prefixed for you by `assetPrefix` (default `/_mochi`) — see [Sub-path and static hosting](/docs/deployment-options/#sub-path-and-static-hosting).
 
 ```svelte
 <!-- SvelteKit -->

--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -6,6 +6,7 @@ description: 'Where to deploy your Mochi app: PaaS, VPS, big cloud, and self-hos
 
 <script>
 import Callout from './_components/Callout.svelte';
+import VersionNote from './_components/VersionNote.svelte';
 </script>
 
 # Deployment options
@@ -71,6 +72,30 @@ Connect to your existing infrastructure at different cloud providers.
 - <span title="United Kingdom">🇬🇧</span> <a href="https://northflank.com" target="_blank" rel="nofollow noopener">Northflank</a> — containers, jobs, and APIs, with bring-your-own-cloud
 - <span title="India">🇮🇳</span> <a href="https://kuberns.com" target="_blank" rel="nofollow noopener">Kuberns</a> — Git-push deploy on AWS infra, no Dockerfile
 - <span title="USA">🇺🇸</span> <a href="https://www.convox.com/" target="_blank" rel="nofollow noopener">Convox</a>
+
+## Sub-path and static hosting
+
+Mochi writes absolute URLs for everything it owns: `/_mochi/client/…`, `/_mochi/css/…`, the island `component-url`, and the `import` specifiers inside the client chunks. To host under a sub-path such as `https://user.github.io/my-app/`, bake the prefix in at build time:
+
+```sh
+mochi-framework build --asset-prefix /my-app/_mochi
+```
+
+The value lands in `manifest.json` and every emitted URL carries it. `Mochi.serve({ assetPrefix })` sets the same thing for on-demand compilation, but once a manifest exists its value wins and a differing `serve()` value only logs a warning.
+
+<Callout type="info">
+
+`assetPrefix` covers framework assets only. Links you write yourself (`href="/about"`) and files in `public/` are served at the paths you give them, so prefix those in your own markup.
+
+</Callout>
+
+The same prefix is what makes a hand-rolled static export work: copy `.mochi/svelte-client` to `<host>/my-app/_mochi/client` and `.mochi/svelte-css` to `<host>/my-app/_mochi/css`, save each prerendered page, and nothing needs rewriting.
+
+### Rewriting URLs yourself
+
+<VersionNote since="0.10.0" message="Before 0.10.0 a relative component-url resolved against the island loader module (/_mochi/client/), not the page." />
+
+If you post-process the HTML into page-relative URLs instead, treat `component-url` like any other attribute: it resolves against the page, so `../_mochi/client/…` on `/my-app/writing/` loads from `/my-app/_mochi/client/`, the same place a `<link href="../_mochi/css/…">` on that page does.
 
 ## Where these companies are based
 

--- a/packages/docs/184-deployment.md
+++ b/packages/docs/184-deployment.md
@@ -75,7 +75,7 @@ Connect to your existing infrastructure at different cloud providers.
 
 ## Sub-path and static hosting
 
-Mochi writes absolute URLs for everything it owns: `/_mochi/client/…`, `/_mochi/css/…`, the island `component-url`, and the `import` specifiers inside the client chunks. To host under a sub-path such as `https://user.github.io/my-app/`, bake the prefix in at build time:
+Mochi writes absolute URLs for everything it owns: `/_mochi/client/…`, `/_mochi/css/…`, the island `component-url`, and the `import` specifiers inside the client chunks. To host under a sub-path such as `https://example.com/my-app/`, bake the prefix in at build time:
 
 ```sh
 mochi-framework build --asset-prefix /my-app/_mochi

--- a/packages/mochi/src/legacyStoreIsland.test.ts
+++ b/packages/mochi/src/legacyStoreIsland.test.ts
@@ -1,0 +1,94 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import { ComponentRegistry } from './compiler/ComponentRegistry';
+import { requestContext } from './runtime/requestContext';
+import { MochiCookieJar } from './runtime/cookies';
+
+// A legacy-mode (`export let`, `$:`) island whose root and child both auto-subscribe to one module-level
+// `svelte/store` — a pattern a real-world app removed after blaming it for a hydration error. Nothing in the
+// demos or the suite used `svelte/store` inside an island before this file.
+describe('legacy-mode island sharing a module-level svelte/store with its child', () => {
+  let dir: string;
+  let registry: ComponentRegistry;
+  let page: string;
+
+  const render = () => {
+    const ctx = {
+      requestId: 'test',
+      request: new Request('http://localhost/'),
+      url: new URL('http://localhost/'),
+      params: {},
+      locals: {},
+      isWarmup: false,
+      cookies: new MochiCookieJar(null),
+      islandProps: new Map(),
+      getClientAddress: () => null,
+    };
+    return requestContext.run(ctx, () => registry.renderComponent(page));
+  };
+
+  beforeAll(async () => {
+    dir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-legacy-store-'));
+    writeFileSync(
+      path.join(dir, 'stores.ts'),
+      `import { derived, writable } from 'svelte/store';
+export const selected = writable<string | null>(null);
+export const label = derived(selected, ($s) => ($s ? \`picked:\${$s}\` : 'none'));
+`,
+    );
+    writeFileSync(
+      path.join(dir, 'Child.svelte'),
+      `<script lang="ts">
+  import { label } from './stores.ts';
+  export let fallback: string = '';
+  $: text = $label === 'none' ? fallback : $label;
+</script>
+
+<p data-testid="child">{text}</p>
+`,
+    );
+    writeFileSync(
+      path.join(dir, 'Root.svelte'),
+      `<script lang="ts">
+  import { label, selected } from './stores.ts';
+  import Child from './Child.svelte';
+  export let items: string[] = [];
+  $: if (items.length > 0 && !$selected) selected.set(items[0]);
+</script>
+
+<ul>
+  {#each items as item}
+    <li class:on={$selected === item}>{item}</li>
+  {/each}
+</ul>
+<Child fallback="nothing" />
+<span data-testid="root">{$label}</span>
+`,
+    );
+    page = path.join(dir, 'Page.svelte');
+    writeFileSync(page, `<script lang="ts">\n  import Root from './Root.svelte';\n</script>\n\n<Root mochi:hydrate items={['a', 'b']} />\n`);
+    registry = new ComponentRegistry({ development: true, outDir: path.join(dir, '.mochi') });
+    await registry.compile(page);
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test('SSR: root and child read the same store instance', async () => {
+    const result = await render();
+    expect(result.body).toContain('<span data-testid="root">picked:a</span>');
+    expect(result.body).toContain('<p data-testid="child">picked:a</p>');
+    expect(result.body).toContain('class="on');
+  });
+
+  test('client: the island bundles, and the store module is bundled exactly once', async () => {
+    const result = await render();
+    expect(result.bootstrapUrl).toBeTruthy();
+    const stats = registry.getClientStats();
+    expect(stats).not.toBeNull();
+    const storeInputs = stats!.outputs.flatMap((o) => o.inputs.map((i) => i.path)).filter((p) => p.endsWith('/stores.ts'));
+    expect(storeInputs).toHaveLength(1);
+  });
+});

--- a/packages/mochi/src/web-components/HydratableIsland.client.test.ts
+++ b/packages/mochi/src/web-components/HydratableIsland.client.test.ts
@@ -1,0 +1,65 @@
+// The loader driven through a real DOM: what is left in the island once hydration throws.
+import { GlobalRegistrator } from '@happy-dom/global-registrator';
+
+GlobalRegistrator.register({ url: 'http://localhost/writing/' });
+
+import { beforeEach, describe, expect, test } from 'bun:test';
+
+// Importing for the side effect of `customElements.define`, after the DOM globals exist.
+const { registerComponent } = await import('./HydratableIsland');
+
+const settle = () => new Promise((r) => setTimeout(r, 0));
+
+function mountIsland(name: string, ssrHtml: string, attrs: Record<string, string>): HTMLElement {
+  const el = document.createElement('mochi-hydratable-island');
+  el.setAttribute('component-name', name);
+  for (const [k, v] of Object.entries(attrs)) {
+    el.setAttribute(k, v);
+  }
+  el.innerHTML = ssrHtml;
+  document.body.appendChild(el);
+  return el;
+}
+
+beforeEach(() => {
+  document.body.innerHTML = '';
+});
+
+describe('hydration failure', () => {
+  test('keeps the server-rendered markup and appends the failure marker after it', async () => {
+    // Registered so the loader gets past the bundle import; the unparsable props block throws before `hydrate()`.
+    registerComponent('Broken_abc', (() => {}) as never);
+    const props = document.createElement('script');
+    props.type = 'application/json';
+    props.id = 'mochi-props-0';
+    props.textContent = 'not devalue';
+    document.body.appendChild(props);
+
+    const el = mountIsland('Broken_abc', '<!--[--><p class="ssr">server text</p><!--]-->', { 'props-ref': 'mochi-props-0' });
+    await settle();
+    await settle();
+
+    expect(el.querySelector('p.ssr')?.textContent).toBe('server text');
+    const marker = el.querySelector('mochi-island-failure');
+    expect(marker?.getAttribute('data-component')).toBe('Broken_abc');
+    expect(el.lastElementChild).toBe(marker);
+    expect(el.querySelectorAll('mochi-island-failure')).toHaveLength(1);
+  });
+
+  test('a client-only island whose mount throws is left with just the marker', async () => {
+    registerComponent('BrokenClientOnly_abc', (() => {}) as never);
+    const props = document.createElement('script');
+    props.type = 'application/json';
+    props.id = 'mochi-props-1';
+    props.textContent = 'not devalue';
+    document.body.appendChild(props);
+
+    const el = mountIsland('BrokenClientOnly_abc', '<p class="fallback">fallback</p>', { 'props-ref': 'mochi-props-1', 'client-only': '' });
+    await settle();
+    await settle();
+
+    // The fallback stays: the loader only clears it once the real component mounts, and that never happened.
+    expect(el.querySelector('p.fallback')?.textContent).toBe('fallback');
+    expect(el.querySelector('mochi-island-failure')?.getAttribute('data-component')).toBe('BrokenClientOnly_abc');
+  });
+});

--- a/packages/mochi/src/web-components/HydratableIsland.ts
+++ b/packages/mochi/src/web-components/HydratableIsland.ts
@@ -9,6 +9,7 @@ import { islandFailureStub } from './islandFailureStub';
 import { observeVisible } from './sharedVisibilityObserver';
 import { isLoadedCss, markLoadedCss } from './sharedCssTracker';
 import { resolveIslandProps } from './resolveIslandProps';
+import { resolveComponentUrl } from './resolveComponentUrl';
 
 const componentRegistry: Record<string, Component> = {};
 
@@ -55,12 +56,12 @@ class HydratableIsland extends HTMLElement {
     try {
       await this._doHydrateInner(name);
     } catch (err) {
-      // Defensive belt — `transformError` on `hydrate()` covers errors raised
-      // by the boundary; this catches synchronous throws from the bundle import,
-      // CSS load, or `hydrate()` itself before the boundary takes effect.
+      // Defensive belt — `transformError` on `hydrate()` covers errors raised by the boundary; this catches throws from
+      // the bundle import, CSS load, props parse, or `hydrate()` itself, all before the component took over the DOM, so
+      // the server-rendered markup is intact and worth keeping next to the marker.
       const e = err instanceof Error ? err : new Error(String(err));
       logger.error(`Island "${name}" failed to hydrate:`, e);
-      this.innerHTML = islandFailureStub(name ?? '', isDev ? e.message : undefined);
+      this.insertAdjacentHTML('beforeend', islandFailureStub(name ?? '', isDev ? e.message : undefined));
     }
   }
 
@@ -105,7 +106,7 @@ class HydratableIsland extends HTMLElement {
     // Load the component's JS bundle (calls registerComponent on import)
     if (!componentRegistry[name] && componentUrl) {
       logger.log('Loading component', name, componentUrl);
-      await import(componentUrl);
+      await import(resolveComponentUrl(componentUrl, document.baseURI));
     }
 
     // Everything past here is synchronous, so one check after the awaits covers the whole method.

--- a/packages/mochi/src/web-components/resolveComponentUrl.test.ts
+++ b/packages/mochi/src/web-components/resolveComponentUrl.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test';
+import { resolveComponentUrl } from './resolveComponentUrl';
+
+describe('resolveComponentUrl', () => {
+  test('an absolute path resolves against the origin regardless of the page depth', () => {
+    expect(resolveComponentUrl('/_mochi/client/_hydrate-X-abc.js', 'https://example.com/writing/post/')).toBe('https://example.com/_mochi/client/_hydrate-X-abc.js');
+  });
+
+  test('a prefixed path (assetPrefix) is left alone', () => {
+    expect(resolveComponentUrl('/my-app/_mochi/client/_hydrate-X-abc.js', 'https://example.com/my-app/writing/')).toBe(
+      'https://example.com/my-app/_mochi/client/_hydrate-X-abc.js',
+    );
+  });
+
+  test('a relative path resolves against the document, not the loader module', () => {
+    // A static export that rewrote every URL to be page-relative expects `../_mochi/client/` from `/my-app/writing/`
+    // to land in `/my-app/_mochi/client/` — the same place `<link href="../_mochi/css/…">` on that page lands.
+    expect(resolveComponentUrl('../_mochi/client/_hydrate-X-abc.js', 'https://example.com/my-app/writing/')).toBe('https://example.com/my-app/_mochi/client/_hydrate-X-abc.js');
+  });
+
+  test('honours a <base href> through the document baseURI', () => {
+    expect(resolveComponentUrl('_mochi/client/_hydrate-X-abc.js', 'https://example.com/my-app/')).toBe('https://example.com/my-app/_mochi/client/_hydrate-X-abc.js');
+  });
+
+  test('a full URL passes through untouched', () => {
+    expect(resolveComponentUrl('https://cdn.example.com/x.js', 'https://example.com/')).toBe('https://cdn.example.com/x.js');
+  });
+});

--- a/packages/mochi/src/web-components/resolveComponentUrl.ts
+++ b/packages/mochi/src/web-components/resolveComponentUrl.ts
@@ -1,0 +1,7 @@
+/**
+ * `import()` resolves a relative specifier against the importing module, which lives under the asset prefix — every
+ * other URL Mochi writes into the page resolves against the document, so anchor `component-url` there too.
+ */
+export function resolveComponentUrl(componentUrl: string, baseURI: string): string {
+  return new URL(componentUrl, baseURI).href;
+}


### PR DESCRIPTION
Audit of the Mochi workarounds in https://github.com/Clumsyoof/Personal-site (mochi-framework 0.9.1, static export to GitHub Pages under `/Personal-site/`). Each one was reproduced in a real browser against 0.9.1 and against a clone linked to HEAD.

## Found bugs (fixed here)

1. **`component-url` resolved against the loader module, not the page.** `HydratableIsland` did `await import(componentUrl)`, so a page-relative value (`../_mochi/client/x.js`) resolved from `/_mochi/client/` and 404'd at `/_mochi/_mochi/client/x.js` — the site's "hydrated component 401" commit. Every other URL Mochi writes into the page is document-relative. Now resolved through `new URL(componentUrl, document.baseURI)` (`resolveComponentUrl.ts` + unit test). Reproduced on 0.9.1 and HEAD; verified fixed in the browser.
2. **A client-side hydration failure wiped the island's server-rendered markup.** The catch in `_doHydrate` replaced `innerHTML` with `<mochi-island-failure>`, which is `display:none` in production — a plain 404 on the island bundle turned a fully rendered post list and navbar into a blank. The stub is now appended after the SSR markup instead (`HydratableIsland.client.test.ts`). Reproduced on 0.9.1 and HEAD; verified fixed in the browser.

## Rejected (not framework bugs)

- **"svelte store sub err"** — the site removed a module-level `svelte/store` shared by a legacy-mode island root and its child, and regex-patched the compiled loader. The pre-fix components hydrate and stay interactive in dev, production and the sub-path export on both 0.9.1 and HEAD. Their regex (`this.innerHTML=c4(`) never matched a 0.9.1 build, so that patch was a no-op in their deploy. `legacyStoreIsland.test.ts` now pins the pattern: one store instance during SSR, store module bundled exactly once.
- **Relative-URL rewriting of the HTML and the chunk `import`s for the sub-path** — avoidable. `mochi-framework build --asset-prefix /Personal-site/_mochi` already prefixes the CSS links, bootstrap script, `component-url` and every chunk `import` specifier; a plain export from that build hydrates under `/Personal-site/` with zero rewriting. The docs said sub-path deploys were unsupported, so nobody looked for it → documented.
- **`patches/svelte-check@4.7.4.patch`** — the same patch `create-mochi` ships from the template `patches/` dir, not a user workaround.

## Conclusions

- Two real island-loader bugs, both present in 0.9.1 and unchanged on HEAD, fixed with tests.
- The supported answer to sub-path / static hosting is `--asset-prefix`, now documented ("Sub-path and static hosting" in Deployment options, the `$app/paths` entry in the SvelteKit guide, "Visual behavior" in Error boundaries). No SSG/static-export feature added.
- The store error is not reproducible; if it resurfaces it needs a minimal repro rather than removing stores.

## Note for hand-rewritten exports

Mochi never emits a relative `component-url`, so nothing changes for default or `--asset-prefix` builds. If you post-process the HTML yourself and made that one attribute loader-relative (`./_hydrate-…js`), drop the special case: it now resolves against the page like `<link href>`.

## Verification

- `bun run checks` green (lint, format, typecheck, 189/189 test files).
- Browser smoke test of the docs pages and the shared-state demo: no console errors, all islands hydrate.
- Before/after on the HEAD-linked site under `/Personal-site/`: a page-relative `component-url` now loads; a forced bundle 404 leaves the post list, entry viewer and navbar on screen with a hidden marker appended.

