### PR TITLE
fix(dev): keep route HMR alive when the entry build fails

### DIFF
--- a/packages/mochi/src/dev/devWatcher.test.ts
+++ b/packages/mochi/src/dev/devWatcher.test.ts
@@ -27,6 +27,13 @@ describe('isServerEntryDep', () => {
     const abs = path.resolve('helper.ts');
     expect(isServerEntryDep('helper.ts', new Set([abs]))).toBe(true);
   });
+
+  // The regression this guards: only a successful build populates the dep set, so a failed one used to send every
+  // later entry edit down the plain-recompile path — route HMR stayed dead for the rest of the dev session.
+  test('with no successful entry build yet, any non-.svelte change retries it', () => {
+    expect(isServerEntryDep('src/index.ts', new Set(), false)).toBe(true);
+    expect(isServerEntryDep('src/App.svelte', new Set(), false)).toBe(false);
+  });
 });
 
 describe('reachedModuleChurnThreshold', () => {

--- a/packages/mochi/src/dev/devWatcher.ts
+++ b/packages/mochi/src/dev/devWatcher.ts
@@ -70,9 +70,11 @@ function publicChangeVerb(event: string): string {
 /**
  * Whether a changed file belongs to the server-entry bundle graph, so its change must rebuild the entry (route wiring).
  * A `.svelte` file is never routed here — it recompiles on the page path — even if it is also an entry input.
+ * Until a build has succeeded the graph is unknown, so every other change retries it: the dep set is only ever
+ * populated by a successful build, and without the retry one failed build would strand route HMR for the session.
  */
-export function isServerEntryDep(filePath: string, serverEntryDeps: Set<string>): boolean {
-  return !filePath.endsWith('.svelte') && serverEntryDeps.has(path.resolve(filePath));
+export function isServerEntryDep(filePath: string, serverEntryDeps: Set<string>, entryGraphKnown = true): boolean {
+  return !filePath.endsWith('.svelte') && (!entryGraphKnown || serverEntryDeps.has(path.resolve(filePath)));
 }
 
 // Each entry reload re-evaluates the whole first-party module graph, so a module-scoped resource (a DB pool, a timer,
@@ -300,6 +302,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
   // Building the entry module discovers its transitive deps, so a dep change can rebuild, re-extract routes via
   // `extractServeOptions`, and hot-swap handlers in place for the running server.
   let serverEntryDeps: Set<string> = new Set();
+  let entryGraphKnown = false;
   const entryBuildOutDir = path.resolve(`${outDir}/entry-hmr`);
 
   let entryReloadCount = 0;
@@ -311,7 +314,9 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       packages: 'external',
       target: 'bun',
       outdir: entryBuildOutDir,
-      naming: { entry: 'entry.js' },
+      // `[ext]` and not a literal `.js`: an entry graph that also imports CSS emits a second output under this same
+      // template, and without the extension both land on `entry.js` and the whole build fails on the collision.
+      naming: { entry: 'entry.[ext]' },
       metafile: true,
       throw: false,
     });
@@ -329,6 +334,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
       }
     }
     serverEntryDeps = newDeps;
