### PR TITLE
fix(compiler): attribute shared side-effect CSS imports to every page that imports them

### DIFF
--- a/packages/mochi/src/__fixtures__/shared-css/Admin.svelte
+++ b/packages/mochi/src/__fixtures__/shared-css/Admin.svelte
@@ -1,0 +1,6 @@
+<script>
+  import './styles/beta.css';
+  import './styles/theme.css';
+</script>
+
+<h1>shared-css admin</h1>

--- a/packages/mochi/src/__fixtures__/shared-css/ErrorAll.svelte
+++ b/packages/mochi/src/__fixtures__/shared-css/ErrorAll.svelte
@@ -1,0 +1,7 @@
+<script>
+  import './styles/alpha.css';
+  import './styles/beta.css';
+  import './styles/theme.css';
+</script>
+
+<h1>shared-css error (all shared)</h1>

--- a/packages/mochi/src/__fixtures__/shared-css/ErrorOwnCss.svelte
+++ b/packages/mochi/src/__fixtures__/shared-css/ErrorOwnCss.svelte
@@ -1,0 +1,5 @@
+<script>
+  import './styles/error-only.css';
+</script>
+
+<h1>shared-css error (own css)</h1>

--- a/packages/mochi/src/__fixtures__/shared-css/ErrorShared.svelte
+++ b/packages/mochi/src/__fixtures__/shared-css/ErrorShared.svelte
@@ -1,0 +1,5 @@
+<script>
+  import './styles/theme.css';
+</script>
+
+<h1>shared-css error (shared theme)</h1>

--- a/packages/mochi/src/__fixtures__/shared-css/Home.svelte
+++ b/packages/mochi/src/__fixtures__/shared-css/Home.svelte
@@ -1,0 +1,7 @@
+<script>
+  import './styles/alpha.css';
+  import './styles/beta.css';
+  import './styles/theme.css';
+</script>
+
+<h1>shared-css home</h1>

--- a/packages/mochi/src/__fixtures__/shared-css/styles/alpha.css
+++ b/packages/mochi/src/__fixtures__/shared-css/styles/alpha.css
@@ -1,0 +1,3 @@
+.shared-css-alpha {
+  color: rebeccapurple;
+}

--- a/packages/mochi/src/__fixtures__/shared-css/styles/beta.css
+++ b/packages/mochi/src/__fixtures__/shared-css/styles/beta.css
@@ -1,0 +1,3 @@
+.shared-css-beta {
+  color: teal;
+}

--- a/packages/mochi/src/__fixtures__/shared-css/styles/error-only.css
+++ b/packages/mochi/src/__fixtures__/shared-css/styles/error-only.css
@@ -1,0 +1,3 @@
+.shared-css-error-only {
+  color: crimson;
+}

--- a/packages/mochi/src/__fixtures__/shared-css/styles/theme.css
+++ b/packages/mochi/src/__fixtures__/shared-css/styles/theme.css
@@ -1,0 +1,3 @@
+.shared-css-theme {
+  color: goldenrod;
+}

--- a/packages/mochi/src/compiler/ComponentRegistry.ts
+++ b/packages/mochi/src/compiler/ComponentRegistry.ts
@@ -935,14 +935,15 @@ export class ComponentRegistry {
     }
 
     // Attribution walks Bun's output graph: `outputs[outKey].inputs` is a flat record of every source file that fed that
-    // chunk, keyed in the same shape as `inputs[]` and so stable to compare against `cssMap` / `importedCssPaths`. The
-    // source-import walk via `inputs[].imports[].path` is unusable, since Bun stores those importer-relative and
-    // `path.resolve` against cwd fabricates absolutes that miss `inputs[]`, killing the BFS one hop in.
+    // chunk, keyed in the same shape as `inputs[]` and so stable to compare against `cssMap`.
     const outputsMeta = result.metafile?.outputs ?? {};
+    const inputsMeta = result.metafile?.inputs ?? {};
     const entryToOutKey = new Map<string, string>();
+    const entryToInputKey = new Map<string, string>();
     for (const [outKey, outMeta] of Object.entries(outputsMeta)) {
       if (outMeta.entryPoint) {
         entryToOutKey.set(path.resolve(outMeta.entryPoint), outKey);
+        entryToInputKey.set(path.resolve(outMeta.entryPoint), outMeta.entryPoint);
       }
     }
 
@@ -970,6 +971,36 @@ export class ComponentRegistry {
       return inputs;
     };
 
