### PR TITLE
fix: make chat WS limits reachable and per-client, and expose the request context in ws upgrade

### DIFF
--- a/packages/docs/100-websocket-routes.md
+++ b/packages/docs/100-websocket-routes.md
@@ -74,6 +74,37 @@ await Mochi.serve({
 
 </Callout>
 
+#### Request context during the handshake
+
+<VersionNote since="0.9.2" message="Earlier versions threw from getRequestContext() inside upgrade." />
+
+`getRequestContext()` works inside `upgrade`, so cookies, `locals` and `getClientAddress()` are available there. Later callbacks receive only the socket, so derive anything header-based here and return it on `ws.data.user`.
+
+```ts
+// file: src/index.ts
+import { Mochi, getRequestContext } from 'mochi-framework';
+
+await Mochi.serve({
+  proxy: { addressHeader: 'x-forwarded-for', xffDepth: 1 },
+  routes: {
+    '/ws/chat': Mochi.ws<{ address: string | null }>({
+      upgrade() {
+        return { address: getRequestContext().getClientAddress() };
+      },
+      message(ws, msg) {
+        console.log(ws.data.user.address, msg);
+      },
+    }),
+  },
+});
+```
+
+<Callout type="info">
+
+Behind a reverse proxy every socket shares one peer address, so `ws.remoteAddress` is the proxy rather than the visitor. Rate limiting keyed on it becomes one bucket for your whole site — configure `proxy.addressHeader` and read `getClientAddress()` instead.
+
+</Callout>
+
 ### `open`
 
 Fires once after a successful upgrade. Use it to subscribe the socket to topics or seed per-connection state.

--- a/packages/docs/100-websocket-routes.md
+++ b/packages/docs/100-websocket-routes.md
@@ -76,9 +76,9 @@ await Mochi.serve({
 
 #### Request context during the handshake
 
-<VersionNote since="0.9.2" message="Earlier versions threw from getRequestContext() inside upgrade." />
+<VersionNote since="0.10.0" message="Earlier versions threw from getRequestContext() inside upgrade." />
 
-`getRequestContext()` works inside `upgrade`, so cookies, `locals` and `getClientAddress()` are available there. Later callbacks receive only the socket, so derive anything header-based here and return it on `ws.data.user`.
+`getRequestContext()` works inside `upgrade`, so cookies and `getClientAddress()` are available there. `handle` middleware does not run for WebSocket upgrades, so `locals` is empty. Later callbacks receive only the socket, so derive anything header-based here and return it on `ws.data.user`.
 
 ```ts
 // file: src/index.ts

--- a/packages/mochi/src/Mochi.ts
+++ b/packages/mochi/src/Mochi.ts
@@ -1271,8 +1271,10 @@ export class Mochi {
           let userData: unknown = undefined;
 
           const liveWsHandlers = wsHandlersMap.get(pattern) ?? wsHandlers;
-          if (liveWsHandlers.upgrade) {
-            const result = await liveWsHandlers.upgrade(req, wsParams);
+          const upgradeHandler = liveWsHandlers.upgrade;
+          if (upgradeHandler) {
+            // The handshake is the only point in a socket's life with a Request to read, so `getRequestContext()` has to work here.
+            const result = await requestContext.run(wsHookCtx, () => upgradeHandler(req, wsParams));
             if (result === false) {
               emitWsReject(400);
               return new Response('WebSocket upgrade rejected', {

--- a/packages/mochi/src/wsUpgradeContext.test.ts
+++ b/packages/mochi/src/wsUpgradeContext.test.ts
@@ -1,0 +1,74 @@
+// Boots a real Mochi.serve() and opens a real socket, because the request context only exists once a request is
+// actually in flight and no exported helper can establish one from a unit test.
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { Mochi } from './Mochi';
+import { getRequestContext } from './runtime/requestContext';
+
+interface ProbeData {
+  clientAddress: string | null;
+  params: string;
+  error?: string;
+}
+
+describe('Mochi.ws() upgrade request context', () => {
+  let server: Server<undefined>;
+  let outDir: string;
+  let base: string;
+
+  beforeAll(async () => {
+    outDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-ws-ctx-'));
+    server = await Mochi.serve({
+      port: 0,
+      outDir,
+      proxy: { addressHeader: 'x-forwarded-for', xffDepth: 1 },
+      routes: {
+        '/ws/probe/:room': Mochi.ws<ProbeData>({
+          upgrade(_req, params) {
+            try {
+              return { clientAddress: getRequestContext().getClientAddress(), params: params.room ?? '' };
+            } catch (error) {
+              return { clientAddress: null, params: '', error: (error as Error).message };
+            }
+          },
+          open(ws) {
+            ws.send(JSON.stringify(ws.data.user));
+          },
+          message() {},
+        }),
+      },
+    });
+    base = `ws://localhost:${server.port}`;
+  });
+
+  afterAll(async () => {
+    await server.stop(true);
+    rmSync(outDir, { recursive: true, force: true });
+  });
+
+  function probe(headers?: Record<string, string>): Promise<ProbeData> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(`${base}/ws/probe/lobby`, { headers } as unknown as string[]);
+      ws.onmessage = (event) => {
+        ws.close();
+        resolve(JSON.parse(String(event.data)) as ProbeData);
+      };
+      ws.onerror = () => reject(new Error('socket failed'));
+      setTimeout(() => reject(new Error('timed out waiting for the upgrade payload')), 5000);
+    });
+  }
+
+  test('exposes the request context to the upgrade handler', async () => {
+    const data = await probe();
+    expect(data.error).toBeUndefined();
+    expect(data.params).toBe('lobby');
+  });
+
+  test('resolves the forwarded client address through the configured proxy options', async () => {
+    const data = await probe({ 'x-forwarded-for': '203.0.113.7, 10.0.0.2' });
+    expect(data.error).toBeUndefined();
+    expect(data.clientAddress).toBe('10.0.0.2');
+  });
+});