+    entryGraphKnown = true;
     const outFile = path.resolve(entryBuildOutDir, 'entry.js');
     const serveOptions = await extractServeOptions(outFile, { fresh: true });
     if (!serveOptions?.routes) {
@@ -734,7 +740,7 @@ export function startDevWatcher(deps: DevWatcherDeps): Promise<void> {
         reloadPublic();
       } else if (filePath.endsWith('.css')) {
         triggerCssReload(filePath);
-      } else if (isServerEntryDep(filePath, serverEntryDeps)) {
+      } else if (isServerEntryDep(filePath, serverEntryDeps, entryGraphKnown)) {
         // triggerEntryReload rebuilds the entry AND recompiles any page whose SSR bundle inlines this module, so the
         // exclusive branch is correct: one serialized task, one reload.
         triggerEntryReload(filePath);

--- a/packages/mochi/src/devRouteHmr.test.ts
+++ b/packages/mochi/src/devRouteHmr.test.ts
@@ -105,9 +105,20 @@ describe('route HMR during a dev session', () => {
     ).toBe(200);
   }, 90_000);
 
-  afterAll(() => {
+  afterAll(async () => {
     proc?.kill();
-    rmSync(appDir, { recursive: true, force: true });
+    // kill() only signals — the dev server still holds handles on its outDir until it actually exits, and Windows
+    // refuses to remove a directory that anything has open. Same best-effort retry as the queue suites: never fail
+    // the run over an ephemeral temp dir. (Bun ignores rmSync's maxRetries option, so retry by hand.)
+    await proc?.exited;
+    for (let attempt = 0; attempt < 25; attempt++) {
+      try {
+        rmSync(appDir, { recursive: true, force: true });
+        return;
+      } catch {
+        await Bun.sleep(100);
+      }
+    }
   });
 
   test('a brand-new route pattern starts serving without a restart', async () => {

--- a/packages/mochi/src/devRouteHmr.test.ts
+++ b/packages/mochi/src/devRouteHmr.test.ts
@@ -1,0 +1,174 @@
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
+import { mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import type { Subprocess } from 'bun';
+
+// A child process, not an in-process Mochi.serve(): the dev watcher reads its entry from `Bun.main`, so route HMR can
+// only be exercised by an app the test actually launches from its own entry file.
+describe('route HMR during a dev session', () => {
+  let appDir: string;
+  let entryFile: string;
+  let proc: Subprocess<'ignore', 'pipe', 'pipe'>;
+  let base: string;
+  let output = '';
+
+  const ROUTES_MARKER = '    // ROUTES';
+
+  const entrySource = (routes: string[]): string =>
+    `import { Mochi } from 'mochi-framework';\n` +
+    // The regression this guards: the entry-HMR build emitted its JS and its CSS under one extension-less naming
+    // template, so any CSS in the entry graph collided and failed the whole build.
+    `import './app.css';\n` +
+    `\n` +
+    `const server = await Mochi.serve({\n` +
+    `  port: 0,\n` +
+    `  development: true,\n` +
+    `  logger: { enabled: false },\n` +
+    `  outDir: '.mochi-out',\n` +
+    `  trailingSlash: 'always',\n` +
+    `  routes: {\n` +
+    `    '/': Mochi.page('./src/Page.svelte', { serverProps: () => ({ label: 'home' }) }),\n` +
+    routes.map((r) => `    ${r}\n`).join('') +
+    `${ROUTES_MARKER}\n` +
+    `  },\n` +
+    `});\n` +
+    `console.log('MOCHI_TEST_PORT=' + server.port);\n`;
+
+  const writeEntry = (routes: string[]) => Bun.write(entryFile, entrySource(routes));
+
+  const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+  async function waitFor<T>(probe: () => Promise<T>, done: (value: T) => boolean, timeoutMs = 30_000): Promise<T> {
+    const deadline = Date.now() + timeoutMs;
+    let last = await probe();
+    while (!done(last) && Date.now() < deadline) {
+      await sleep(100);
+      last = await probe();
+    }
+    return last;
+  }
+
+  const status = async (p: string): Promise<number> => {
+    try {
+      return (await fetch(base + p, { redirect: 'manual' })).status;
+    } catch {
+      return 0;
+    }
+  };
+
+  const body = async (p: string): Promise<string> => {
+    try {
+      return await (await fetch(base + p)).text();
+    } catch {
+      return '';
+    }
+  };
+
+  beforeAll(async () => {
+    appDir = mkdtempSync(path.join(import.meta.dir, '..', '.mochi-dev-route-hmr-'));
+    mkdirSync(path.join(appDir, 'src'));
+    entryFile = path.join(appDir, 'src', 'index.ts');
+    await Bun.write(path.join(appDir, 'src', 'app.css'), 'body { margin: 0; }\n');
+    await Bun.write(path.join(appDir, 'src', 'Page.svelte'), `<script lang="ts">\n  let { label = '' } = $props();\n<` + `/script>\n\n<h1>page:{label}</h1>\n`);
+    await writeEntry([`'/doomed': Mochi.page('./src/Page.svelte', { serverProps: () => ({ label: 'doomed' }) }),`]);
+
+    proc = Bun.spawn([process.execPath, 'src/index.ts'], {
+      cwd: appDir,
+      env: { ...process.env, NODE_ENV: 'development' },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    void (async () => {
+      for await (const chunk of proc.stdout) {
+        output += new TextDecoder().decode(chunk);
+      }
+    })();
+    void (async () => {
+      for await (const chunk of proc.stderr) {
+        output += new TextDecoder().decode(chunk);
+      }
+    })();
+
+    const port = await waitFor(
+      async () => output.match(/MOCHI_TEST_PORT=(\d+)/)?.[1],
+      (p) => p !== undefined,
+      60_000,
+    );
+    expect(port, `dev server never reported a port:\n${output}`).toBeDefined();
+    base = `http://localhost:${port}`;
+    expect(
+      await waitFor(
+        () => status('/'),
+        (s) => s === 200,
+        30_000,
+      ),
+    ).toBe(200);
+  }, 90_000);
+
+  afterAll(() => {
+    proc?.kill();
+    rmSync(appDir, { recursive: true, force: true });
+  });
+
+  test('a brand-new route pattern starts serving without a restart', async () => {
+    expect(await status('/added/')).toBe(404);
+
+    await Bun.write(path.join(appDir, 'src', 'Added.svelte'), `<h1>added</h1>\n`);
+    const src = await Bun.file(entryFile).text();
+    await Bun.write(entryFile, src.replace(ROUTES_MARKER, `    '/added': Mochi.page('./src/Added.svelte'),\n${ROUTES_MARKER}`));
+
+    expect(
+      await waitFor(
+        () => status('/added/'),
+        (s) => s === 200,
+      ),
+    ).toBe(200);
+    expect(await body('/added/')).toContain('added');
+  }, 60_000);
+
+  test('a new api route registers too, and the trailing-slash mirror follows the route kind', async () => {
+    const src = await Bun.file(entryFile).text();
+    await Bun.write(entryFile, src.replace(ROUTES_MARKER, `    '/ping': Mochi.api(() => Response.json({ pong: true })),\n${ROUTES_MARKER}`));
+
+    expect(
+      await waitFor(
+        () => status('/ping'),
+        (s) => s === 200,
+      ),
+    ).toBe(200);
+    // Only page routes mirror the alternate slash form.
+    expect(await status('/ping/')).toBe(404);
+  }, 60_000);
+
+  test('editing an existing route handler swaps it in place', async () => {
+    const src = await Bun.file(entryFile).text();
+    await Bun.write(entryFile, src.replace(`label: 'home'`, `label: 'home-edited'`));
+
+    expect(
+      await waitFor(
+        () => body('/'),
+        (b) => b.includes('home-edited'),
+      ),
+    ).toContain('home-edited');
+  }, 60_000);
+
+  test('a removed route pattern stops matching', async () => {
+    expect(await status('/doomed/')).toBe(200);
+
+    const src = await Bun.file(entryFile).text();
+    await Bun.write(
+      entryFile,
+      src
+        .split('\n')
+        .filter((line) => !line.includes(`'/doomed'`))
+        .join('\n'),
+    );
+
+    expect(
+      await waitFor(
+        () => status('/doomed/'),
+        (s) => s === 404,
+      ),
+    ).toBe(404);
+  }, 60_000);
+});


### PR DESCRIPTION
## Symptom

Reported against `mochi-framework` 0.9.1, reproduced unchanged on `main`.

With a dev server running (`development: true`), adding brand-new route patterns to the `routes` object in the app entry has no effect — every new path 404s indefinitely until the process is restarted. Editing an existing route's `serverProps` is equally inert. Meanwhile pre-existing routes keep serving and `.svelte` edits hot-reload normally the whole time, so the dev server looks healthy.

## Root cause

Two defects compound.

**1. The entry-HMR build collides with itself.** `buildEntry()` bundles the app entry with `naming: { entry: 'entry.js' }`. That template has no extension placeholder, so an entry graph that also pulls in CSS (`import './app.css'`, a library stylesheet, anything reaching a `.css` file from the server entry) emits its JS chunk *and* its CSS bundle to the same `entry.js` path. Bun rejects the whole build:

```
Entry rebuild failed:
  ./entry.js:
entry naming is './entry.js', consider adding '[hash]' to make filenames unique
```

**2. A failed build strands route HMR permanently.** `serverEntryDeps` is only ever assigned by a *successful* build, and `buildEntry()` is reachable only from `triggerEntryReload`, which the watcher dispatches to via `isServerEntryDep()`. When the build fails at boot the dep set stays empty, so every subsequent `src/index.ts` (or `src/routes.ts`) save fails that check and falls through to the generic `triggerReload` recompile path — which never touches route wiring. Nothing ever calls `buildEntry()` again. The dev session cannot recover without a restart.

That is the whole reported symptom: `.svelte` edits still work because they go through `ComponentRegistry.recompileChanged`, which is independent of the entry graph, while everything route-shaped is silently frozen behind a single `logger.warn` line at boot.

`applyRouteChanges()` itself is fine — it already registers new patterns, retypes changed ones, unregisters removed ones, and repairs trailing-slash mirrors. It was simply never being reached.

## Fix

`packages/mochi/src/dev/devWatcher.ts`, two small changes:

- Name the entry output `entry.[ext]` instead of a literal `entry.js`, so the JS and CSS outputs no longer share a path. The resolved `outFile` is still `entry.js`.
- Track `entryGraphKnown` and thread it into `isServerEntryDep()`. Until a build has succeeded the dep set carries no information, so any non-`.svelte` change retries the entry build rather than being routed away from it. Once a build succeeds the real dep set takes over and behaviour is unchanged.

Nothing in the route-reconciliation path changed, so the existing handling of module-scoped resource churn, cron re-registration, file routes, and trailing-slash canonicalisation is untouched.

## Testing

- New `packages/mochi/src/devRouteHmr.test.ts` spawns a real dev server from its own entry file (the watcher reads `Bun.main`, so this can't be done in-process) and drives a live session: add a brand-new page route, add a new api route, edit an existing route's handler, remove a route. The fixture entry imports a `.css` file, so the test also pins defect 1. All four tests fail on `main` and pass here.
- New unit case in `devWatcher.test.ts` covering `isServerEntryDep`'s unknown-graph retry.
- Manual matrix against a scratch app, all confirmed working: five new routes added at once; a route added before its component file exists (500 until the file lands, then 200); a parameterised route; three routes removed at once; a route added after an intervening syntax-error save.
- `bun run checks` clean — lint, format, typecheck, and 200/200 `mochi-framework` test files, plus site and support.

## Note, out of scope

An app that reaches the framework by a *relative* path (a vendored copy of `packages/mochi/src`) rather than the bare `mochi-framework` specifier also breaks entry HMR, for an unrelated reason: `packages: 'external'` only externalizes bare specifiers, so the framework gets bundled into `entry.js`, `compiler/virtualModuleTemplate.ts` resolves its template siblings against the bundle's `import.meta.url` and throws `ENOENT`, and `extractServeOptions`'s `build.module('mochi-framework')` stub never engages. That shape is unsupported by the extraction design and is not addressed here; with this PR it at least warns on every save instead of only once at boot.
