### PR TITLE
fix: close the MochiCache lost-update race between set() and an unregistered fetch

### DIFF
--- a/packages/mochi/src/cache/cache.test.ts
+++ b/packages/mochi/src/cache/cache.test.ts
@@ -954,3 +954,70 @@ describe('MochiCache invalidation during the initial-read gap', () => {
     expect(await cache.peek('d')).toBeNull();
   });
 });
+
+describe('MochiCache generation bookkeeping under failure', () => {
+  // A throwing `cache:error` subscriber is the one way a marker write/remove can reject, and it must not strand the
+  // key's generation entry — the refcount is what keeps that map from growing without bound.
+  function markerFailingCache(failing: 'set' | 'remove') {
+    const store = new Map<string, unknown>();
+    const isMarker = (key: string) => key.startsWith('mochi:inflight:');
+    const storage: Storage = {
+      getItem: (key) => store.get(key) ?? null,
+      setItem: (key, value) => {
+        if (failing === 'set' && isMarker(key)) {
+          throw new Error('marker write failed');
+        }
+        store.set(key, value);
+      },
+      removeItem: (key) => {
+        if (failing === 'remove' && isMarker(key)) {
+          throw new Error('marker remove failed');
+        }
+        store.delete(key);
+      },
+      clear: () => store.clear(),
+    };
+    const cache = new MochiCache({ storage, crossProcessInflight: true, inflightTimeout: 5_000 });
+    mochiEvents.on('cache:error', () => {
+      throw new Error('subscriber blew up');
+    });
+    return { cache, generations: (cache as unknown as { generations: Map<string, unknown> }).generations };
+  }
+
+  test('a rejected marker write still releases the key generation', async () => {
+    const { cache, generations } = markerFailingCache('set');
+    await expect(cache.fetch('k', () => 'v')).rejects.toThrow('subscriber blew up');
+    expect(generations.size).toBe(0);
+  });
+
+  test('a rejected marker removal still releases the key generation', async () => {
+    const { cache, generations } = markerFailingCache('remove');
+    await expect(cache.fetch('k', () => 'v')).rejects.toThrow('subscriber blew up');
+    expect(generations.size).toBe(0);
+  });
+
+  test('a caller coalesced onto a superseded run is served its value but nothing is stored', async () => {
+    const store = new Map<string, unknown>();
+    const storage: Storage = {
+      getItem: (key) => store.get(key) ?? null,
+      setItem: (key, value) => void store.set(key, value),
+      removeItem: (key) => void store.delete(key),
+      clear: () => store.clear(),
+    };
+    const cache = new MochiCache({ storage, minTimeToStale: 1_000, maxTimeToLive: 5_000 });
+
+    const first = cache.fetch('k', async () => {
+      await wait(20);
+      return 'computed';
+    });
+    await cache.delete('k');
+    await wait(5);
+    // Enters after the delete has fully landed, but adopts the superseded run rather than starting its own.
+    const second = cache.fetch('k', () => 'never-called');
+
+    expect(await first).toBe('computed');
+    expect(await second).toBe('computed');
+    expect(store.size).toBe(0);
+    expect((cache as unknown as { generations: Map<string, unknown> }).generations.size).toBe(0);
+  });
+});

--- a/packages/mochi/src/cache/cache.test.ts
+++ b/packages/mochi/src/cache/cache.test.ts
@@ -296,8 +296,8 @@ describe('MochiCache.set', () => {
       await wait(30);
       return 'from-fn';
     });
-    // Let the run claim its in-flight slot — `fetch` awaits a storage read first, and
-    // `set` can only supersede a run that has already registered.
+    // Let the run claim its in-flight slot, so this covers the registered-run path; the
+    // initial-read gap before registration has its own tests below.
     await wait(5);
     await cache.set('k', 'from-set');
 
