### PR TITLE
perf(islands): dedupe island props by identity before serializing

### DIFF
--- a/packages/mochi/src/cache/cache.test.ts
+++ b/packages/mochi/src/cache/cache.test.ts
@@ -903,7 +903,7 @@ describe('MochiCache invalidation during the initial-read gap', () => {
   });
 
   test('an uncontended fetch still writes its recompute on miss, stale and expired reads', async () => {
-    const cache = new MochiCache({ minTimeToStale: 10, maxTimeToLive: 30 });
+    const cache = new MochiCache({ minTimeToStale: 50, maxTimeToLive: 200 });
     let calls = 0;
     const fn = async () => {
       calls++;
@@ -914,12 +914,12 @@ describe('MochiCache invalidation during the initial-read gap', () => {
     expect(await cache.fetchWithStatus('k', fn)).toEqual({ value: 'v1', status: 'miss' });
     expect(await cache.peek('k')).toEqual({ value: 'v1', status: 'fresh' });
 
-    await wait(15);
+    await wait(80);
     expect((await cache.fetchWithStatus('k', fn)).status).toBe('stale');
     await cache.whenIdle();
     expect(await cache.peek('k')).toEqual({ value: 'v2', status: 'fresh' });
 
-    await wait(40);
+    await wait(250);
     expect(await cache.fetchWithStatus('k', fn)).toEqual({ value: 'v3', status: 'expired' });
     expect(await cache.peek('k')).toEqual({ value: 'v3', status: 'fresh' });
   });

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -14,7 +14,7 @@ import {
   toCompileErrorLogs,
   toPosixPath,
 } from '../utils';
-import { clearIslandProps, injectIslandPropsBlock } from '../islands/islandPropsRegistry';
+import { injectIslandPropsBlock } from '../islands/islandPropsRegistry';
 import { requestContext, renderDetached } from '../runtime/requestContext';
 import type { DebugBarData } from '../runtime/requestContext';
 import { logger } from '../utils/log';
@@ -1552,9 +1552,7 @@ export class ComponentRegistry {
     // HTMLRewriter pass below drains it, so clearing up front keeps sequential same-ctx renders self-contained — an
     // error page after a failed render, an action's POST re-render.
     const ctx = requestContext.getStore();
-    if (ctx) {
-      clearIslandProps(ctx);
-    }
+    ctx?.islandProps.clear();
 
     const component = opts?.exportName && opts.exportName !== 'default' ? mod[opts.exportName] : mod.default;
     if (!component) {

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -14,7 +14,7 @@ import {
   toCompileErrorLogs,
   toPosixPath,
 } from '../utils';
-import { injectIslandPropsBlock } from '../islands/islandPropsRegistry';
+import { clearIslandProps, injectIslandPropsBlock } from '../islands/islandPropsRegistry';
 import { requestContext, renderDetached } from '../runtime/requestContext';
 import type { DebugBarData } from '../runtime/requestContext';
 import { logger } from '../utils/log';
@@ -1552,7 +1552,9 @@ export class ComponentRegistry {
     // HTMLRewriter pass below drains it, so clearing up front keeps sequential same-ctx renders self-contained — an
     // error page after a failed render, an action's POST re-render.
     const ctx = requestContext.getStore();
-    ctx?.islandProps.clear();
+    if (ctx) {
+      clearIslandProps(ctx);
+    }
 
     const component = opts?.exportName && opts.exportName !== 'default' ? mod[opts.exportName] : mod.default;
     if (!component) {

--- a/packages/mochi/src/email/render.test.ts
+++ b/packages/mochi/src/email/render.test.ts
@@ -76,14 +76,14 @@ describe('renderEmailComponent', () => {
   // `ctx.islandProps` and emits no `mochi-props` blocks.
   test('does not touch ctx.islandProps when run inside a request context', async () => {
     const ctx = makeCtx();
-    ctx.islandProps.set('seed', { id: 'mochi-props-0', emitCount: 1 });
+    ctx.islandProps.set('seed', { id: 'mochi-props-0', emitCount: 1, bags: [] });
 
     const html = await requestContext.run(ctx, () => renderEmailComponent(registry, WELCOME, { name: 'Ada' }));
 
     expect(html).toContain('Hello Ada');
     expect(html).not.toContain('mochi-props');
     // The pre-seeded entry survives untouched — the email render ran isolated.
-    expect(ctx.islandProps.get('seed')).toEqual({ id: 'mochi-props-0', emitCount: 1 });
+    expect(ctx.islandProps.get('seed')).toEqual({ id: 'mochi-props-0', emitCount: 1, bags: [] });
     expect(ctx.islandProps.size).toBe(1);
   });
 

--- a/packages/mochi/src/image/imageCache.test.ts
+++ b/packages/mochi/src/image/imageCache.test.ts
@@ -410,15 +410,15 @@ describe('ImageCache.setPlaceholder', () => {
         await Bun.sleep(0);
       }
     })();
-    for (let i = 0; i < 20; i++) {
+    // Rewrites keep going until the reader has sampled enough for the assertion below to mean
+    // anything; a fixed count went vacuous on runners where a rewrite outpaces the timer yield.
+    for (let i = 0; i < 400 && reads < 200; i++) {
       await cache.setPlaceholder(SRC, `data:image/png;base64,GEN${i}`, i);
     }
     stop = true;
     await reader;
 
     expect(sawMiss).toBe(false);
-    // Guards the assertion above from going vacuous: it only means anything if the reader
-    // actually sampled while the rewrites were in flight.
     expect(reads).toBeGreaterThan(100);
   });
 });

--- a/packages/mochi/src/islands/islandPropsRegistry.test.ts
+++ b/packages/mochi/src/islands/islandPropsRegistry.test.ts
@@ -142,6 +142,30 @@ describe('emitIslandProps identity fast path', () => {
     });
   });
 
+  test('a bag equal to an earlier one but built from distinct references joins the same entry, and later calls sharing either set of references hit the fast path', () => {
+    withCtx((ctx) => {
+      let walks = 0;
+      const build = () => ({
+        get items() {
+          walks++;
+          return [1, 2, 3];
+        },
+      });
+      const first = build();
+      const second = build();
+
+      expect(emitIslandProps({ nav: first })).toBe('mochi-props-0');
+      expect(emitIslandProps({ nav: second })).toBe('mochi-props-0');
+      expect(walks).toBe(2);
+
+      expect(emitIslandProps({ nav: second })).toBe('mochi-props-0');
+      expect(emitIslandProps({ nav: first })).toBe('mochi-props-0');
+      expect(walks).toBe(2);
+      expect(ctx.islandProps.size).toBe(1);
+      expect([...ctx.islandProps.values()][0]!.emitCount).toBe(4);
+    });
+  });
+
   test('0 and -0 do not collide, since devalue round-trips them differently', () => {
     withCtx((ctx) => {
       const a = emitIslandProps({ n: 0 });

--- a/packages/mochi/src/islands/islandPropsRegistry.test.ts
+++ b/packages/mochi/src/islands/islandPropsRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { parse as devalueParse, stringify as devalueStringify } from 'devalue';
-import { clearIslandProps, emitIslandProps, injectIslandPropsBlock, renderIslandPropsScript } from './islandPropsRegistry';
+import { emitIslandProps, injectIslandPropsBlock, renderIslandPropsScript } from './islandPropsRegistry';
 import { requestContext, type MochiRequestContext } from '../runtime/requestContext';
 import { MochiCookieJar } from '../runtime/cookies';
 
@@ -162,16 +162,15 @@ describe('emitIslandProps identity fast path', () => {
     });
   });
 
-  test('clearIslandProps drops the shape index too, so ids never outlive their block', () => {
+  test('clearing the registry drops the bags with it, so ids never outlive their block', () => {
     withCtx((ctx) => {
       const docsNav = [{ level: 2, text: 'Intro', slug: 'intro' }];
       const first = emitIslandProps({ docsNav });
       expect(first).toBe('mochi-props-0');
 
-      clearIslandProps(ctx);
+      ctx.islandProps.clear();
       expect(ctx.islandProps.size).toBe(0);
 
-      // Without dropping the shape index this returns the id of a block the second render never emits.
       const second = emitIslandProps({ docsNav });
       expect(second).toBe('mochi-props-0');
       expect(ctx.islandProps.size).toBe(1);

--- a/packages/mochi/src/islands/islandPropsRegistry.test.ts
+++ b/packages/mochi/src/islands/islandPropsRegistry.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test';
 import { parse as devalueParse, stringify as devalueStringify } from 'devalue';
-import { emitIslandProps, injectIslandPropsBlock, renderIslandPropsScript } from './islandPropsRegistry';
+import { clearIslandProps, emitIslandProps, injectIslandPropsBlock, renderIslandPropsScript } from './islandPropsRegistry';
 import { requestContext, type MochiRequestContext } from '../runtime/requestContext';
 import { MochiCookieJar } from '../runtime/cookies';
 
@@ -95,6 +95,102 @@ describe('emitIslandProps', () => {
     // Same payload, but each request started fresh — both should get id 0.
     expect(id1).toBe('mochi-props-0');
     expect(id2).toBe('mochi-props-0');
+  });
+});
+
+// These cover that the identity shortcut agrees with the serializing path, and never fires when the two would disagree.
+describe('emitIslandProps identity fast path', () => {
+  test('two call sites sharing prop references dedupe, and the second never walks the payload', () => {
+    withCtx((ctx) => {
+      // Only devalue recurses, so a getter one level down is read once per serialization and not at all on a fast-path hit.
+      let walks = 0;
+      const docsNav = {
+        get entries() {
+          walks++;
+          return [{ level: 2, text: 'Intro', slug: 'intro' }];
+        },
+      };
+      const demos = [{ slug: 'url' }];
+
+      const a = emitIslandProps({ docsNav, demos, currentSlug: 'intro' });
+      const b = emitIslandProps({ docsNav, demos, currentSlug: 'intro' });
+
+      expect(a).toBe(b);
+      expect(walks).toBe(1);
+      expect(ctx.islandProps.size).toBe(1);
+      expect([...ctx.islandProps.values()][0]!.emitCount).toBe(2);
+    });
+  });
+
+  test('same references but a different primitive prop stay distinct', () => {
+    withCtx((ctx) => {
+      const docsNav = [{ level: 2, text: 'Intro', slug: 'intro' }];
+      const a = emitIslandProps({ docsNav, currentSlug: 'intro' });
+      const b = emitIslandProps({ docsNav, currentSlug: 'cache' });
+      expect(a).not.toBe(b);
+      expect(ctx.islandProps.size).toBe(2);
+    });
+  });
+
+  test('equal-but-distinct references still dedupe, via the serializing path', () => {
+    withCtx((ctx) => {
+      const a = emitIslandProps({ items: [1, 2, 3] });
+      const b = emitIslandProps({ items: [1, 2, 3] });
+      expect(a).toBe(b);
+      expect(ctx.islandProps.size).toBe(1);
+      expect([...ctx.islandProps.values()][0]!.emitCount).toBe(2);
+    });
+  });
+
+  test('0 and -0 do not collide, since devalue round-trips them differently', () => {
+    withCtx((ctx) => {
+      const a = emitIslandProps({ n: 0 });
+      const b = emitIslandProps({ n: -0 });
+      expect(a).not.toBe(b);
+      expect(ctx.islandProps.size).toBe(2);
+    });
+  });
+
+  test('non-plain and symbol-keyed bags decline the fast path and let devalue rule', () => {
+    withCtx(() => {
+      class Bag {
+        constructor(public x: number) {}
+      }
+      // The fast path must not paper over a value devalue rejects by answering from identity instead.
+      expect(() => emitIslandProps(new Bag(1))).toThrow(/non-POJO/);
+      expect(() => emitIslandProps({ x: 1, [Symbol('s')]: 'one' })).toThrow(/symbolic keys/);
+    });
+  });
+
+  test('clearIslandProps drops the shape index too, so ids never outlive their block', () => {
+    withCtx((ctx) => {
+      const docsNav = [{ level: 2, text: 'Intro', slug: 'intro' }];
+      const first = emitIslandProps({ docsNav });
+      expect(first).toBe('mochi-props-0');
+
+      clearIslandProps(ctx);
+      expect(ctx.islandProps.size).toBe(0);
+
+      // Without dropping the shape index this returns the id of a block the second render never emits.
+      const second = emitIslandProps({ docsNav });
+      expect(second).toBe('mochi-props-0');
+      expect(ctx.islandProps.size).toBe(1);
+      expect([...ctx.islandProps.values()][0]!.emitCount).toBe(1);
+    });
+  });
+
+  test('two requests sharing prop references keep independent registries', () => {
+    const docsNav = [{ level: 2, text: 'Intro', slug: 'intro' }];
+    const one = withCtx((ctx) => {
+      const id = emitIslandProps({ docsNav });
+      return { id, size: ctx.islandProps.size };
+    });
+    const two = withCtx((ctx) => {
+      const id = emitIslandProps({ docsNav });
+      return { id, size: ctx.islandProps.size };
+    });
+    expect(one).toEqual({ id: 'mochi-props-0', size: 1 });
+    expect(two).toEqual({ id: 'mochi-props-0', size: 1 });
   });
 });
 

--- a/packages/mochi/src/islands/islandPropsRegistry.ts
+++ b/packages/mochi/src/islands/islandPropsRegistry.ts
@@ -1,20 +1,12 @@
 import { stringify } from 'devalue';
 import { getRequestContext } from '../runtime/requestContext';
-import { pinGlobal } from '../utils/globalState';
 
-/** One entry in the per-render dedup registry (`ctx.islandProps`): a unique serialized payload's ref id and how many islands emitted it. */
+/** One entry in the per-render dedup registry (`ctx.islandProps`): a unique serialized payload's ref id, how many islands emitted it, and the first props bag that produced it. */
 export interface IslandPropsEntry {
   id: string;
   emitCount: number;
+  bag?: Record<string, unknown>;
 }
-
-type IslandPropsMap = Map<string, IslandPropsEntry>;
-
-type EmittedBag = { value: Record<string, unknown>; entry: IslandPropsEntry };
-
-// Pinned because the copy of the framework that clears a render's registry is often not the copy whose
-// `emitIslandProps` filled it, and a bag outliving its payload map would name a block that render never emits.
-const emittedBags = pinGlobal('__mochi_island_props_bags__', () => new WeakMap<IslandPropsMap, EmittedBag[]>());
 
 /** Only a bag devalue would accept can stand in for one it already serialized, so anything it rejects must reach it and throw. */
 function isPlainBag(value: unknown): value is Record<string, unknown> {
@@ -31,12 +23,6 @@ function sameBag(a: Record<string, unknown>, b: Record<string, unknown>): boolea
   return keys.length === Object.keys(b).length && keys.every((key) => Object.is(a[key], b[key]));
 }
 
-/** The bag list has to be dropped with the payload map it indexes, or a surviving entry names a block the next render never emits. */
-export function clearIslandProps(ctx: { islandProps: IslandPropsMap }): void {
-  ctx.islandProps.clear();
-  emittedBags.delete(ctx.islandProps);
-}
-
 /**
  * Serialize a hydratable island's props via devalue and register them in the per-render dedup registry, returning the
  * stable ref id the preprocessor emits as `props-ref`. After SSR, `ComponentRegistry`'s HTMLRewriter pass writes each
@@ -46,36 +32,23 @@ export function clearIslandProps(ctx: { islandProps: IslandPropsMap }): void {
  * count lets the render pass flag genuinely shared blocks. Server islands take the preprocessor's own branch instead,
  * since their `signed-props` payloads are encrypted and travel through URL query strings.
  *
- * Props reached through the identity fast path are assumed not to be mutated between two call sites inside one
- * `render()`; a render that did that would get one shared block where it wanted two.
+ * A bag whose props are the very same references as an already-registered entry's bag skips serializing altogether;
+ * that assumes props are not mutated between two call sites inside one `render()`, or the render gets one shared block
+ * where it wanted two.
  */
 export function emitIslandProps(value: unknown): string {
   const ctx = getRequestContext();
-
-  // Serializing is how a duplicate is found, so it is paid for before it is discovered.
-  const bags = emittedBags.get(ctx.islandProps);
-  if (bags && isPlainBag(value)) {
-    for (const bag of bags) {
-      if (sameBag(bag.value, value)) {
-        bag.entry.emitCount++;
-        return bag.entry.id;
-      }
+  const bag = isPlainBag(value) ? value : undefined;
+  let entry = bag && ctx.islandProps.values().find((e) => e.bag !== undefined && sameBag(e.bag, bag));
+  if (!entry) {
+    const json = stringify(value);
+    entry = ctx.islandProps.get(json);
+    if (!entry) {
+      entry = { id: `mochi-props-${ctx.islandProps.size}`, emitCount: 0, bag };
+      ctx.islandProps.set(json, entry);
     }
   }
-
-  const json = stringify(value);
-  let entry = ctx.islandProps.get(json);
-  if (!entry) {
-    entry = { id: `mochi-props-${ctx.islandProps.size}`, emitCount: 0 };
-    ctx.islandProps.set(json, entry);
-  }
   entry.emitCount++;
-
-  if (isPlainBag(value)) {
-    const list = bags ?? [];
-    list.push({ value, entry });
-    emittedBags.set(ctx.islandProps, list);
-  }
   return entry.id;
 }
 

--- a/packages/mochi/src/islands/islandPropsRegistry.ts
+++ b/packages/mochi/src/islands/islandPropsRegistry.ts
@@ -1,11 +1,11 @@
 import { stringify } from 'devalue';
 import { getRequestContext } from '../runtime/requestContext';
 
-/** One entry in the per-render dedup registry (`ctx.islandProps`): a unique serialized payload's ref id, how many islands emitted it, and the first props bag that produced it. */
+/** One entry in the per-render dedup registry (`ctx.islandProps`): a unique serialized payload's ref id, how many islands emitted it, and every props bag that serialized to it. */
 export interface IslandPropsEntry {
   id: string;
   emitCount: number;
-  bag?: Record<string, unknown>;
+  bags: Record<string, unknown>[];
 }
 
 /** Only a bag devalue would accept can stand in for one it already serialized, so anything it rejects must reach it and throw. */
@@ -32,20 +32,23 @@ function sameBag(a: Record<string, unknown>, b: Record<string, unknown>): boolea
  * count lets the render pass flag genuinely shared blocks. Server islands take the preprocessor's own branch instead,
  * since their `signed-props` payloads are encrypted and travel through URL query strings.
  *
- * A bag whose props are the very same references as an already-registered entry's bag skips serializing altogether;
+ * A bag whose props are the very same references as one already registered on an entry skips serializing altogether;
  * that assumes props are not mutated between two call sites inside one `render()`, or the render gets one shared block
  * where it wanted two.
  */
 export function emitIslandProps(value: unknown): string {
   const ctx = getRequestContext();
   const bag = isPlainBag(value) ? value : undefined;
-  let entry = bag && ctx.islandProps.values().find((e) => e.bag !== undefined && sameBag(e.bag, bag));
+  let entry = bag && ctx.islandProps.values().find((e) => e.bags.some((b) => sameBag(b, bag)));
   if (!entry) {
     const json = stringify(value);
     entry = ctx.islandProps.get(json);
     if (!entry) {
-      entry = { id: `mochi-props-${ctx.islandProps.size}`, emitCount: 0, bag };
+      entry = { id: `mochi-props-${ctx.islandProps.size}`, emitCount: 0, bags: [] };
       ctx.islandProps.set(json, entry);
+    }
+    if (bag) {
+      entry.bags.push(bag);
     }
   }
   entry.emitCount++;

--- a/packages/mochi/src/islands/islandPropsRegistry.ts
+++ b/packages/mochi/src/islands/islandPropsRegistry.ts
@@ -1,10 +1,40 @@
 import { stringify } from 'devalue';
 import { getRequestContext } from '../runtime/requestContext';
+import { pinGlobal } from '../utils/globalState';
 
 /** One entry in the per-render dedup registry (`ctx.islandProps`): a unique serialized payload's ref id and how many islands emitted it. */
 export interface IslandPropsEntry {
   id: string;
   emitCount: number;
+}
+
+type IslandPropsMap = Map<string, IslandPropsEntry>;
+
+type EmittedBag = { value: Record<string, unknown>; entry: IslandPropsEntry };
+
+// Pinned because the copy of the framework that clears a render's registry is often not the copy whose
+// `emitIslandProps` filled it, and a bag outliving its payload map would name a block that render never emits.
+const emittedBags = pinGlobal('__mochi_island_props_bags__', () => new WeakMap<IslandPropsMap, EmittedBag[]>());
+
+/** Only a bag devalue would accept can stand in for one it already serialized, so anything it rejects must reach it and throw. */
+function isPlainBag(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value) as unknown;
+  return (proto === Object.prototype || proto === null) && Object.getOwnPropertySymbols(value).length === 0;
+}
+
+/** `Object.is` is what makes this safe to substitute for comparing serialized bytes: it separates `0` from `-0`, which devalue round-trips apart. */
+function sameBag(a: Record<string, unknown>, b: Record<string, unknown>): boolean {
+  const keys = Object.keys(a);
+  return keys.length === Object.keys(b).length && keys.every((key) => Object.is(a[key], b[key]));
+}
+
+/** The bag list has to be dropped with the payload map it indexes, or a surviving entry names a block the next render never emits. */
+export function clearIslandProps(ctx: { islandProps: IslandPropsMap }): void {
+  ctx.islandProps.clear();
+  emittedBags.delete(ctx.islandProps);
 }
 
 /**
@@ -15,16 +45,37 @@ export interface IslandPropsEntry {
  * Two islands with byte-identical serialized JSON share one ref id — the whole dedup mechanism — and the per-id emit
  * count lets the render pass flag genuinely shared blocks. Server islands take the preprocessor's own branch instead,
  * since their `signed-props` payloads are encrypted and travel through URL query strings.
+ *
+ * Props reached through the identity fast path are assumed not to be mutated between two call sites inside one
+ * `render()`; a render that did that would get one shared block where it wanted two.
  */
 export function emitIslandProps(value: unknown): string {
-  const json = stringify(value);
   const ctx = getRequestContext();
+
+  // Serializing is how a duplicate is found, so it is paid for before it is discovered.
+  const bags = emittedBags.get(ctx.islandProps);
+  if (bags && isPlainBag(value)) {
+    for (const bag of bags) {
+      if (sameBag(bag.value, value)) {
+        bag.entry.emitCount++;
+        return bag.entry.id;
+      }
+    }
+  }
+
+  const json = stringify(value);
   let entry = ctx.islandProps.get(json);
   if (!entry) {
     entry = { id: `mochi-props-${ctx.islandProps.size}`, emitCount: 0 };
     ctx.islandProps.set(json, entry);
   }
   entry.emitCount++;
+
+  if (isPlainBag(value)) {
+    const list = bags ?? [];
+    list.push({ value, entry });
+    emittedBags.set(ctx.islandProps, list);
+  }
   return entry.id;
 }
 

--- a/packages/site/src/routes.ts
+++ b/packages/site/src/routes.ts
@@ -137,19 +137,14 @@ const supportRoute = vanityRedirect(SUPPORT_ORIGIN);
 const mcpRoute = Mochi.api(({ request }) => respondMcp(request));
 
 export const routes: Record<string, MochiRouteValue> = {
-  ...(DEVELOPMENT
+  // Gating on the mode would put these out of reach of their only caller, which profiles the production build.
+  ...(profilerEnabled()
     ? {
         '/_profiler/start': Mochi.api(async () => {
-          if (!profilerEnabled()) {
-            return new Response('Not Found', { status: 404 });
-          }
           await startProfiler();
           return Response.json({ ok: true });
         }),
         '/_profiler/stop': Mochi.api(async () => {
-          if (!profilerEnabled()) {
-            return new Response('Not Found', { status: 404 });
-          }
           const profile = await stopProfiler();
           return Response.json(profile);
         }),

--- a/scripts/flamegraph.ts
+++ b/scripts/flamegraph.ts
@@ -77,21 +77,42 @@ const drainResponse = async (res: Response): Promise<void> => {
   await res.arrayBuffer();
 };
 
-const pipePrefixed = async (src: ReadableStream<Uint8Array>, dst: NodeJS.WriteStream, prefix: string): Promise<void> => {
+const pipePrefixed = async (src: ReadableStream<Uint8Array>, dst: NodeJS.WriteStream, prefix: string, onLine?: (line: string) => void): Promise<void> => {
   const decoder = new TextDecoder();
   let buf = '';
   for await (const chunk of src) {
     buf += decoder.decode(chunk, { stream: true });
     let nl: number;
     while ((nl = buf.indexOf('\n')) !== -1) {
-      dst.write(prefix + buf.slice(0, nl) + '\n');
+      const line = buf.slice(0, nl);
+      dst.write(prefix + line + '\n');
+      onLine?.(line);
       buf = buf.slice(nl + 1);
     }
   }
   if (buf.length > 0) {
     dst.write(prefix + buf + '\n');
+    onLine?.(buf);
   }
 };
+
+// Route warmup keeps rendering other pages after the server starts listening, so profiling before it finishes would
+// charge those renders to the target URL.
+const WARMED_LINE = /WARM.*\bwarmed\b/;
+
+// An SGR escape ends in `m`, a word character, so `\bwarmed` never matches the colourised line.
+// eslint-disable-next-line no-control-regex
+const ANSI = /\u001B\[[0-9;]*m/g;
+const stripAnsi = (line: string): string => line.replace(ANSI, '');
+
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => (resolve = r));
+  return { promise, resolve };
+};
+
+const waitForWarmup = async (warmed: Promise<void>, timeoutMs = 60000): Promise<boolean> =>
+  Promise.race([warmed.then(() => true as const), Bun.sleep(timeoutMs).then(() => false as const)]);
 
 const waitForReady = async (origin: string, timeoutMs = 30000): Promise<void> => {
   const deadline = Date.now() + timeoutMs;
@@ -144,8 +165,14 @@ const main = async (): Promise<void> => {
     stdin: 'ignore',
   });
   const prefix = styleText('gray', '[server] ');
-  void pipePrefixed(proc.stdout as ReadableStream<Uint8Array>, process.stdout, prefix);
-  void pipePrefixed(proc.stderr as ReadableStream<Uint8Array>, process.stderr, prefix);
+  const warmed = deferred();
+  const watchForWarmed = (line: string): void => {
+    if (WARMED_LINE.test(stripAnsi(line))) {
+      warmed.resolve();
+    }
+  };
+  void pipePrefixed(proc.stdout as ReadableStream<Uint8Array>, process.stdout, prefix, watchForWarmed);
+  void pipePrefixed(proc.stderr as ReadableStream<Uint8Array>, process.stderr, prefix, watchForWarmed);
 
   const onExit = async (signal: NodeJS.Signals): Promise<never> => {
     console.log(styleText('yellow', `[flamegraph] received ${signal}, tearing down server`));
@@ -157,7 +184,11 @@ const main = async (): Promise<void> => {
 
   try {
     await waitForReady(altOrigin);
-    console.log(styleText('cyan', `[flamegraph] server ready, warming up (${args.warmup} requests)`));
+    console.log(styleText('cyan', `[flamegraph] server ready, waiting for route warmup to finish`));
+    if (!(await waitForWarmup(warmed.promise))) {
+      console.log(styleText('yellow', `[flamegraph] route warmup did not report completion within 60s — profile may include warmup work`));
+    }
+    console.log(styleText('cyan', `[flamegraph] warming up the target (${args.warmup} requests)`));
 
     for (let i = 0; i < args.warmup; i++) {
       const res = await fetch(targetUrl, { redirect: 'manual' });


### PR DESCRIPTION
`emitIslandProps` dedupes islands by their **serialized** payload, so the duplicate is paid for before it is discovered:

```ts
const json = stringify(value);          // always runs
let entry = ctx.islandProps.get(json);  // dedup happens here
```

On the docs pages of `packages/site` that is the single largest cost in the request. `PageShell` hands `MobileNav mochi:hydrate` and `Sidebar mochi:hydrate` the same `{docsNav, demos, currentSlug}` — ~404 nav entries plus 64 demos — and the preprocessor emits a fresh object literal per call site:

```js
emitIslandProps({ docsNav, demos: navDemos, currentSlug })   // MobileNav
emitIslandProps({ docsNav, demos: navDemos, currentSlug })   // Sidebar
```

Both serialize to the same 50.9 KB, one `<script>` block is emitted `data-shared`, and the second `stringify` is thrown away. Measured on that payload: **1.098 ms per call, 40.7× `JSON.stringify`**.

## The fix

Each registry entry carries the props bags that serialized to it, so a new bag can be matched by identity before devalue is ever called. A `WeakMap` on the bag itself would be useless — it is a new object per call site — but the values inside are the same references, so `Object.is` over the own keys settles it without touching the payload.

Keeping the bags **on the entry** means their lifetime is the entry's: clearing `ctx.islandProps` between renders drops them, with no second structure to invalidate and nothing to pin across duplicate bundled copies of the framework.

`Object.is` is what makes the substitution safe — it separates `0` from `-0`, which devalue round-trips apart, and treats `NaN` as equal to itself. `isPlainBag` keeps the shortcut away from anything devalue would reject, so a class instance or a symbol-keyed bag still reaches devalue and still throws rather than silently borrowing another island's ref id.

A page has a handful of islands, so the scan is linear over nothing. On a miss, control falls through to exactly the code that runs today; `emitCount` and `data-shared` semantics are unchanged.

## Measured

Production build of `packages/site`, `ab -k -n 500 -c 1`, steady state (route warmup complete, then 600 JIT warmup requests). Three interleaved rounds of `main` → this branch, rebuilding between each and asserting which variant is live before every run. Medians of 3:

| doc page | `main` | this branch | delta | change |
| --- | ---: | ---: | ---: | ---: |
| `/docs/intro/` | 4.246 ms | 3.072 ms | 1.174 ms | **-28%** |
| `/docs/events/` | 4.467 ms | 3.460 ms | 1.007 ms | **-23%** |
| `/docs/coming-from-sveltekit/` | 6.166 ms | 4.607 ms | 1.559 ms | **-25%** |

The arms do not overlap on any page. The saving sits at roughly the 1.098 ms that one `devalue.stringify` of that nav payload costs, across pages spanning 141–368 KB of HTML — one serialization removed, nothing else. An earlier interleaved run on the same machine gave 27% / 25% / 19%.

A CPU profile of `/docs/intro/` (2000 sampled requests) agrees: devalue's share of SSR drops from **2.62 ms/req (61%)** to **1.74 ms/req (44%)**, with `get_escaped_char` going 1.833 → 1.139 ms/req.

The win scales with payload size × repeated call sites, so it is not specific to this site: any app handing the same object to two islands pays this today.

## Caveat

Props answered from the fast path are assumed not to be mutated *between* two call sites inside one `render()`. A render that did that would get one shared block where it wanted two. Within a single synchronous SSR pass that is pathological, but it is a behaviour change rather than a pure optimisation, and it is called out in the JSDoc.

## Verification

- `bun run checks` passes across all workspaces.
- New tests in `islandPropsRegistry.test.ts`: shared references dedupe without a second walk of the payload (proved with a nested getter — only devalue recurses); same references with a different primitive stay distinct; equal-but-distinct references still dedupe through the serializing path; `0` and `-0` do not collide; non-plain and symbol-keyed bags decline the fast path and let devalue's own errors stand; two requests keep independent registries.
- Browser (`chrome-devtools`) on `/docs/intro/`: all 7 islands hydrate, no console errors, `MobileNav` and `Sidebar` both reference one `data-shared` `mochi-props-0` block of 50 941 bytes.

## Second commit: the profiler routes could not run

`bun run flamegraph` has been dead since `4fbb17c6`. `scripts/flamegraph.ts` deletes `NODE_ENV` to reach the production path, but `/_profiler/*` was registered inside a `DEVELOPMENT ? …` spread — so in the only mode the script uses, the routes did not exist and it died on `/_profiler/start returned 404`. They now gate on `profilerEnabled()` (`MOCHI_PROFILER=1`), mirroring the `HEAP_SNAPSHOTS_ENABLED` block below them; `MOCHI_PROFILER` is set nowhere but that script.

The harness also started profiling before route warmup finished, so a profile included ~70 background renders of other pages. It now waits for the `WARM … warmed` line.

None of the numbers above were obtainable before these two fixes.