+    // Side-effect CSS gets stripped to an empty module, and an empty module shared by two entrypoints is hoisted by
+    // `splitting` into a chunk nothing emits an import statement for — so the output walk above reaches neither the
+    // chunk nor the stylesheet, and it ends up attributed to no page at all. The pre-chunking input graph still records
+    // the import edge, so CSS is walked there instead. Unbundled specifiers (`svelte`, `node:fs`) appear as edges with
+    // no `inputs[]` entry of their own, which is why this compares raw metafile keys rather than resolving every hop.
+    const transitiveSourceInputs = (rootInputKey: string): Set<string> => {
+      const visited = new Set<string>();
+      const queue = [rootInputKey];
+      while (queue.length > 0) {
+        const key = queue.shift()!;
+        const meta = inputsMeta[key];
+        if (visited.has(key) || !meta) {
+          continue;
+        }
+        visited.add(key);
+        for (const imp of meta.imports) {
+          queue.push(imp.path);
+        }
+      }
+      return visited;
+    };
+
+    // The CSS plugin records absolute paths while metafile keys are cwd-relative, so bridge the two once per build.
+    const cssInputKeyByPath = new Map<string, string>();
+    for (const key of Object.keys(inputsMeta)) {
+      if (key.endsWith('.css')) {
+        cssInputKeyByPath.set(path.resolve(key), key);
+      }
+    }
+
     const compileDuration = performance.now() - compileStart;
     for (const filename of todo) {
       const outKey = entryToOutKey.get(filename);
@@ -988,12 +1019,13 @@ export class ComponentRegistry {
 
       const entryInputs = transitiveInputs(outKey);
 
-      // Side-effect CSS imports reachable from this entry. The plugin records
-      // every `.css` load globally; intersect with the entry's transitive
-      // input set to get the per-entry subset.
+      // Side-effect CSS imports reachable from this entry. The plugin records every `.css` load globally, so the
+      // per-entry subset comes from the source-import walk.
+      const entrySourceInputs = transitiveSourceInputs(entryToInputKey.get(filename)!);
       const entryCss = new Set<string>();
       for (const p of importedCssPaths) {
-        if (entryInputs.has(path.resolve(p))) {
+        const cssKey = cssInputKeyByPath.get(path.resolve(p));
+        if (cssKey && entrySourceInputs.has(cssKey)) {
           entryCss.add(p);
         }
       }
@@ -1038,6 +1070,17 @@ export class ComponentRegistry {
         serverIslandCount: entryServerIslands.length,
         durationMs: compileDuration,
       });
+    }
+
+    // The build's entrypoints are exactly `todo`, so every stylesheet the plugin loaded must belong to at least one of
+    // them; one that belongs to none is bundled and served but linked by nothing, which only shows up as an unstyled page.
+    const unattributedCss = [...importedCssPaths].filter((p) => !todo.some((f) => this.entryImportedCss.get(f)?.has(p)));
+    if (unattributedCss.length > 0) {
+      logger.warn(
+        `${unattributedCss.length} imported stylesheet(s) could not be attributed to any page, so nothing will link them:\n` +
+          unattributedCss.map((p) => `  - ${relForDisplay(p)}`).join('\n') +
+          `\nThis is a Mochi bug — please report it with a reproduction.`,
+      );
     }
 
     mochiEvents.emit('compile:batch-complete', {

--- a/packages/mochi/src/compiler/sharedCssImports.test.ts
+++ b/packages/mochi/src/compiler/sharedCssImports.test.ts
@@ -1,0 +1,158 @@
+// A side-effect `.css` import is stripped to an empty module, and `splitting` hoists an empty module shared by two
+// entrypoints into a chunk that emits no import statement — so attributing CSS through the *output* graph silently lost
+// every stylesheet more than one page imported, and every page that imported it rendered unstyled with no warning.
+// Adding an `errorPage` that shares a stylesheet with the routes is how this first surfaced, so the error page compiles
+// in the same cohort here, exactly as `Mochi.serve()` does it.
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { ComponentRegistry } from './ComponentRegistry';
+import { requestContext } from '../runtime/requestContext';
+import { MochiCookieJar } from '../runtime/cookies';
+
+const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'shared-css');
+const HOME = path.join(FIXTURE_DIR, 'Home.svelte');
+const ADMIN = path.join(FIXTURE_DIR, 'Admin.svelte');
+
+const ALPHA = path.join(FIXTURE_DIR, 'styles', 'alpha.css');
+const BETA = path.join(FIXTURE_DIR, 'styles', 'beta.css');
+const THEME = path.join(FIXTURE_DIR, 'styles', 'theme.css');
+const ERROR_ONLY = path.join(FIXTURE_DIR, 'styles', 'error-only.css');
+
+const outDirs: string[] = [];
+
+type LinksFor = (entry: string) => Promise<string[]>;
+
+/** Compiles one cohort the way `Mochi.serve()` does — error page first, then the routes. */
+async function compileCohort(label: string, errorPage: string | null): Promise<LinksFor> {
+  const outDir = mkdtempSync(path.join(import.meta.dir, '..', '..', `.mochi-shared-css-${label}-`));
+  outDirs.push(outDir);
+  const registry = new ComponentRegistry({ development: true, outDir });
+  await registry.compileAll([...(errorPage ? [errorPage] : []), HOME, ADMIN]);
+
+  // The rendered `cssUrls` is what the shell turns into `<link rel="stylesheet">`, so assert on it rather than on the
+  // internal map — the bug was invisible in `importedCssUrls`, which stayed complete throughout.
+  return async (entry: string) => {
+    const ctx = {
+      requestId: 'test',
+      request: new Request('http://localhost/'),
+      url: new URL('http://localhost/'),
+      params: {},
+      locals: {},
+      isWarmup: false,
+      cookies: new MochiCookieJar(null),
+      islandProps: new Map(),
+      getClientAddress: () => null,
+    };
+    const result = await requestContext.run(ctx, () => registry.renderComponent(entry));
+    return result.cssUrls.filter((u) => u.includes('/import-css/'));
+  };
+}
+
+/** `import-css` URLs are content-hashed, so match on the stylesheet's basename stem instead. */
+function linksTo(urls: string[], cssPath: string): boolean {
+  const stem = path.basename(cssPath, '.css');
+  return urls.some((u) => path.basename(u).startsWith(`${stem}-`));
+}
+
+afterAll(() => {
+  for (const dir of outDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe('shared side-effect CSS imports — no error page', () => {
+  let linksFor: LinksFor;
+
+  beforeAll(async () => {
+    linksFor = await compileCohort('none', null);
+  });
+
+  test('every page links every stylesheet it imports, shared or not', async () => {
+    const home = await linksFor(HOME);
+    expect(linksTo(home, ALPHA)).toBe(true);
+    expect(linksTo(home, BETA)).toBe(true);
+    expect(linksTo(home, THEME)).toBe(true);
+
+    const admin = await linksFor(ADMIN);
+    expect(linksTo(admin, BETA)).toBe(true);
+    expect(linksTo(admin, THEME)).toBe(true);
+    expect(linksTo(admin, ALPHA)).toBe(false);
+  });
+});
+
+describe('shared side-effect CSS imports — error page with its own stylesheet', () => {
+  const ERROR_PAGE = path.join(FIXTURE_DIR, 'ErrorOwnCss.svelte');
+  let linksFor: LinksFor;
+
+  beforeAll(async () => {
+    linksFor = await compileCohort('own', ERROR_PAGE);
+  });
+
+  test('the error page links only its own stylesheet', async () => {
+    const error = await linksFor(ERROR_PAGE);
+    expect(linksTo(error, ERROR_ONLY)).toBe(true);
+    expect(linksTo(error, THEME)).toBe(false);
+  });
+
+  test('the routes keep their own stylesheets', async () => {
+    const home = await linksFor(HOME);
+    expect(linksTo(home, ALPHA)).toBe(true);
+    expect(linksTo(home, BETA)).toBe(true);
+    expect(linksTo(home, THEME)).toBe(true);
+    expect(linksTo(home, ERROR_ONLY)).toBe(false);
+  });
+});
+
+describe('shared side-effect CSS imports — error page shares one stylesheet with the routes', () => {
+  const ERROR_PAGE = path.join(FIXTURE_DIR, 'ErrorShared.svelte');
+  let linksFor: LinksFor;
+
+  beforeAll(async () => {
+    linksFor = await compileCohort('shared', ERROR_PAGE);
+  });
+
+  test('the error page links the shared stylesheet', async () => {
+    expect(linksTo(await linksFor(ERROR_PAGE), THEME)).toBe(true);
+  });
+
+  test('the routes still link the stylesheet the error page shares', async () => {
+    const home = await linksFor(HOME);
+    expect(linksTo(home, THEME)).toBe(true);
+    expect(linksTo(home, ALPHA)).toBe(true);
+    expect(linksTo(home, BETA)).toBe(true);
+
+    const admin = await linksFor(ADMIN);
+    expect(linksTo(admin, THEME)).toBe(true);
+    expect(linksTo(admin, BETA)).toBe(true);
+  });
+});
+
+describe('shared side-effect CSS imports — error page shares every stylesheet', () => {
+  const ERROR_PAGE = path.join(FIXTURE_DIR, 'ErrorAll.svelte');
+  let linksFor: LinksFor;
+
+  beforeAll(async () => {
+    linksFor = await compileCohort('all', ERROR_PAGE);
+  });
+
+  test('the error page links all three', async () => {
+    const error = await linksFor(ERROR_PAGE);
+    expect(linksTo(error, ALPHA)).toBe(true);
+    expect(linksTo(error, BETA)).toBe(true);
+    expect(linksTo(error, THEME)).toBe(true);
+  });
+
+  // The worst shape of the bug: `Admin.svelte` imports nothing the error page doesn't, and was emptied completely.
+  test('the routes are unaffected by what the error page imports', async () => {
+    const home = await linksFor(HOME);
+    expect(linksTo(home, ALPHA)).toBe(true);
+    expect(linksTo(home, BETA)).toBe(true);
+    expect(linksTo(home, THEME)).toBe(true);
+
+    const admin = await linksFor(ADMIN);
+    expect(linksTo(admin, BETA)).toBe(true);
+    expect(linksTo(admin, THEME)).toBe(true);
+    expect(linksTo(admin, ALPHA)).toBe(false);
+  });
+});

--- a/packages/mochi/src/compiler/sharedCssImportsBuild.test.ts
+++ b/packages/mochi/src/compiler/sharedCssImportsBuild.test.ts
@@ -1,0 +1,111 @@
+// The production half of `sharedCssImports.test.ts`: `mochi-framework build` batches the error page and every route
+// into the same `Bun.build`, so a stylesheet two of them import was hoisted into a chunk the output graph could not
+// reach and landed in no entry's `entryImportedCss` — a prebuilt deploy then served every one of those pages unstyled.
+//
+// process.chdir() is safe here because every test file runs in its own process (scripts/run-tests.ts).
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { cpSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import type { Server } from 'bun';
+import { build } from '../cli/build';
+import { Mochi } from '../Mochi';
+import { encodeSourcePath } from './manifestPaths';
+import type { MochiManifest } from '../types';
+
+const FIXTURE_DIR = path.join(import.meta.dir, '..', '__fixtures__', 'shared-css');
+const RM_OPTS = { recursive: true, force: true, maxRetries: 5, retryDelay: 100 } as const;
+
+const routes = { '/': Mochi.page('app/Home.svelte'), '/admin': Mochi.page('app/Admin.svelte') };
+
+let root: string;
+let server: Server<undefined> | undefined;
+const originalCwd = process.cwd();
+
+/** One production build per error-page shape, each into its own out-dir so the manifests can be compared side by side. */
+async function buildWith(outDir: string, errorPage: string): Promise<MochiManifest> {
+  await build({ routes, errorPage: `app/${errorPage}`, development: false, outDir });
+  return JSON.parse(await Bun.file(path.join(root, outDir, 'manifest.json')).text());
+}
+
+/** Stylesheets the manifest says this entry links, reduced to bare basenames. */
+function importedCss(manifest: MochiManifest, entry: string): string[] {
+  return (manifest.entryImportedCss?.[encodeSourcePath(path.join(root, 'app', entry))] ?? []).map((p) => path.basename(p)).sort();
+}
+
+describe('shared side-effect CSS imports survive a production build', () => {
+  let ownCss: MochiManifest;
+  let shared: MochiManifest;
+  let all: MochiManifest;
+
+  beforeAll(async () => {
+    // Inside the package: the build dynamically imports the SSR modules it emits, and those resolve node_modules from
+    // the out-dir.
+    root = mkdtempSync(path.join(import.meta.dir, '..', '..', '.mochi-shared-css-build-'));
+    cpSync(FIXTURE_DIR, path.join(root, 'app'), { recursive: true });
+    // Present only to keep the build's "no Svelte config" notice out of the output.
+    writeFileSync(path.join(root, 'svelte.config.js'), 'export default {};\n');
+    process.chdir(root);
+
+    ownCss = await buildWith('out-own', 'ErrorOwnCss.svelte');
+    shared = await buildWith('out-shared', 'ErrorShared.svelte');
+    all = await buildWith('out-all', 'ErrorAll.svelte');
+
+    server = await Mochi.serve({
+      port: 0,
+      development: false,
+      warmup: false,
+      logger: { enabled: false },
+      outDir: path.join(root, 'out-all'),
+      routes,
+      errorPage: 'app/ErrorAll.svelte',
+    });
+  });
+
+  afterAll(() => {
+    server?.stop(true);
+    process.chdir(originalCwd);
+    rmSync(root, RM_OPTS);
+  });
+
+  test('an error page with its own stylesheet leaves the routes alone', () => {
+    expect(importedCss(ownCss, 'ErrorOwnCss.svelte')).toEqual(['error-only.css']);
+    expect(importedCss(ownCss, 'Home.svelte')).toEqual(['alpha.css', 'beta.css', 'theme.css']);
+    expect(importedCss(ownCss, 'Admin.svelte')).toEqual(['beta.css', 'theme.css']);
+  });
+
+  test('a stylesheet the error page shares with the routes stays on all three', () => {
+    expect(importedCss(shared, 'ErrorShared.svelte')).toEqual(['theme.css']);
+    expect(importedCss(shared, 'Home.svelte')).toEqual(['alpha.css', 'beta.css', 'theme.css']);
+    expect(importedCss(shared, 'Admin.svelte')).toEqual(['beta.css', 'theme.css']);
+  });
+
+  test('an error page sharing every stylesheet still leaves each route with its own', () => {
+    expect(importedCss(all, 'ErrorAll.svelte')).toEqual(['alpha.css', 'beta.css', 'theme.css']);
+    expect(importedCss(all, 'Home.svelte')).toEqual(['alpha.css', 'beta.css', 'theme.css']);
+    expect(importedCss(all, 'Admin.svelte')).toEqual(['beta.css', 'theme.css']);
+  });
+
+  test('the served pages carry the <link> tags', async () => {
+    const linked = async (url: string) => {
+      const res = await fetch(new URL(url, server!.url));
+      const html = await res.text();
+      return [...html.matchAll(/<link rel="stylesheet" href="([^"]+import-css[^"]+)"/g)].map((m) => path.basename(m[1]!));
+    };
+
+    const home = await linked('/');
+    expect(home.some((f) => f.startsWith('alpha-'))).toBe(true);
+    expect(home.some((f) => f.startsWith('beta-'))).toBe(true);
+    expect(home.some((f) => f.startsWith('theme-'))).toBe(true);
+
+    const admin = await linked('/admin');
+    expect(admin.some((f) => f.startsWith('beta-'))).toBe(true);
+    expect(admin.some((f) => f.startsWith('theme-'))).toBe(true);
+    expect(admin.some((f) => f.startsWith('alpha-'))).toBe(false);
+
+    // The error page renders through the same shell, and was the entry that went missing from `entryImportedCss` entirely.
+    const notFound = await linked('/nope');
+    expect(notFound.some((f) => f.startsWith('alpha-'))).toBe(true);
+    expect(notFound.some((f) => f.startsWith('beta-'))).toBe(true);
+    expect(notFound.some((f) => f.startsWith('theme-'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Problem

A `.css` file imported for its side effects by more than one page ended up linked by **no** page.

Attribution walked Bun's *output* graph (`outputs[].inputs`). Side-effect CSS is stripped to an empty module, and an empty module shared by two entrypoints gets hoisted by `splitting` into a chunk that nothing emits an import statement for. The walk therefore reached neither the chunk nor the stylesheet, and the CSS was attributed to zero pages — bundled and served, but never linked. The visible symptom was an unstyled page (most obviously the error page, which typically shares a theme stylesheet with the rest of the site).

## Fix

Walk the pre-chunking **input** graph (`metafile.inputs[].imports[]`) for CSS attribution instead. That graph still records the import edge before chunking erases it. The output-graph walk stays in place for everything else it's used for.

Two details:

- Unbundled specifiers (`svelte`, `node:fs`) show up as import edges with no `inputs[]` entry of their own, so the BFS compares raw metafile keys rather than resolving every hop.
- The CSS plugin records absolute paths while metafile keys are cwd-relative; a single `cssInputKeyByPath` map bridges the two once per build.

## Guardrail

The build's entrypoints are exactly the set being compiled, so every stylesheet the plugin loaded must belong to at least one of them. Any stylesheet attributed to none now logs a warning naming the files and asking for a bug report — this class of failure is otherwise silent until someone notices a page rendering unstyled.

## Tests

New fixtures under `packages/mochi/src/__fixtures__/shared-css/` plus two suites:

- `sharedCssImports.test.ts` — attribution across pages sharing a stylesheet, pages with their own CSS, and an error page that shares one.
- `sharedCssImportsBuild.test.ts` — the same through a real `build()`, asserting the emitted links.