--- a/packages/site/src/demos/chat/Chat.svelte
+++ b/packages/site/src/demos/chat/Chat.svelte
@@ -9,7 +9,7 @@
 
 <DemoPage
   title="Real-time Chat"
-  description="An example of building a simple in-memory chat using a hydrated island and the built-in WebSocket support in Bun. The server stores a bounded message history and replays it to new connections; ws.publish() broadcasts each message to all clients. Frames over 4 KB are dropped by Bun before they are buffered, and a per-address window closes any client sending more than 20 messages per 10 seconds. Open this page in two tabs to see them sync in real time."
+  description="An example of building a simple in-memory chat using a hydrated island and the built-in WebSocket support in Bun. The server stores a bounded message history and replays it to new connections; ws.publish() broadcasts each message to all clients. Messages over 4 KB are rejected, frames over 8 KB are dropped by Bun before they are buffered, and a per-client window closes anyone sending more than 20 messages per 10 seconds. Open this page in two tabs to see them sync in real time."
   {sources}
 >
   <ChatWidget mochi:hydrate />

--- a/packages/site/src/demos/chat/ChatWidget.svelte
+++ b/packages/site/src/demos/chat/ChatWidget.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { isBrowser } from 'mochi-framework';
 
-  let messages: Array<{ text: string; fromMe: boolean }> = $state([{ text: 'Hello friend! How are you?', fromMe: false }]);
+  const GREETING = { text: 'Hello friend! How are you?', fromMe: false };
+
+  let messages: Array<{ text: string; fromMe: boolean }> = $state([GREETING]);
   let input = $state('');
   let messagesEl: HTMLDivElement | undefined = $state();
 
@@ -12,7 +14,12 @@
 
   let chatSocket: WebSocket | null = null;
   let disconnected = $state<string | null>(null);
+  let reconnecting = $state(false);
   let userId = '';
