### PR TITLE
chore: bump @types/bun to 1.4.1 and correct the update-bun skill

### DIFF
--- a/.claude/skills/update-bun/SKILL.md
+++ b/.claude/skills/update-bun/SKILL.md
@@ -1,57 +1,82 @@
 ---
 name: update-bun
-description: Upgrade Bun to the latest version and sync the pinned version across .bun-version, Dockerfile, Dockerfile.production, and @types/bun in package.json. Use when the user asks to "update bun", "upgrade bun", or "bump bun version".
+description: Upgrade Bun to a target version (default latest) and sync the pin across all nine locations — .bun-version, the devcontainer, build.yml's matrix, the four Dockerfiles, and @types/bun in every package.json plus .syncpackrc.json. Use when the user asks to "update bun", "upgrade bun", or "bump bun version".
 user-invocable: true
 ---
 
 # Update Bun version
 
-This skill upgrades the local Bun install to the latest release and propagates the new version to every place it is pinned in the repo.
+This skill upgrades Bun and propagates the new version to every place it is pinned in the repo.
+
+The target version is **optional**: if the user names one (e.g. "update bun to 1.4.2"), pin exactly that. Otherwise upgrade to the latest release.
 
 ## Pinned locations
 
-- `.bun-version` — bare semver, no `v` prefix (e.g. `1.3.12`). Also consumed by `oven-sh/setup-bun@v2` via `bun-version-file: .bun-version` in `.github/workflows/test.yml`, so CI is updated automatically.
-- `Dockerfile` line 2 — `FROM oven/bun:<version> AS base` (no `v` prefix)
-- `Dockerfile.production` line 2 — `FROM oven/bun:<version> AS base` (no `v` prefix)
-- `package.json` — `"@types/bun"` dependency, pinned exactly (no `^`, no `latest`)
+All nine must move together. Grep for the old version before finishing — a missed location fails CI or silently ships the wrong runtime.
+
+1. **`.bun-version`** — bare semver, no `v` prefix. Consumed by `oven-sh/setup-bun@v2` via `bun-version-file: .bun-version` in **seven** workflows (`test.yml`, `format.yml`, `release.yml`, `review.yml`, `site-health.yml`, `svelte-latest-test.yml`, `cli-regression-test.yml`), so all of CI follows this one file. Do not edit the workflows for this. (`test.yml` and `cli-regression-test.yml` each also run a separate `bun-version: canary` leg — that one is deliberate and never pinned.)
+2. **`.devcontainer/Dockerfile`** — `ARG BUN_VERSION=<v>` (feeds `curl … | bash -s "bun-v${BUN_VERSION}"`, which is the one place a `v` prefix appears, already supplied by the template).
+3. **`.devcontainer/devcontainer.json`** — the `BUN_VERSION` build arg, which must match the line above.
+4. **`.github/workflows/build.yml`** — **three** `bun_image: oven/bun:<v>-alpine` matrix entries (the `site`, `demos`, and `support` legs). All three, not one.
+5. **`Dockerfile`** — `ARG BUN_IMAGE=oven/bun:<v>-alpine`, **plus a prose comment above it** that names the tag ("Base image defaults to oven/bun:…"). Move both.
+6. **`Dockerfile.production`** — `ARG BUN_IMAGE=oven/bun:<v>-alpine`, **plus its own prose comment** naming the tag ("Base image is oven/bun:…"). Move both.
+7. **`Dockerfile.memtest`** — `ARG BUN_IMAGE=oven/bun:<v>-alpine` (no prose comment here).
+8. **`packages/demos/Dockerfile.production`** — `FROM oven/bun:<v> AS base`. Note: **no `-alpine` suffix** on this one.
+9. **`packages/minimal/Dockerfile`** — `FROM oven/bun:<v>-alpine`.
+
+And the types pin, which moves on its own schedule (see the `@types/bun` note below):
+
+- **`@types/bun`** in **all 13 `package.json` files** — the root plus `packages/{cli,demos,docker,minimal,minimal-rsvelte,mochi,mochi-rsvelte,mochi-svelte-shaker,shared,site,support,video-animations}`. Pinned exactly (no `^`, no `latest`).
+- **`.syncpackrc.json`** — the versionGroup labelled "Pin @types/bun across the workspace" carries its own hard `pinVersion`. It **must** move in lockstep with the 13 package.json files or `syncpack lint` fails.
 
 ## Steps
 