@@ -783,5 +783,174 @@ describe('MochiCache invalidation vs in-flight revalidation', () => {
 
     const internals = cache as unknown as { inflight: Map<string, unknown> };
     expect(internals.inflight.size).toBe(0);
+  });
+});
+
+describe('MochiCache invalidation during the initial-read gap', () => {
+  // A backend whose next read answers from the store immediately but parks before returning, like an async backend
+  // whose read was already served when a later write landed; `releaseRead` lets the parked fetch proceed.
+  function makeGatedStorage() {
+    const store = new Map<string, unknown>();
+    let armed = false;
+    let release: (() => void) | undefined;
+    const storage: Storage = {
+      async getItem(key) {
+        const raw = store.get(key) ?? null;
+        if (armed) {
+          armed = false;
+          await new Promise<void>((r) => {
+            release = r;
+          });
+        }
+        return raw;
+      },
+      setItem: (key, value) => void store.set(key, value),
+      removeItem: (key) => void store.delete(key),
+      clear: () => store.clear(),
+    };
+    return {
+      storage,
+      store,
+      armRead: () => {
+        armed = true;
+      },
+      releaseRead: () => release!(),
+    };
+  }
+
+  const expiredEntry = (value: unknown) => ({ value, createdAt: Date.now() - 100_000 });
+
+  test("set() during a fetch's initial read wins over the fetch's later recompute", async () => {
+    const cache = new MochiCache({ minTimeToStale: 1_000, maxTimeToLive: 5_000 });
+    // The read is already in progress (and answered as a miss) when set runs — no in-flight slot exists yet.
+    const pending = cache.fetch('k', () => 'from-fn');
+    await cache.set('k', 'from-set');
+
+    await expect(pending).resolves.toBe('from-fn');
+    expect(await cache.peek('k')).toEqual({ value: 'from-set', status: 'fresh' });
+  });
+
+  test("delete() during a fetch's initial read is not resurrected by the recompute", async () => {
+    const { storage, store, armRead, releaseRead } = makeGatedStorage();
+    const cache = new MochiCache({ storage, minTimeToStale: 10, maxTimeToLive: 20 });
+    store.set('k', expiredEntry('v0'));
+
+    armRead();
+    const pending = cache.fetch('k', () => 'from-fn');
+    await wait(1);
+    await cache.delete('k');
+    releaseRead();
+
+    await expect(pending).resolves.toBe('from-fn');
+    expect(store.size).toBe(0);
+    expect(await cache.peek('k')).toBeNull();
+  });
+
+  test("markStale() during a fetch's initial read keeps its backdated entry", async () => {
+    const { storage, store, armRead, releaseRead } = makeGatedStorage();
+    const cache = new MochiCache({ storage, minTimeToStale: 10_000, maxTimeToLive: 100_000 });
+    store.set('k', expiredEntry('v0'));
+
+    armRead();
+    const pending = cache.fetch('k', () => 'from-fn');
+    await wait(1);
+    // A peer replaces the entry while our read is parked, then this process backdates it.
+    store.set('k', { value: 'from-peer', createdAt: Date.now() });
+    await cache.markStale('k');
+    expect(await cache.peek('k')).toEqual({ value: 'from-peer', status: 'stale' });
+    releaseRead();
+
+    await expect(pending).resolves.toBe('from-fn');
+    expect(await cache.peek('k')).toEqual({ value: 'from-peer', status: 'stale' });
+  });
+
+  test("clearItems() during a fetch's initial read is not repopulated by the recompute", async () => {
+    const { storage, store, armRead, releaseRead } = makeGatedStorage();
+    const cache = new MochiCache({ storage, minTimeToStale: 10, maxTimeToLive: 20 });
+
+    armRead();
+    const pending = cache.fetch('k', () => 'from-fn');
+    await wait(1);
+    await cache.clearItems();
+    releaseRead();
+
+    await expect(pending).resolves.toBe('from-fn');
+    expect(store.size).toBe(0);
+  });
+
+  test("a set() whose write lands after a later fetch's read still wins", async () => {
+    const store = new Map<string, unknown>();
+    const storage: Storage = {
+      getItem: (key) => store.get(key) ?? null,
+      async setItem(key, value) {
+        await wait(10);
+        store.set(key, value);
+      },
+      removeItem: (key) => void store.delete(key),
+      clear: () => store.clear(),
+    };
+    const cache = new MochiCache({ storage, minTimeToStale: 1_000, maxTimeToLive: 5_000 });
+
+    // set is called first, but its slow write lands only after the fetch has read a miss and while fn is still running.
+    const setting = cache.set('k', 'from-set');
+    const pending = cache.fetch('k', async () => {
+      await wait(20);
+      return 'from-fn';
+    });
+    await Promise.all([setting, pending]);
+
+    expect(await cache.peek('k')).toEqual({ value: 'from-set', status: 'fresh' });
+  });
+
+  test('an uncontended fetch still writes its recompute on miss, stale and expired reads', async () => {
+    const cache = new MochiCache({ minTimeToStale: 10, maxTimeToLive: 30 });
+    let calls = 0;
+    const fn = async () => {
+      calls++;
+      await wait(1);
+      return `v${calls}`;
+    };
+
+    expect(await cache.fetchWithStatus('k', fn)).toEqual({ value: 'v1', status: 'miss' });
+    expect(await cache.peek('k')).toEqual({ value: 'v1', status: 'fresh' });
+
+    await wait(15);
+    expect((await cache.fetchWithStatus('k', fn)).status).toBe('stale');
+    await cache.whenIdle();
+    expect(await cache.peek('k')).toEqual({ value: 'v2', status: 'fresh' });
+
+    await wait(40);
+    expect(await cache.fetchWithStatus('k', fn)).toEqual({ value: 'v3', status: 'expired' });
+    expect(await cache.peek('k')).toEqual({ value: 'v3', status: 'fresh' });
+  });
+
+  test('the generation map is reclaimed once no fetch or run holds the key', async () => {
+    const cache = new MochiCache({ minTimeToStale: 10, maxTimeToLive: 60_000, inflightTimeout: 20 });
+    const internals = cache as unknown as { generations: Map<string, unknown> };
+
+    // Plain fetch, coalesced fetches, and a set/delete that supersede an unregistered fetch.
+    await cache.fetch('a', () => 'v1');
+    await Promise.all([cache.fetch('b', () => wait(5).then(() => 'v1')), cache.fetch('b', () => 'v1')]);
+    const pending = cache.fetch('c', () => 'v1');
+    await cache.set('c', 'v2');
+    await cache.delete('c');
+    await pending;
+    expect(internals.generations.size).toBe(0);
+
+    // A background revalidation outlives its fetch; the entry lives with the run and goes with it.
+    await wait(15);
+    await cache.fetch('a', () => 'v2');
+    expect(internals.generations.has('a')).toBe(true);
+    await cache.whenIdle();
+    expect(internals.generations.size).toBe(0);
+
+    // A run abandoned by the timeout keeps the entry until the work itself settles, then releases it.
+    let release!: (value: string) => void;
+    await expect(cache.fetch('d', () => new Promise<string>((r) => (release = r)))).rejects.toThrow(/timed out/);
+    expect(internals.generations.has('d')).toBe(true);
+    release('late');
+    await wait(5);
+    expect(internals.generations.size).toBe(0);
+    expect(await cache.peek('d')).toBeNull();
   });
 });