+
+  // The server states its reason for these; anything else is a transport drop worth retrying.
+  const POLICY_CLOSE_CODES = new Set([1003, 1008, 1009]);
+  const MAX_RECONNECT_ATTEMPTS = 5;
 
   if (isBrowser) {
     userId =
@@ -25,17 +32,42 @@
 
     const host = window.location.host;
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    let attempts = 0;
 
-    chatSocket = new WebSocket(`${wsProtocol}//${host}/ws/chat`);
-    chatSocket.addEventListener('message', (e) => {
-      const msg = JSON.parse(e.data);
-      messages = [...messages, { text: msg.text, fromMe: msg.userId === userId }];
-    });
-    // The server closes the socket on an oversized or too-frequent message; send() on a closed socket is a silent
-    // no-op, so without this the box would keep accepting text into the void.
-    chatSocket.addEventListener('close', (e) => {
-      disconnected = e.reason || (e.code === 1009 ? 'Message too large' : 'Connection closed');
-    });
+    const connect = () => {
+      const socket = new WebSocket(`${wsProtocol}//${host}/ws/chat`);
+      chatSocket = socket;
+
+      socket.addEventListener('open', () => {
+        attempts = 0;
+        reconnecting = false;
+        disconnected = null;
+        // The server replays its whole history on every connection, so a reconnect would otherwise double every message.
+        messages = [GREETING];
+      });
+
+      socket.addEventListener('message', (e) => {
+        const msg = JSON.parse(e.data);
+        messages = [...messages, { text: msg.text, fromMe: msg.userId === userId }];
+      });
+
+      // send() on a closed socket is a silent no-op, so without this the box would keep accepting text into the void.
+      socket.addEventListener('close', (e) => {
+        if (POLICY_CLOSE_CODES.has(e.code)) {
+          disconnected = e.reason || (e.code === 1009 ? 'Message too large' : 'Connection closed');
+          return;
+        }
+        if (attempts >= MAX_RECONNECT_ATTEMPTS) {
+          reconnecting = false;
+          disconnected = 'Connection closed';
+          return;
+        }
+        reconnecting = true;
+        setTimeout(connect, 500 * 2 ** attempts++);
+      });
+    };
+
+    connect();
   }
 
   function send() {
@@ -72,11 +104,13 @@
 
   {#if disconnected}
     <p class="disconnected" role="alert">{disconnected} — reload the page to reconnect.</p>
+  {:else if reconnecting}
+    <p class="disconnected" role="status">Reconnecting…</p>
   {/if}
 
   <div class="chat-input">
-    <input type="text" bind:value={input} onkeydown={onKeydown} placeholder="Type a message..." disabled={!!disconnected} />
-    <button onclick={send} disabled={!!disconnected}>Send</button>
+    <input type="text" bind:value={input} onkeydown={onKeydown} placeholder="Type a message..." disabled={!!disconnected || reconnecting} />
+    <button onclick={send} disabled={!!disconnected || reconnecting}>Send</button>
   </div>
 </div>
 

--- a/packages/site/src/demos/chat/ChatWidget.svelte
+++ b/packages/site/src/demos/chat/ChatWidget.svelte
@@ -15,11 +15,14 @@
   let chatSocket: WebSocket | null = null;
   let disconnected = $state<string | null>(null);
   let reconnecting = $state(false);
+  const locked = $derived(!!disconnected || reconnecting);
   let userId = '';
 
   // The server states its reason for these; anything else is a transport drop worth retrying.
   const POLICY_CLOSE_CODES = new Set([1003, 1008, 1009]);
   const MAX_RECONNECT_ATTEMPTS = 5;
+  // A connection that outlived the longest backoff was healthy, so its drop starts a fresh attempt budget.
+  const STABLE_CONNECTION_MS = 500 * 2 ** MAX_RECONNECT_ATTEMPTS;
 
   if (isBrowser) {
     userId =
@@ -33,32 +36,35 @@
     const host = window.location.host;
     const wsProtocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     let attempts = 0;
+    let openedAt = 0;
 
     const connect = () => {
-      const socket = new WebSocket(`${wsProtocol}//${host}/ws/chat`);
-      chatSocket = socket;
+      chatSocket = new WebSocket(`${wsProtocol}//${host}/ws/chat`);
 
-      socket.addEventListener('open', () => {
-        attempts = 0;
+      chatSocket.addEventListener('open', () => {
+        openedAt = Date.now();
         reconnecting = false;
         disconnected = null;
         // The server replays its whole history on every connection, so a reconnect would otherwise double every message.
         messages = [GREETING];
       });
 
-      socket.addEventListener('message', (e) => {
+      chatSocket.addEventListener('message', (e) => {
         const msg = JSON.parse(e.data);
         messages = [...messages, { text: msg.text, fromMe: msg.userId === userId }];
       });
 
       // send() on a closed socket is a silent no-op, so without this the box would keep accepting text into the void.
-      socket.addEventListener('close', (e) => {
+      chatSocket.addEventListener('close', (e) => {
         if (POLICY_CLOSE_CODES.has(e.code)) {
-          disconnected = e.reason || (e.code === 1009 ? 'Message too large' : 'Connection closed');
+          disconnected = e.reason || 'Connection closed';
           return;
         }
+        if (openedAt && Date.now() - openedAt > STABLE_CONNECTION_MS) {
+          attempts = 0;
+        }
+        openedAt = 0;
         if (attempts >= MAX_RECONNECT_ATTEMPTS) {
-          reconnecting = false;
           disconnected = 'Connection closed';
           return;
         }
@@ -109,8 +115,8 @@
   {/if}
 
   <div class="chat-input">
-    <input type="text" bind:value={input} onkeydown={onKeydown} placeholder="Type a message..." disabled={!!disconnected || reconnecting} />
-    <button onclick={send} disabled={!!disconnected || reconnecting}>Send</button>
+    <input type="text" bind:value={input} onkeydown={onKeydown} placeholder="Type a message..." disabled={locked} />
+    <button onclick={send} disabled={locked}>Send</button>
   </div>
 </div>
 

--- a/packages/site/src/demos/chat/routes.test.ts
+++ b/packages/site/src/demos/chat/routes.test.ts
@@ -44,7 +44,6 @@ describe('chat rate-limit identity', () => {
     expect(rateKeyFor('203.0.113.7')).toBe(rateKeyFor('203.0.113.7'));
   });
 
-  // Behind a proxy that forwards nothing every visitor shares one address, so a shared key would let one burst disconnect them all.
   test('issues a distinct key per socket when no client address is available', () => {
     expect(rateKeyFor(null)).not.toBe(rateKeyFor(null));
     expect(rateKeyFor(null)).toStartWith('socket:');
@@ -97,7 +96,7 @@ describe('chat WebSocket resource bounds', () => {
     expect(sender.closed).toEqual([{ code: 1008, reason: 'Message rate exceeded' }]);
   });
 
-  // The counter lives on the address, so dropping the socket and redialling must not hand out a fresh allowance.
+  // The counter lives on the rate key, not the socket, so dropping the socket and redialling must not hand out a fresh allowance.
   test('keeps the budget across reconnects from the same address', async () => {
     const handlers = chatHandlers();
     const rateKey = rateKeyFor('203.0.113.7');

--- a/packages/site/src/demos/chat/routes.test.ts
+++ b/packages/site/src/demos/chat/routes.test.ts
@@ -1,20 +1,24 @@
 import { describe, expect, test } from 'bun:test';
 import type { ServerWebSocket } from 'bun';
 import type { MochiWsConfig, MochiWsData, MochiWsHandlers } from 'mochi-framework';
-import { CHAT_MAX_HISTORY_BYTES, CHAT_MAX_HISTORY_MESSAGES, CHAT_MAX_MESSAGE_BYTES, CHAT_RATE_LIMIT, CHAT_RATE_WINDOW_MS, createChatRoutes } from './routes';
+import { CHAT_MAX_HISTORY_BYTES, CHAT_MAX_HISTORY_MESSAGES, CHAT_MAX_MESSAGE_BYTES, CHAT_RATE_LIMIT, CHAT_RATE_WINDOW_MS, createChatRoutes, rateKeyFor } from './routes';
+
+interface ChatSocketData {
+  rateKey: string;
+}
 
 interface FakeSocket {
-  ws: ServerWebSocket<MochiWsData>;
+  ws: ServerWebSocket<MochiWsData<ChatSocketData>>;
   sent: string[];
   published: string[];
   closed: Array<{ code: number; reason: string }>;
 }
 
-function chatHandlers(): MochiWsHandlers {
-  return (createChatRoutes()['/ws/chat'] as MochiWsConfig).handlers;
+function chatHandlers(): MochiWsHandlers<ChatSocketData> {
+  return (createChatRoutes()['/ws/chat'] as MochiWsConfig).handlers as unknown as MochiWsHandlers<ChatSocketData>;
 }
 
-function fakeSocket(remoteAddress = '203.0.113.7'): FakeSocket {
+function fakeSocket(rateKey = rateKeyFor('203.0.113.7')): FakeSocket {
   const sent: string[] = [];
   const published: string[] = [];
   const closed: Array<{ code: number; reason: string }> = [];
@@ -23,24 +27,36 @@ function fakeSocket(remoteAddress = '203.0.113.7'): FakeSocket {
       __mochiRoutePattern: '/ws/chat',
       __mochiOpenedAt: performance.now(),
       __mochiPath: '/ws/chat',
-      user: undefined,
+      user: { rateKey },
     },
-    remoteAddress,
     send: (message: string | Buffer) => sent.push(String(message)),
     publish: (_topic: string, message: string | Buffer) => published.push(String(message)),
     close: (code: number, reason: string) => closed.push({ code, reason }),
     subscribe: () => true,
     unsubscribe: () => true,
-  } as unknown as ServerWebSocket<MochiWsData>;
+  } as unknown as ServerWebSocket<MochiWsData<ChatSocketData>>;
   return { ws, sent, published, closed };
 }
+
+describe('chat rate-limit identity', () => {
+  test('reuses one key per client address so a reconnect keeps the same budget', () => {
+    expect(rateKeyFor('203.0.113.7')).toBe('ip:203.0.113.7');
+    expect(rateKeyFor('203.0.113.7')).toBe(rateKeyFor('203.0.113.7'));
+  });
+
+  // Behind a proxy that forwards nothing every visitor shares one address, so a shared key would let one burst disconnect them all.
+  test('issues a distinct key per socket when no client address is available', () => {
+    expect(rateKeyFor(null)).not.toBe(rateKeyFor(null));
+    expect(rateKeyFor(null)).toStartWith('socket:');
+  });
+});
 
 describe('chat WebSocket resource bounds', () => {
   test('retains and replays only the configured message and byte window', async () => {
     const handlers = chatHandlers();
     for (let i = 0; i < CHAT_MAX_HISTORY_MESSAGES + 20; i++) {
-      // A distinct address per sender so the rate limiter never trips during setup.
-      await handlers.message(fakeSocket(`198.51.100.${i % 200}`).ws, `${i}:` + 'x'.repeat(900));
+      // A distinct key per sender so the rate limiter never trips during setup.
+      await handlers.message(fakeSocket(`ip:198.51.100.${i % 200}`).ws, `${i}:` + 'x'.repeat(900));
     }
 
     const receiver = fakeSocket();
@@ -84,9 +100,10 @@ describe('chat WebSocket resource bounds', () => {
   // The counter lives on the address, so dropping the socket and redialling must not hand out a fresh allowance.
   test('keeps the budget across reconnects from the same address', async () => {
     const handlers = chatHandlers();
+    const rateKey = rateKeyFor('203.0.113.7');
     let published = 0;
     for (let i = 0; i <= CHAT_RATE_LIMIT; i++) {
-      const sender = fakeSocket();
+      const sender = fakeSocket(rateKey);
       await handlers.message(sender.ws, String(i));
       published += sender.published.length;
       if (i === CHAT_RATE_LIMIT) {
@@ -97,18 +114,28 @@ describe('chat WebSocket resource bounds', () => {
     expect(published).toBe(CHAT_RATE_LIMIT);
   });
 
-  test('lets a different address through and forgets a window once it expires', async () => {
+  // One socket burning its window must not spend anyone else's.
+  test('leaves other clients untouched when one exhausts its window', async () => {
+    const handlers = chatHandlers();
+    const noisy = fakeSocket(rateKeyFor(null));
+    for (let i = 0; i <= CHAT_RATE_LIMIT; i++) {
+      await handlers.message(noisy.ws, String(i));
+    }
+    expect(noisy.closed).toEqual([{ code: 1008, reason: 'Message rate exceeded' }]);
+
+    const bystander = fakeSocket(rateKeyFor(null));
+    await handlers.message(bystander.ws, 'still allowed');
+    expect(bystander.closed).toEqual([]);
+    expect(bystander.published).toEqual(['still allowed']);
+  });
+
+  test('forgets a window once it expires', async () => {
     const handlers = chatHandlers();
     for (let i = 0; i < CHAT_RATE_LIMIT; i++) {
       await handlers.message(fakeSocket().ws, String(i));
     }
 
-    const other = fakeSocket('192.0.2.9');
-    await handlers.message(other.ws, 'hello');
-    expect(other.closed).toEqual([]);
-
     const later = fakeSocket();
-    Bun.sleepSync(0);
     const realNow = Date.now;
     Date.now = () => realNow() + CHAT_RATE_WINDOW_MS;
     try {

--- a/packages/site/src/demos/chat/routes.ts
+++ b/packages/site/src/demos/chat/routes.ts
@@ -1,7 +1,9 @@
-import { Mochi } from 'mochi-framework';
+import { Mochi, getRequestContext } from 'mochi-framework';
 import type { MochiRouteValue } from 'mochi-framework';
 
 export const CHAT_MAX_MESSAGE_BYTES = 4 * 1024;
+// Bun drops a frame past this before `message` runs, so it has to sit above the app limit or the handler's 1009 close is unreachable.
+export const CHAT_WS_MAX_PAYLOAD_BYTES = 2 * CHAT_MAX_MESSAGE_BYTES;
 export const CHAT_MAX_HISTORY_MESSAGES = 100;
 export const CHAT_MAX_HISTORY_BYTES = 64 * 1024;
 export const CHAT_RATE_LIMIT = 20;
@@ -17,21 +19,29 @@ interface HistoryEntry {
   bytes: number;
 }
 
+interface ChatSocketData {
+  rateKey: string;
+}
+
+// Behind a proxy that forwards no client address, a shared key would put every visitor in one bucket and let a single burst disconnect them all.
+export function rateKeyFor(address: string | null): string {
+  return address ? `ip:${address}` : `socket:${crypto.randomUUID()}`;
+}
+
 export function createChatRoutes(): Record<string, MochiRouteValue> {
   const history: HistoryEntry[] = [];
   let historyBytes = 0;
-  // Keyed by remote address so the allowance survives a reconnect: a per-socket counter would reset on every reconnect,
-  // and each reconnect also replays the history buffer — so dropping and redialling would cost the server more than staying under the limit.
+  // Keyed by client address so the allowance survives a reconnect, which would otherwise hand out a fresh budget and replay the history buffer again.
   const windows = new Map<string, RateWindow>();
 
-  function allowMessage(address: string, now: number): boolean {
-    for (const [key, window] of windows) {
+  function allowMessage(key: string, now: number): boolean {
+    for (const [k, window] of windows) {
       if (now - window.startedAt >= CHAT_RATE_WINDOW_MS) {
-        windows.delete(key);
+        windows.delete(k);
       }
     }
-    const window = windows.get(address) ?? { messages: 0, startedAt: now };
-    windows.set(address, window);
+    const window = windows.get(key) ?? { messages: 0, startedAt: now };
+    windows.set(key, window);
     if (window.messages >= CHAT_RATE_LIMIT) {
       return false;
     }
@@ -43,7 +53,10 @@ export function createChatRoutes(): Record<string, MochiRouteValue> {
     '/demos/chat': Mochi.page('./src/demos/chat/Chat.svelte'),
     '/ws/chat': (() => {
       const TOPIC = 'chat';
-      return Mochi.ws({
+      return Mochi.ws<ChatSocketData>({
+        upgrade() {
+          return { rateKey: rateKeyFor(getRequestContext().getClientAddress()) };
+        },
         open(ws) {
           ws.subscribe(TOPIC);
           for (const entry of history) {
@@ -60,7 +73,7 @@ export function createChatRoutes(): Record<string, MochiRouteValue> {
             ws.close(1003, 'Chat frames must be text');
             return;
           }
-          if (!allowMessage(ws.remoteAddress, Date.now())) {
+          if (!allowMessage(ws.data.user.rateKey, Date.now())) {
             ws.close(1008, 'Message rate exceeded');
             return;
           }

--- a/packages/site/src/demos/chat/routes.ts
+++ b/packages/site/src/demos/chat/routes.ts
@@ -1,4 +1,4 @@
-import { Mochi, getRequestContext } from 'mochi-framework';
+import { Mochi, getRequestContext, memoryStore } from 'mochi-framework';
 import type { MochiRouteValue } from 'mochi-framework';
 
 export const CHAT_MAX_MESSAGE_BYTES = 4 * 1024;
@@ -9,11 +9,6 @@ export const CHAT_MAX_HISTORY_BYTES = 64 * 1024;
 export const CHAT_RATE_LIMIT = 20;
 export const CHAT_RATE_WINDOW_MS = 10_000;
 
-interface RateWindow {
-  messages: number;
-  startedAt: number;
-}
-
 interface HistoryEntry {
   text: string;
   bytes: number;
@@ -23,7 +18,8 @@ interface ChatSocketData {
   rateKey: string;
 }
 
-// Behind a proxy that forwards no client address, a shared key would put every visitor in one bucket and let a single burst disconnect them all.
+// `getClientAddress()` only returns null when Bun has no peer address at all (behind a proxy it still yields the proxy's IP,
+// so separating visitors there is `proxy.addressHeader`'s job); a per-socket key keeps that edge case from sharing one bucket.
 export function rateKeyFor(address: string | null): string {
   return address ? `ip:${address}` : `socket:${crypto.randomUUID()}`;
 }
@@ -32,22 +28,7 @@ export function createChatRoutes(): Record<string, MochiRouteValue> {
   const history: HistoryEntry[] = [];
   let historyBytes = 0;
   // Keyed by client address so the allowance survives a reconnect, which would otherwise hand out a fresh budget and replay the history buffer again.
-  const windows = new Map<string, RateWindow>();
-
-  function allowMessage(key: string, now: number): boolean {
-    for (const [k, window] of windows) {
-      if (now - window.startedAt >= CHAT_RATE_WINDOW_MS) {
-        windows.delete(k);
-      }
-    }
-    const window = windows.get(key) ?? { messages: 0, startedAt: now };
-    windows.set(key, window);
-    if (window.messages >= CHAT_RATE_LIMIT) {
-      return false;
-    }
-    window.messages++;
-    return true;
-  }
+  const limiter = memoryStore();
 
   return {
     '/demos/chat': Mochi.page('./src/demos/chat/Chat.svelte'),
@@ -63,7 +44,7 @@ export function createChatRoutes(): Record<string, MochiRouteValue> {
             ws.send(entry.text);
           }
         },
-        message(ws, message) {
+        async message(ws, message) {
           const bytes = typeof message === 'string' ? Buffer.byteLength(message, 'utf8') : message.byteLength;
           if (bytes > CHAT_MAX_MESSAGE_BYTES) {
             ws.close(1009, 'Message too large');
@@ -73,7 +54,8 @@ export function createChatRoutes(): Record<string, MochiRouteValue> {
             ws.close(1003, 'Chat frames must be text');
             return;
           }
-          if (!allowMessage(ws.data.user.rateKey, Date.now())) {
+          const { count } = await limiter.hit(ws.data.user.rateKey, CHAT_RATE_WINDOW_MS, CHAT_RATE_LIMIT);
+          if (count > CHAT_RATE_LIMIT) {
             ws.close(1008, 'Message rate exceeded');
             return;
           }

--- a/packages/site/src/index.ts
+++ b/packages/site/src/index.ts
@@ -16,7 +16,7 @@ import { handle as modeWatcherHandle } from './demos/mode-watcher/routes';
 import { handle as shotHandle } from './shot/routes';
 import { encodeDebugBarGlobals } from './lib/debugBarEncode';
 import { routes, queues, cron } from './routes';
-import { CHAT_MAX_MESSAGE_BYTES } from './demos/chat/routes';
+import { CHAT_WS_MAX_PAYLOAD_BYTES } from './demos/chat/routes';
 
 const DEVELOPMENT = process.env.NODE_ENV === 'development';
 const IS_DOCKER = process.env.MOCHI_DOCKER === 'true';
@@ -171,8 +171,9 @@ await Mochi.serve({
   port: PORT,
   liveReload: process.env.MOCHI_LIVE_RELOAD === 'false' ? false : undefined,
   htmlShell: './src/shell.html',
-  // The only inbound bound that runs before Bun buffers a frame; it tightens Bun's 16 MB-per-message default.
-  websocket: { maxPayloadLength: CHAT_MAX_MESSAGE_BYTES },
+  // `maxPayloadLength` is the only inbound bound running before Bun buffers a frame, and `idleTimeout` keeps Bun's
+  // keepalive pings landing inside nginx's 60s `proxy_read_timeout`, which would otherwise drop every idle tab.
+  websocket: { maxPayloadLength: CHAT_WS_MAX_PAYLOAD_BYTES, idleTimeout: 30 },
   speculationRules,
   trailingSlash: 'always',
   // /ci/dashboard is a chrome-free always-on display — it would otherwise report a pageview every refresh.
@@ -202,7 +203,8 @@ await Mochi.serve({
   warmup: { enabledInProd: true, enabledInDev: true },
   additionalWatchPaths: ['../docs'],
   logger: { level: 'log' },
-  proxy: { origin }, // TODO: This is a bit of an awkward way to set the allowed csrf domain...
+  // nginx is the socket peer for every visitor, so reading the rightmost entry nginx appends is what distinguishes them.
+  proxy: { origin, addressHeader: 'x-forwarded-for', xffDepth: 1 }, // TODO: This is a bit of an awkward way to set the allowed csrf domain...
   // Served straight from disk as one Bun directory route for the /demos/static-dirs page
   // (kept in sync with the example shown in ./src/demoIndex.ts).
   staticDirs: { '/gallery': './images' },


### PR DESCRIPTION
Follow-up to #332. I drove the demos that PR touched through a browser against the live site; these are the bugs that pass turned up. Every claim below is backed by a probe against `mochi.fast` or a minimal local repro, not by reading the code.

## 1. The `1009 Message too large` path was unreachable

`websocket: { maxPayloadLength }` was set to `CHAT_MAX_MESSAGE_BYTES` — the *same* 4096 the `message` handler checks against. Bun drops a frame past `maxPayloadLength` before the handler runs, so `ws.close(1009, 'Message too large')` could never fire:

```
# before, against mochi.fast
OVERSIZED (>4096) -> {"code":1006,"reason":""}
```

`ChatWidget`'s `e.code === 1009 ? 'Message too large'` branch was dead in production — an oversized paste read as a generic "Connection closed". Bun's cap now sits at `2 *` the app limit, leaving a band the handler owns:

```
# after
OVER APP LIMIT (5K)  -> {"code":1009,"reason":"Message too large"}
OVER BUN CAP   (9K)  -> {"code":1006,"reason":"Connection ended"}
UNDER LIMIT  (3.9K)  -> still open
```

## 2. The rate limit was one bucket for the whole site

`allowMessage(ws.remoteAddress, …)` used Bun's TCP peer address. The site is behind nginx (`server: nginx` on every response), so that address is the proxy's — identical for every visitor. One person sending 21 messages in 10s would trip the window and disconnect *everyone*, and since the window is address-keyed and survives reconnects, they'd stay locked out for the rest of it.

The address now comes from the request context, which already resolves `proxy.addressHeader` (see §4), so behind the site's nginx each visitor gets their own bucket. Note the limit is only per-visitor when the proxy forwards the client address: `getClientAddress()` falls back to Bun's peer address, not `null`, so behind a proxy that forwards nothing the key is still the proxy's address and the bucket is still shared. The `null` branch in `rateKeyFor` only covers a request with no peer address at all. The counter itself now uses `mochi-framework`'s `memoryStore()` instead of a hand-rolled window (review follow-up, b7a5061b).

## 3. A quiet chat box went permanently dead after 60 seconds

Not introduced by #332, but made visible by it. Probing production:

| Route | Traffic | Result |
|---|---|---|
| `/ws/time` | 1 frame/sec | open at 90s |
| `/ws/cron-log` | sparse | closed 81.5s, 1006 |
| `/ws/chat` | silent | closed 60.3s, 1006 |

That's nginx's 60s `proxy_read_timeout`, reset by any traffic. The site's existing `idleTimeout: 60` is the *HTTP* knob and never applied to sockets — confirmed with a local repro where `idleTimeout: 5` left a WebSocket open well past 5s. #332's new `close` handler then turned that silent drop into a disabled input reading "reload the page to reconnect", so anyone who read the page for a minute before typing found a dead box.

Fixed on both ends:

- `websocket: { idleTimeout: 30 }` puts Bun's [`sendPings`](https://bun.com/docs/runtime/http/websockets#timeouts-and-limits) keepalive inside nginx's window. Verified: a socket idle for **70s** stays open (`{"stillOpenAfterMs":70004,"readyState":1}`). 30 rather than 60 because Bun documents `sendPings` but not its interval, so this is safe whether it fires at the timeout or half of it.
- The widget reconnects with backoff on transport drops, and deliberately **not** on the server's 1003/1008/1009 policy closes, where retrying would just spam a rejected client. On reconnect it resets to the greeting before the server replays history, so messages don't double up. The attempt budget only resets after a connection has stayed open longer than the longest backoff, so an accept-then-drop server exhausts the five attempts instead of looping forever (review follow-up, b7a5061b).

## 4. `getRequestContext()` threw inside `Mochi.ws({ upgrade })`

Fixing §2 surfaced a framework gap. `buildRequestContext` already ran for WebSocket routes and already built a correct `getClientAddress()` from `cfg.proxy` — but `Mochi.ts` wrapped only the `route:matched` hook in `requestContext.run()`, leaving the `upgrade` call outside it:

```
THREW: getRequestContext() called outside of a request.
```

That contradicts the error's own wording: `upgrade` *is* server-side code in a Mochi request handler, and it's the only callback with a Request behind it — so it's exactly where auth and client identity belong. Without the fix, every caller has to duplicate the configured `proxy` options to derive a client address.

One line in `Mochi.ts`:

```ts
const result = await requestContext.run(wsHookCtx, () => upgradeHandler(req, wsParams));
```

Covered by `wsUpgradeContext.test.ts`, which boots a real server and opens a real socket. Mutation-checked: reverting the line fails both tests.

## Verified working, unchanged

The rest of the regression pass found nothing wrong: queue enqueue → SSE update, all four image demos returning real optimized bytes through the rewritten DNS-pinned fetch, `/ws/time` unaffected by the site-wide payload cap, clean hydration with no console errors.

## Not addressed

- **Enhanced-action error masking is inert on `mochi.fast`.** The site is deployed with the dev-mode Dockerfile, so `development` is true and `POST /demos/form-errors/?/throwError` still returns the raw `"Something went wrong on the server"`, not `"Internal Server Error"`. That matches #332's stated accepted risk; flagging it because the fix can't be observed on the site it protects, and only the unit test covers it.
- **`queue.server.ts`'s `pendingSince.shift()`** drops the oldest timestamp regardless of which job settled, so the TTL can age out the wrong entry. Left alone — the count stays correct and fixing it properly means tracking job ids, more machinery than the demo needs.

## Checks

`bun run checks` passes: 0 typecheck errors, mochi-framework 191/191 files, mochi-site 16/16, all suites 0 fail.