-1. Install the latest Bun:
+1. Determine `$NEW`:
+   - If the user named a target version, use it verbatim.
+   - Otherwise install the latest and read the version back:
+
+     ```sh
+     curl -fsSL https://bun.com/install | bash
+     bun --version
+     ```
+
+     Output is a bare semver like `1.4.2`.
+
+2. Read `.bun-version` to get `$OLD`. If `$NEW == $OLD`, report "Bun is already up to date at $NEW" and stop without touching any files.
+
+3. Update the nine runtime locations above from `$OLD` to `$NEW`. Do not blind-replace `$OLD` repo-wide — see the false-positives note below.
+
+4. Pick the `@types/bun` version. It tracks Bun **minors**, so a package matching `$NEW` exactly often does not exist. Check npm first:
 
    ```sh
-   curl -fsSL https://bun.com/install | bash
+   bun info @types/bun version          # latest
+   bun info @types/bun versions --json  # all published
    ```
 
-2. Get the new version:
+   Pin the newest published version that is `<= $NEW`. It is expected and fine for this to lag the runtime pin (precedent: runtime 1.4.2 with `@types/bun` 1.4.1, because 1.4.2 was never published). Update all 13 package.json files **and** `.syncpackrc.json` to that version.
 
-   ```sh
-   bun --version
-   ```
-
-   Output is a bare semver like `1.3.12`. Call this `$NEW`.
-
-3. Read `.bun-version` to get `$OLD` (e.g. `1.3.11`). The file stores a bare semver with no `v` prefix.
-
-4. If `$NEW == $OLD`, report "Bun is already up to date at $NEW" and stop. Do not touch any files.
-
-5. Otherwise, update the four files using the Edit tool:
-   - **`.bun-version`**: write `$NEW` (overwrite full content, no `v` prefix).
-   - **`Dockerfile`**: replace `oven/bun:$OLD` with `oven/bun:$NEW`.
-   - **`Dockerfile.production`**: replace `oven/bun:$OLD` with `oven/bun:$NEW`.
-   - **`package.json`**: update the `@types/bun` entry. If the current value is `"latest"`, replace `"@types/bun": "latest"` with `"@types/bun": "$NEW"`. If it is already a pinned version (`"@types/bun": "$OLD"`), replace that string with `"@types/bun": "$NEW"`.
-
-6. Refresh the lockfile and formatting:
+5. Refresh and verify:
 
    ```sh
    bun install
+   bun run syncpack     # must report no issues
+   bun run typecheck    # the real test for an @types/bun move
    bun run format
    ```
 
-7. Report the upgrade: `Bun $OLD → $NEW` and list the four files modified.
+   A runtime-only bump (no `@types/bun` change) leaves the lockfile untouched; an `@types/bun` bump is expected to move it.
+
+6. Report `Bun $OLD → $NEW`, the `@types/bun` version chosen (and why, if it lags), and the files modified.
 
 ## Notes
 