--- a/packages/mochi/src/cache/cache.ts
+++ b/packages/mochi/src/cache/cache.ts
@@ -214,7 +214,8 @@ export class MochiCache {
    *
    * It supersedes the key's in-flight recompute, so a run already underway settles without writing. As with `delete`
    * and `markStale`, that covers a `fetch` at any point after entry — including one still awaiting its initial storage
-   * read — so this write is never overwritten by a recompute that began before it landed.
+   * read. The one gap is a recompute that had already cleared its own write guard and handed `setItem` to the backend
+   * before this call: both writes are then in flight and whichever lands last wins.
    */
   async set<T>(key: string, value: T): Promise<void> {
     this.supersedeRuns(key);
@@ -340,8 +341,10 @@ export class MochiCache {
     return raw == null ? null : (this.deserialize(raw) as CacheEntry);
   }
 
-  // Run `fn` once per key even under concurrent callers, then persist the result. `generation` is what the owning
-  // fetch captured at entry; a coalesced caller shares the owner's run and never writes.
+  // Run `fn` once per key even under concurrent callers, then persist the result. `generation` is what the owning fetch
+  // captured at entry; a coalesced caller shares the owner's run and its verdict, so a caller that entered after an
+  // invalidation is dropped along with the owner — its value came from the owner's `fn`, which may predate that
+  // invalidation — and the next fetch recomputes.
   private run<T>(key: string, fn: () => T | Promise<T>, generation: number): Promise<T> {
     const existing = this.inflight.get(key) as Promise<T> | undefined;
     if (existing) {
@@ -355,9 +358,9 @@ export class MochiCache {
     // Held until the work itself settles — past a timeout abandonment — so the write guard below reads a live generation.
     this.retainGeneration(key);
     const work = (async () => {
-      // Published before the expensive `fn` so a peer starting moments later sees it and defers, and removed once this run settles.
-      await this.writeMarker(key, runId);
       try {
+        // Published before the expensive `fn` so a peer starting moments later sees it and defers, and removed once this run settles.
+        await this.writeMarker(key, runId);
         const value = await fn();
         const serialized = this.serialize({ value, createdAt: this.now() } satisfies CacheEntry);
         // A run superseded since its fetch entered — by an inflight takeover, a timeout, or a set/delete/markStale/clear
@@ -376,9 +379,12 @@ export class MochiCache {
         return (this.deserialize(serialized) as CacheEntry).value as T;
       } finally {
         await this.removeMarker(key, runId);
-        this.releaseGeneration(key);
       }
-    })();
+    })().finally(() => {
+      // Released out here rather than in the `finally` above, because a throwing `cache:error` subscriber can reject
+      // either marker call and a skipped release would strand this key's generation entry for the process's lifetime.
+      this.releaseGeneration(key);
+    });
 
     const guarded = this.inflightTimeout > 0 && Number.isFinite(this.inflightTimeout) ? withTimeout(work, this.inflightTimeout, key) : work;
     const promise = guarded.finally(() => {

--- a/packages/mochi/src/cache/cache.ts
+++ b/packages/mochi/src/cache/cache.ts
@@ -78,6 +78,12 @@ interface CacheEntry {
 
 const identity = (value: unknown) => value;
 
+/** A key's invalidation counter plus how many fetches/runs currently hold it, so the entry is reclaimed at zero. */
+interface KeyGeneration {
+  generation: number;
+  holders: number;
+}
+
 // Racing against a timeout keeps a hung `fn` from holding the per-key in-flight lock forever. `Promise.race` attaches a
 // reaction to `work`, so a rejection arriving after the timeout wins still counts as handled and `run`'s stored-write
 // guard discards its result.
@@ -98,6 +104,7 @@ export class MochiCache {
   private inflightTimeout: number;
   private crossProcessInflight: boolean;
   private inflight = new Map<string, Promise<unknown>>();
+  private generations = new Map<string, KeyGeneration>();
 
   constructor(options: MochiCacheOptions = {}) {
     this.storage = options.storage ?? new MemoryStorage();
@@ -119,10 +126,20 @@ export class MochiCache {
   }
 
   async fetchWithStatus<T>(key: string, fn: () => T | Promise<T>): Promise<CacheResult<T>> {
+    // Captured before the storage read, so a set/delete/markStale landing during that await still supersedes this run's write.
+    const generation = this.retainGeneration(key);
+    try {
+      return await this.lookup(key, fn, generation);
+    } finally {
+      this.releaseGeneration(key);
+    }
+  }
+
+  private async lookup<T>(key: string, fn: () => T | Promise<T>, generation: number): Promise<CacheResult<T>> {
     const entry = await this.read(key);
 
     if (entry == null) {
-      const value = await this.run(key, fn);
+      const value = await this.run(key, fn, generation);
       return this.emitRead(key, value, 'miss');
     }
 
@@ -142,7 +159,7 @@ export class MochiCache {
       // Serving stale while refreshing in the background would hide a failing upstream until `maxTimeToLive`, so the
       // event surfaces the degradation to logging and metrics.
       mochiEvents.emit('cache:revalidate', { key });
-      void this.run(key, fn).catch((error) => {
+      void this.run(key, fn, generation).catch((error) => {
         mochiEvents.emit('cache:revalidate:failed', { key, error });
       });
       return this.emitRead(key, cached, 'stale');
@@ -155,18 +172,19 @@ export class MochiCache {
       return this.emitRead(key, cached, 'stale');
     }
 
-    const value = await this.run(key, fn);
+    const value = await this.run(key, fn, generation);
     return this.emitRead(key, value, 'expired');
   }
 
   async delete(key: string): Promise<void> {
-    this.inflight.delete(key);
+    this.supersedeRuns(key);
     try {
       await this.storage.removeItem(key);
     } catch (error) {
       mochiEvents.emit('cache:error', { key, operation: 'remove', error });
       throw error;
     }
+    this.bumpGeneration(key);
     // Dropping the advisory marker keeps a just-invalidated key from making peers defer to a regeneration that will no longer happen.
     await this.removeMarker(key);
     mochiEvents.emit('cache:delete', { key });
@@ -194,12 +212,12 @@ export class MochiCache {
    * miss and each start their own recompute; on `FileStorage` this is a single atomic replace, so a reader sees the old
    * value or the new one.
    *
-   * It drops the key's in-flight run, so a recompute already underway settles without writing. As with `delete` and
-   * `markStale`, that reaches only a run that has registered: a `fetch` still awaiting its initial storage read hasn't
-   * claimed the slot, and its write lands after this one.
+   * It supersedes the key's in-flight recompute, so a run already underway settles without writing. As with `delete`
+   * and `markStale`, that covers a `fetch` at any point after entry — including one still awaiting its initial storage
+   * read — so this write is never overwritten by a recompute that began before it landed.
    */
   async set<T>(key: string, value: T): Promise<void> {
-    this.inflight.delete(key);
+    this.supersedeRuns(key);
     const entry = this.serialize({ value, createdAt: this.now() } satisfies CacheEntry);
     try {
       await this.storage.setItem(key, entry);
@@ -207,6 +225,8 @@ export class MochiCache {
       mochiEvents.emit('cache:error', { key, operation: 'set', error });
       throw error;
     }
+    // Bumped again once the write lands, so a fetch that entered during it and read the old value can't overwrite this one either.
+    this.bumpGeneration(key);
   }
 
   /**
@@ -215,9 +235,8 @@ export class MochiCache {
    * already at-or-past that age, so an entry can only move staler. Runs through the `Storage` interface, covering both backends.
    */
   async markStale(key: string): Promise<void> {
-    // Drop any in-flight run first so its supersession guard trips and a pending
-    // revalidation can't overwrite the backdated timestamp.
-    this.inflight.delete(key);
+    // Supersede any fetch in progress first, so a pending revalidation can't overwrite the backdated timestamp.
+    this.supersedeRuns(key);
     let raw: unknown;
     try {
       raw = await this.storage.getItem(key);
@@ -239,6 +258,7 @@ export class MochiCache {
     } catch (error) {
       mochiEvents.emit('cache:error', { key, operation: 'set', error });
     }
+    this.bumpGeneration(key);
   }
 
   /**
@@ -258,14 +278,52 @@ export class MochiCache {
   }
 
   async clearItems(): Promise<void> {
-    // Drop in-flight runs first so a pending revalidation can't repopulate a key
-    // after the storage is cleared.
+    // Supersede every fetch in progress first, so a pending revalidation can't repopulate a key after the storage is cleared.
     this.inflight.clear();
+    for (const key of this.generations.keys()) {
+      this.bumpGeneration(key);
+    }
     try {
       await this.storage.clear();
     } catch (error) {
       mochiEvents.emit('cache:error', { key: '*', operation: 'clear', error });
       throw error;
+    }
+    for (const key of this.generations.keys()) {
+      this.bumpGeneration(key);
+    }
+  }
+
+  // Both halves of superseding a key's recompute: a registered run loses its slot, and one still awaiting its initial
+  // read — which has no slot yet — loses the generation it captured at entry.
+  private supersedeRuns(key: string): void {
+    this.inflight.delete(key);
+    this.bumpGeneration(key);
+  }
+
+  // The entry exists only while a fetch or run holds the key, so the map can't grow with caller-shaped keys.
+  private retainGeneration(key: string): number {
+    let state = this.generations.get(key);
+    if (!state) {
+      state = { generation: 0, holders: 0 };
+      this.generations.set(key, state);
+    }
+    state.holders++;
+    return state.generation;
+  }
+
+  private releaseGeneration(key: string): void {
+    const state = this.generations.get(key);
+    if (state && --state.holders === 0) {
+      this.generations.delete(key);
+    }
+  }
+
+  // A key nobody is fetching has no pending write to reject, so bumping it is a no-op rather than an allocation.
+  private bumpGeneration(key: string): void {
+    const state = this.generations.get(key);
+    if (state) {
+      state.generation++;
     }
   }
 
@@ -282,8 +340,9 @@ export class MochiCache {
     return raw == null ? null : (this.deserialize(raw) as CacheEntry);
   }
 
-  // Run `fn` once per key even under concurrent callers, then persist the result.
-  private run<T>(key: string, fn: () => T | Promise<T>): Promise<T> {
+  // Run `fn` once per key even under concurrent callers, then persist the result. `generation` is what the owning
+  // fetch captured at entry; a coalesced caller shares the owner's run and never writes.
+  private run<T>(key: string, fn: () => T | Promise<T>, generation: number): Promise<T> {
     const existing = this.inflight.get(key) as Promise<T> | undefined;
     if (existing) {
       return existing;
@@ -293,15 +352,17 @@ export class MochiCache {
     // Owns this run's advisory marker: a timed-out/superseded run that settles
     // late must not delete the marker a newer run has since written.
     const runId = randomUUID();
+    // Held until the work itself settles — past a timeout abandonment — so the write guard below reads a live generation.
+    this.retainGeneration(key);
     const work = (async () => {
       // Published before the expensive `fn` so a peer starting moments later sees it and defers, and removed once this run settles.
       await this.writeMarker(key, runId);
       try {
         const value = await fn();
         const serialized = this.serialize({ value, createdAt: this.now() } satisfies CacheEntry);
-        // A run superseded while `fn` was pending — by an inflight takeover, a timeout, or a delete/markStale/clear —
-        // skips its write, so a late revalidation can't resurrect a key the caller removed.
-        if (this.inflight.get(key) === ref.current) {
+        // A run superseded since its fetch entered — by an inflight takeover, a timeout, or a set/delete/markStale/clear
+        // at any point, even during the initial read — skips its write, so it can't clobber newer state or resurrect a key.
+        if (this.inflight.get(key) === ref.current && this.generations.get(key)?.generation === generation) {
           // Emitting and continuing keeps a storage write failure from discarding the freshly computed value the caller
           // is waiting on; the next read recomputes.
           try {
@@ -315,6 +376,7 @@ export class MochiCache {
         return (this.deserialize(serialized) as CacheEntry).value as T;
       } finally {
         await this.removeMarker(key, runId);
+        this.releaseGeneration(key);
       }
     })();
 


### PR DESCRIPTION
Split out from the security triage in #347, where this was reported by a static scan as a security finding. It is not one — it is a cache lost-update — so it is fixed here on its own merits rather than bundled into a security PR.

## The race is real, and reproducible

`set()`'s docstring already described this as known behaviour ("a `fetch` still awaiting its initial storage read hasn't claimed the slot, and its write lands after this one"), so the first job was establishing whether it actually bites. It does. It reproduces **on the default in-memory storage with no artificial gating**:

- A `set()` issued right after a `fetch()` is lost — the fetch's later recompute overwrites it.
- A `delete()` issued during an expired fetch's read is resurrected as a fresh entry.

The awaited storage read yields a microtask even when the backend is fully synchronous, and that is the entire gap needed. `fetchWithStatus()` registers its per-key in-flight promise only *after* that read, so an invalidator running in the gap has nothing to invalidate.

## The fix

A per-key **generation counter** that covers the whole fetch rather than only the registered window:

- `fetchWithStatus` captures the key's generation at entry, before the storage read, and passes it to `run`.
- The invalidators (`set`, `delete`, `markStale`, and `clearItems`, which had the identical gap) bump that generation via a shared `supersedeRuns` helper, in addition to their existing `inflight.delete`.
- `run`'s write guard now requires **both** the in-flight identity and the generation to match.

The identity check is deliberately kept alongside the generation check: the `inflightTimeout` path releases the slot *without* bumping, and a timed-out run must still lose its write.

**One addition beyond the original brief:** each invalidator bumps a second time after its storage write lands. Without it, a fetch entering after `set()` was called but before its slow write completed could read the old value, compute, and overwrite. This closes the case where `fn` is still running when the write lands. It deliberately does **not** cover a fetch whose own write was already issued to the backend — that needs storage-level compare-and-swap, and the committed tests are scoped to what the bump actually guarantees rather than overclaiming.

## Bounding the generation map

The map is keyed by cache key, and cache keys are attacker-influenced in some callers, so it cannot grow unbounded. Each entry carries a refcount of holders: a fetch holds it for its duration, a run holds it from creation until the underlying work settles (past any timeout abandonment). The entry is deleted at zero, and bumping a key with no entry is a no-op rather than an allocation. A hung `fn` keeps one entry alive — but it already keeps the promise and closure alive, so nothing new leaks.

A test asserts the map is empty after plain, coalesced, superseded, background, and timed-out runs.

## Why the obvious fix doesn't work

Registering the in-flight promise earlier — the one-line version of this fix — breaks two things: `deferToPeer` uses `inflight.has()` to decide whether to serve stale, and `whenIdle()` drains that map. A placeholder registered before the read changes both behaviours.

The refcount also has to cover runs and not just fetches, because a stale read returns immediately while its background revalidation keeps going; reclaiming on fetch exit alone would let a later fetch recreate the entry at generation zero and spuriously mismatch an abandoned run's captured value.

## Tests and docs

New regression tests cover `set()`, `delete()` and `markStale()` landing during the initial-read gap, plus the uncontended happy path to prove the invalidation is not over-eager.

- The `set()` docstring and `markStale()` comment now state the guarantee instead of the bug.
- One comment in the existing `set()` supersession test claimed `set` could only reach a registered run; it now says that test covers the registered path. Its timing and assertions are unchanged.
- **No existing test needed its assertions altered**, which is the evidence that the new invalidation is not too aggressive.

## Verification

`bun run checks` green across every workspace. No dependencies added.

One pre-existing flake to be aware of, untouched here: the ImageCache slow-disk test fails under bare `bun test` on a slow machine at 5.00s against a 4.97s runtime. It fails identically on unfixed `main`, and the repo's own runner passes a 30s timeout, so it does not reproduce through `bun run checks`.