-- The `bun --version` output has no `v` prefix. No file should have a `v` prefix — `.bun-version`, the Dockerfile tags, and `@types/bun` all use bare semver.
-- Do not run `bun upgrade` — the `curl | bash` installer is the canonical path used by this project.
+- **Do not bump `engines.bun` or `MIN_BUN_VERSION`.** The `"bun": ">=1.4.0"` in the root `package.json`, `MIN_BUN_VERSION` in `packages/mochi/src/cli/checkEnvironment.ts`, and the matching prose in `README.md` / `packages/docs/` are a **support floor**, not a pin — they declare the oldest Bun that Mochi runs on. Raising them drops support for users on older Bun and is a breaking change requiring its own deliberate `feat!:` commit (precedent: `bfe317c feat!: require Bun >=1.4`). A routine version bump must leave all of them alone.
+- **`@types/bun` tracks Bun minors, not patches.** Never assume a `@types/bun@$NEW` exists — check npm (step 4). Pinning a nonexistent version fails `bun install`.
+- **Beware a global find-and-replace of `$OLD`.** These matches must _not_ change:
+  - `packages/cli/src/utils.test.ts` asserts `bunVersionWarning('1.4.2')` is null. That is a sample value exercising the 1.4 floor logic, not a pin — rewriting it is pointless churn.
+  - `packages/docs/185-docker.md` shows `oven/bun:1.4-alpine`, a deliberate floating **minor** tag for users' own Dockerfiles. It moves on a minor bump, never on a patch bump.
+  - `packages/site/package.json` has `"valibot": "1.4.2"`, an unrelated package that can coincidentally share the version string.
+- `.devcontainer/codebay.devcontainer.json` and `.devcontainer/devcontainer-lock.json` may also carry a `BUN_VERSION`, but they are untracked sandbox artifacts listed in `.git/info/exclude`. Leave them alone; they are not part of the repo.
+- No file stores a `v` prefix — `.bun-version`, the image tags, `BUN_VERSION`, and `@types/bun` all use bare semver. (The `.devcontainer/Dockerfile` install command adds `bun-v` itself.)
+- Do not run `bun upgrade` — the `curl | bash` installer is the canonical path used by this project, and it is the only one that can target a specific version (`bash -s "bun-v$NEW"`).
 - If the shell PATH still points at the old Bun after installing, use the fresh install path printed by the installer (typically `~/.bun/bin/bun`) for the `bun --version` check.

--- a/.syncpackrc.json
+++ b/.syncpackrc.json
@@ -4,7 +4,7 @@
     {
       "label": "Pin @types/bun across the workspace",
       "dependencies": ["@types/bun"],
-      "pinVersion": "1.4.0"
+      "pinVersion": "1.4.1"
     },
     {
       "label": "Pin svelte-check across the workspace",

--- a/bun.lock
+++ b/bun.lock
@@ -7,7 +7,7 @@
       "devDependencies": {
         "@eslint/js": "^10.0.1",
         "@memlab/api": "^2.0.4",
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "eslint": "^10.8.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-svelte": "^3.22.0",
@@ -30,7 +30,7 @@
         "commander": "^15.0.0",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "typescript": "^6.0.3",
       },
     },
@@ -49,7 +49,7 @@
         "tailwindcss": "^4.3.3",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
@@ -57,7 +57,7 @@
     "packages/docker": {
       "name": "mochi-docker",
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "typescript": "^6.0.3",
       },
     },
@@ -82,7 +82,7 @@
         "svelte": "^5.56.8",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
@@ -95,7 +95,7 @@
       },
       "devDependencies": {
         "@mochi-framework/rsvelte": "workspace:*",
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
@@ -130,7 +130,7 @@
         "@happy-dom/global-registrator": "^20.11.1",
         "@tailwindcss/node": "^4.3.3",
         "@tailwindcss/oxide": "^4.3.3",
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "@types/smtp-server": "3.5.13",
         "fast-check": "4.9.0",
         "smtp-server": "3.19.2",
@@ -159,7 +159,7 @@
         "@rsvelte/vite-plugin-svelte-native": ">=0.2.8 <1.0.0",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "mochi-framework": "workspace:*",
         "svelte": "^5.56.8",
         "typescript": "^6.0.3",
@@ -178,7 +178,7 @@
         "svelte-shaker": ">=0.18.1",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "mochi-framework": "workspace:*",
         "svelte": "^5.56.8",
         "typescript": "^6.0.3",
@@ -204,7 +204,7 @@
         "mochi-framework": "workspace:*",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "typescript": "^6.0.3",
       },
     },
@@ -242,7 +242,7 @@
         "varlock": "1.16.0",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
       },
@@ -258,7 +258,7 @@
         "svelte": "^5.56.8",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "devalue": "^5.9.0",
         "svelte-check": "4.7.4",
         "typescript": "^6.0.3",
@@ -274,7 +274,7 @@
         "subset-font": "2.5.0",
       },
       "devDependencies": {
-        "@types/bun": "1.4.0",
+        "@types/bun": "1.4.1",
         "typescript": "^6.0.3",
       },
     },
@@ -600,7 +600,7 @@
 
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
-    "@types/bun": ["@types/bun@1.4.0", "", { "dependencies": { "bun-types": "1.4.0" } }, "sha512-K+lZULY23vRgK/CfTjFIV+tyifaNdSMlPh9j+6mQ/cLfpOznLyAuzgV/JQysyECpkBQLVMSyvjlr2fBUSA9wFQ=="],
+    "@types/bun": ["@types/bun@1.4.1", "", { "dependencies": { "bun-types": "1.4.1" } }, "sha512-0AVGiTXGajf1rgKom3N+c5L7CBxuoyyv1i44M0nX4UDK0G/fnRAMiri93nHuVPIb429KKtAgj7HatVmmOjeQLA=="],
 
     "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
 
@@ -720,7 +720,7 @@
 
     "bun-boss": ["bun-boss@0.5.1", "", { "dependencies": { "croner": "^10.0.1" }, "peerDependencies": { "@types/bun": ">=1.3.14" }, "optionalPeers": ["@types/bun"] }, "sha512-eRkLHfGx+cF1f2D5psluIfhq8oLnLSEBMukGXYdBfqnMAFUlvm+gkpNelg5w2plCen+r/OpE0Yfl1uLL0lGkXQ=="],
 
-    "bun-types": ["bun-types@1.4.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-iIKw23BspnQQYd3prITOBxeUsxBHnwzX6YJfGMuNOZzeNcMmVqzIIVGRm1l69ogaPQmb4wB6BN8mA5bE9YuC5Q=="],
+    "bun-types": ["bun-types@1.4.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-loKuVrAFZKfEv+JvWkHRS9GW5IqLuLRjVXN9p+vZvBN86O5hf/pBZQ5hSoyipsrMmWObZBDvWnlmKvjKTM0PdA=="],
 
     "call-bind": ["call-bind@1.0.9", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "get-intrinsic": "^1.3.0", "set-function-length": "^1.2.2" } }, "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "@eslint/js": "^10.0.1",
     "@memlab/api": "^2.0.4",
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "eslint": "^10.8.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.22.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -57,7 +57,7 @@
     "commander": "^15.0.0"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/demos/package.json
+++ b/packages/demos/package.json
@@ -26,7 +26,7 @@
     "tailwindcss": "^4.3.3"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   },

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -14,7 +14,7 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/minimal-rsvelte/package.json
+++ b/packages/minimal-rsvelte/package.json
@@ -20,7 +20,7 @@
   },
   "devDependencies": {
     "@mochi-framework/rsvelte": "workspace:*",
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   },

--- a/packages/minimal/package.json
+++ b/packages/minimal/package.json
@@ -18,7 +18,7 @@
     "svelte": "^5.56.8"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   },

--- a/packages/mochi-rsvelte/package.json
+++ b/packages/mochi-rsvelte/package.json
@@ -58,7 +58,7 @@
     }
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "mochi-framework": "workspace:*",
     "svelte": "^5.56.8",
     "typescript": "^6.0.3"

--- a/packages/mochi-svelte-shaker/package.json
+++ b/packages/mochi-svelte-shaker/package.json
@@ -59,7 +59,7 @@
     }
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "mochi-framework": "workspace:*",
     "svelte": "^5.56.8",
     "typescript": "^6.0.3"

--- a/packages/mochi/package.json
+++ b/packages/mochi/package.json
@@ -125,7 +125,7 @@
     "@happy-dom/global-registrator": "^20.11.1",
     "@tailwindcss/node": "^4.3.3",
     "@tailwindcss/oxide": "^4.3.3",
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "@types/smtp-server": "3.5.13",
     "fast-check": "4.9.0",
     "smtp-server": "3.19.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,7 +16,7 @@
     "mochi-framework": "workspace:*"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "typescript": "^6.0.3"
   }
 }

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -48,7 +48,7 @@
     "varlock": "1.16.0"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"
   }

--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -22,7 +22,7 @@
     "svelte": "^5.56.8"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "devalue": "^5.9.0",
     "svelte-check": "4.7.4",
     "typescript": "^6.0.3"

--- a/packages/video-animations/package.json
+++ b/packages/video-animations/package.json
@@ -20,7 +20,7 @@
     "subset-font": "2.5.0"
   },
   "devDependencies": {
-    "@types/bun": "1.4.0",
+    "@types/bun": "1.4.1",
     "typescript": "^6.0.3"
   }
 }


### PR DESCRIPTION
The two follow-ups #345 left on the table. **Two independent commits — split them if you'd rather land them separately.**

## `af585c7 chore: update @types/bun to 1.4.1`

#344 pinned `@types/bun` at 1.4.0 on the reasoning that the package tracks Bun *minors* and 1.4.0 was the only 1.4.x ever published, and flagged it as *"worth a follow-up if `@types/bun@1.4.1` ever ships."* It has since shipped, so this is that follow-up.

- All 13 workspace `package.json` files (root + `cli`, `demos`, `docker`, `minimal`, `minimal-rsvelte`, `mochi`, `mochi-rsvelte`, `mochi-svelte-shaker`, `shared`, `site`, `support`, `video-animations`).
- `.syncpackrc.json` — the `pinVersion` on the "Pin @types/bun across the workspace" group, which has to move in lockstep or `syncpack lint` fails.
- `bun.lock` — **+15 / −15**: the 13 workspace declarations plus two resolution entries (`@types/bun@1.4.1` and its transitive `bun-types@1.4.1`). No dependency-graph change.

**1.4.1 is deliberately one behind the 1.4.2 runtime pin** — `@types/bun@1.4.2` does not exist. Per the rule this PR also writes into the skill: pin the newest published version `<= $NEW`.

`typecheck` is the real test for a types bump, and it's **0 errors across all workspaces** — 1.4.1 introduced no incompatibilities, so nothing was suppressed or cast away. `syncpack lint` reports no issues.

`engines.bun`, `MIN_BUN_VERSION` and the README/docs prose are untouched — support floor, not a pin.

## `ae33407 docs: correct the update-bun skill`

`.claude/skills/update-bun/SKILL.md` (+51 / −26). #344 flagged this skill as out of date and nothing had fixed it; following it literally would still have missed most of #345's diff. It claimed **four** pinned locations (there are nine), described `Dockerfile` line 2 as `FROM oven/bun:… AS base` (it's `ARG BUN_IMAGE=` now), never mentioned `.syncpackrc.json`, and could only ever target *latest* — which is precisely what neither real bump needed.

Beyond those, the rewrite fixes four things we hadn't spotted:

- **The `.bun-version` → CI claim was true but badly understated.** `bun-version-file` is consumed by **seven** workflows — `test`, `format`, `release` (six occurrences on its own), `review`, `site-health`, `svelte-latest-test`, `cli-regression-test`. The old text implied one. It also now records that `test.yml` and `cli-regression-test.yml` each run a deliberate `bun-version: canary` leg that must never be pinned — an easy thing to "helpfully" break.
- **Two find-replace landmines**, which the old skill's blind `$OLD → $NEW` phrasing actively invited: `packages/cli/src/utils.test.ts`'s `bunVersionWarning('1.4.2')` (a fixture exercising the 1.4 *floor*, not a pin) and `packages/site/package.json`'s unrelated `"valibot": "1.4.2"`.
- **`packages/docs/185-docker.md` pins `oven/bun:1.4-alpine`** — a floating *minor* tag shown to users for their own Dockerfiles. Correctly stays put on a patch bump, but does need moving on a minor bump. Documented as a distinction rather than added as a tenth mandatory location.
- **Per-file syntax quirks are now spelled out**: the missing `-alpine` on `packages/demos/Dockerfile.production`, the `v` prefix that appears only inside the devcontainer install command, and the fact that `Dockerfile.memtest` has no prose comment while `Dockerfile` and `Dockerfile.production` both do.

It also now takes an optional target version (defaulting to latest) and records both hard-won caveats — the `@types/bun`-tracks-minors rule with a check-npm-first step, and the support-floor rule citing `bfe317c`.

## Verification

`bun install`, `bun run lint`, `bun run typecheck`, `bun run test`, `bun run format` all pass. Tests green (mochi-framework 189/189 files, plus the demos/site/support/rsvelte/svelte-shaker/minimal legs).

---
🤖 Written by Claude Code in a [Codebay](https://github.com/khromov/codebay) sandbox, driven over MCP.
